### PR TITLE
fix(agent): sign s3:// model fetches on the metal path

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -330,6 +330,7 @@ func (a *MetalAgent) buildExecutors() {
 		a.config.LlamaServerBin,
 		a.config.ModelStorePath,
 		a.logger.With("subsystem", "executor"),
+		WithKubeClient(a.config.Namespace, a.config.K8sClient, nil),
 	)
 	if a.config.LlamaServerStartupTimeout > 0 {
 		metalExec.SetStartupTimeout(a.config.LlamaServerStartupTimeout)
@@ -604,6 +605,7 @@ func buildExecutorConfig(
 		Namespace:              isvc.Namespace,
 		ModelSource:            model.Spec.Source,
 		ModelName:              model.Name,
+		SourceSecretRef:        model.Spec.SourceSecretRef,
 		GPULayers:              base.GPULayers,
 		ContextSize:            base.ContextSize,
 		RopeScalingType:        ropeType,

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -30,6 +30,8 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
 )
@@ -39,9 +41,13 @@ type ExecutorConfig struct {
 	Namespace   string
 	ModelSource string
 	ModelName   string
-	GPULayers   int32
-	ContextSize int
-	Jinja       bool
+	// SourceSecretRef is the Model's spec.sourceSecretRef, used to resolve
+	// credentials for s3:// fetches on the metal path. May be nil for non-s3
+	// sources.
+	SourceSecretRef *corev1.LocalObjectReference
+	GPULayers       int32
+	ContextSize     int
+	Jinja           bool
 
 	// RopeScaling* map to llama.cpp's RoPE context-extension flags, resolved
 	// from InferenceService.spec.ropeScaling at the agent boundary. Empty
@@ -173,15 +179,45 @@ type MetalExecutor struct {
 	// instead of an ephemeral one. Set via SetPort. A fixed port gives native
 	// OpenAI-compatible clients a stable endpoint across process respawns.
 	fixedPort int
+
+	// namespace and k8sClient let the executor resolve a Model's
+	// sourceSecretRef for s3:// credentials (resolveS3Credentials). Both are
+	// optional: when nil, s3:// sources fail with a clear message rather than
+	// silently falling through to an anonymous GET. They are set via
+	// WithKubeClient.
+	namespace string
+	k8sClient client.Client
+	caCerts   [][]byte
 }
 
-func NewMetalExecutor(llamaServerBin, modelStorePath string, logger *zap.SugaredLogger) *MetalExecutor {
-	return &MetalExecutor{
+// Option configures a MetalExecutor. Used to wire the Kubernetes client and
+// namespace the s3 fetch path needs.
+type Option func(*MetalExecutor)
+
+// WithKubeClient attaches the agent's controller-runtime client and the
+// InferenceService/Model namespace so ensureModel can resolve sourceSecretRef
+// for s3:// sources. caCerts is the set of PEM CA bundles the operator trusts
+// (from the same caCertConfigMap the controller uses), so a private MinIO
+// behind a self-signed CA is reachable.
+func WithKubeClient(namespace string, c client.Client, caCerts [][]byte) Option {
+	return func(e *MetalExecutor) {
+		e.namespace = namespace
+		e.k8sClient = c
+		e.caCerts = caCerts
+	}
+}
+
+func NewMetalExecutor(llamaServerBin, modelStorePath string, logger *zap.SugaredLogger, opts ...Option) *MetalExecutor {
+	e := &MetalExecutor{
 		llamaServerBin: llamaServerBin,
 		modelStorePath: modelStorePath,
 		logger:         logger,
 		startupTimeout: DefaultLlamaServerStartupTimeout,
 	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // SetStartupTimeout overrides the default llama-server startup timeout.
@@ -205,7 +241,7 @@ func (e *MetalExecutor) SetPort(port int) {
 }
 
 func (e *MetalExecutor) StartProcess(ctx context.Context, config ExecutorConfig) (*ManagedProcess, error) {
-	modelPath, err := e.ensureModel(ctx, config.ModelSource, config.ModelName)
+	modelPath, err := e.ensureModel(ctx, config.ModelSource, config.ModelName, config.SourceSecretRef)
 	if err != nil {
 		return nil, fmt.Errorf("failed to ensure model: %w", err)
 	}
@@ -279,7 +315,7 @@ func (e *MetalExecutor) StopProcess(pid int) error {
 	}
 }
 
-func (e *MetalExecutor) ensureModel(ctx context.Context, source, name string) (string, error) {
+func (e *MetalExecutor) ensureModel(ctx context.Context, source, name string, secretRef s3SecretRef) (string, error) {
 	filename := filepath.Base(source)
 	localPath := filepath.Join(e.modelStorePath, name, filename)
 
@@ -293,7 +329,7 @@ func (e *MetalExecutor) ensureModel(ctx context.Context, source, name string) (s
 	}
 
 	e.logger.Infow("downloading model", "source", source, "destination", localPath)
-	if err := e.downloadFile(ctx, source, localPath); err != nil {
+	if err := e.fetchModel(ctx, source, localPath, secretRef); err != nil {
 		return "", fmt.Errorf("failed to download model: %w", err)
 	}
 
@@ -301,7 +337,87 @@ func (e *MetalExecutor) ensureModel(ctx context.Context, source, name string) (s
 	return localPath, nil
 }
 
+// fetchModel downloads source to filePath. s3:// sources are routed through a
+// sigv4-signed client (the metal half of #1449, which #1450 fixed for the
+// controller path): the raw source never reaches a plain GET.
+func (e *MetalExecutor) fetchModel(ctx context.Context, source, filePath string, secretRef s3SecretRef) error {
+	if isS3Source(source) {
+		return e.downloadS3(ctx, source, filePath, secretRef)
+	}
+	return e.downloadFile(ctx, source, filePath)
+}
+
+// downloadS3 fetches an s3:// source into filePath using AWS SigV4 signing and
+// the operator's trusted CA bundle, mirroring the controller's parseS3GGUFMetadata
+// (internal/controller/model_controller.go) and the init container's signed curl
+// (buildS3DownloadCommand, internal/controller/model_storage.go). secretRef is
+// the Model's spec.sourceSecretRef; when nil the fetch fails clearly rather than
+// falling back to an anonymous GET.
+func (e *MetalExecutor) downloadS3(ctx context.Context, source, filePath string, secretRef s3SecretRef) error {
+	bucket, _, err := parseS3Source(source)
+	if err != nil {
+		return err
+	}
+
+	var secretName string
+	if secretRef != nil {
+		secretName = secretRef.Name
+	}
+	creds, err := e.resolveS3Credentials(ctx, source, secretName)
+	if err != nil {
+		return err
+	}
+
+	httpClient, objectURL, err := e.s3DownloadClient(source, creds)
+	if err != nil {
+		return err
+	}
+
+	e.logger.Infow("downloading model from S3", "bucket", bucket, "destination", filePath)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, objectURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("s3 GET %s: %s", objectURL, resp.Status)
+	}
+
+	return e.copyToFile(filePath, resp.Body, resp.ContentLength)
+}
+
 func (e *MetalExecutor) downloadFile(ctx context.Context, url, filePath string) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("bad status: %s", resp.Status)
+	}
+
+	return e.copyToFile(filePath, resp.Body, resp.ContentLength)
+}
+
+// copyToFile streams r into filePath atomically: it writes to a ".partial"
+// file first and renames it into place only on success, so an interrupted
+// transfer (connection drop, mid-download error) never leaves a truncated
+// model that the stat check in ensureModel would treat as cached. When
+// contentLength > 0 it verifies the byte count matches, so a connection drop
+// mid-download doesn't leave a truncated model that passes the stat check.
+func (e *MetalExecutor) copyToFile(filePath string, r io.Reader, contentLength int64) error {
 	tmpPath := filePath + ".partial"
 
 	out, err := os.Create(tmpPath)
@@ -314,51 +430,19 @@ func (e *MetalExecutor) downloadFile(ctx context.Context, url, filePath string) 
 		}
 	}()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	written, err := io.Copy(out, r)
 	if err != nil {
-		if rmErr := os.Remove(tmpPath); rmErr != nil {
-			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
-		}
+		_ = os.Remove(tmpPath)
 		return err
 	}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		if rmErr := os.Remove(tmpPath); rmErr != nil {
-			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
-		}
-		return err
-	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
-
-	if resp.StatusCode != http.StatusOK {
-		if rmErr := os.Remove(tmpPath); rmErr != nil {
-			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
-		}
-		return fmt.Errorf("bad status: %s", resp.Status)
-	}
-
-	written, err := io.Copy(out, resp.Body)
-	if err != nil {
-		if rmErr := os.Remove(tmpPath); rmErr != nil {
-			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
-		}
-		return err
-	}
-
-	// Verify Content-Length against bytes written so a connection drop
-	// mid-download doesn't leave a truncated model that passes the stat
-	// check.
-	if resp.ContentLength > 0 && written != resp.ContentLength {
-		if rmErr := os.Remove(tmpPath); rmErr != nil {
-			e.logger.Warnw("failed to clean up partial download", "path", tmpPath, "error", rmErr)
-		}
-		return fmt.Errorf("download truncated: expected %d bytes, got %d", resp.ContentLength, written)
+	if contentLength > 0 && written != contentLength {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("download truncated: expected %d bytes, got %d", contentLength, written)
 	}
 
 	if err := os.Rename(tmpPath, filePath); err != nil {
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("failed to rename downloaded model: %w", err)
 	}
 	return nil

--- a/pkg/agent/executor_s3_test.go
+++ b/pkg/agent/executor_s3_test.go
@@ -1,0 +1,304 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// An s3:// source must be signed with AWS SigV4, never sent as a plain GET.
+//
+// Regression for #1449/#1667: before this fix the metal fetch path handed the
+// raw s3:// source string to a plain net/http GET, which cannot sign the
+// request, so a private MinIO returns 403. This test points AWS_ENDPOINT_URL at
+// a real test server standing in for MinIO and asserts the request the executor
+// makes carries a SigV4 Authorization header scoped to the s3 service. A plain
+// GET (the buggy behavior) carries no Authorization header, so this fails
+// without the fix.
+func TestEnsureModel_S3UsesSigV4(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Stand-in for the S3/MinIO endpoint. It rejects unsigned requests the way
+	// a real bucket does, and answers signed ones with the object bytes.
+	var gotAuth, gotDate, gotPayloadHash, gotURL string
+	capture := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotDate = r.Header.Get("x-amz-date")
+		gotPayloadHash = r.Header.Get("x-amz-content-sha256")
+		gotURL = r.URL.String()
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "AWS4-HMAC-SHA256") {
+			w.WriteHeader(http.StatusForbidden) // anonymous GET refused
+			return
+		}
+		body := []byte("fake-gguf-bytes")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewServer(capture)
+	defer srv.Close()
+
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add inference scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+
+	// The secret the executor must resolve. The endpoint points at the test
+	// server, standing in for the MinIO endpoint.
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "minio-models", Namespace: "default"},
+		Data: map[string][]byte{
+			"AWS_ACCESS_KEY_ID":     []byte("AKIAEXAMPLE0000000"),
+			"AWS_SECRET_ACCESS_KEY": []byte("secretaccesskeyvalue0000000000000"),
+			"AWS_REGION":            []byte("us-east-1"),
+			"AWS_ENDPOINT_URL":      []byte(srv.URL),
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger(),
+		WithKubeClient("default", k8sClient, nil))
+
+	modelDir := filepath.Join(tmpDir, "s3-model")
+	path, err := executor.ensureModel(
+		t.Context(),
+		"s3://models/org/repo/model-Q4_K_M.gguf",
+		"s3-model",
+		&corev1.LocalObjectReference{Name: "minio-models"},
+	)
+	if err != nil {
+		t.Fatalf("ensureModel: %v", err)
+	}
+
+	// The downloaded file must land at the expected path.
+	want := filepath.Join(modelDir, "model-Q4_K_M.gguf")
+	if path != want {
+		t.Errorf("ensureModel path = %q, want %q", path, want)
+	}
+
+	// The request must carry a SigV4 Authorization header scoped to s3.
+	if !strings.HasPrefix(gotAuth, "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE0000000/") {
+		t.Errorf("Authorization = %q, want an AWS4-HMAC-SHA256 header with the access key", gotAuth)
+	}
+	if !strings.Contains(gotAuth, "/us-east-1/s3/aws4_request") {
+		t.Errorf("Authorization = %q, want a us-east-1/s3 scope", gotAuth)
+	}
+	if !strings.Contains(gotAuth, "Signature=") {
+		t.Errorf("Authorization = %q, want a Signature", gotAuth)
+	}
+	if gotDate == "" {
+		t.Error("x-amz-date header not set")
+	}
+	if gotPayloadHash == "" {
+		t.Error("x-amz-content-sha256 header not set")
+	}
+
+	// The object URL must be the path-style endpoint <endpoint>/<bucket>/<key>,
+	// matching the controller and init-container shape.
+	if !strings.HasSuffix(gotURL, "/models/org/repo/model-Q4_K_M.gguf") {
+		t.Errorf("request URL = %q, want a path-style <endpoint>/models/org/repo/... object URL", gotURL)
+	}
+
+	// The body must have been written to disk.
+	got, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read downloaded model: %v", err)
+	}
+	if string(got) != "fake-gguf-bytes" {
+		t.Errorf("downloaded body = %q, want %q", string(got), "fake-gguf-bytes")
+	}
+}
+
+// A missing sourceSecretRef must fail clearly rather than fall through to an
+// anonymous GET that 403s confusingly.
+func TestEnsureModel_S3MissingSecretRefFails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add inference scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger(),
+		WithKubeClient("default", k8sClient, nil))
+
+	_, err := executor.ensureModel(
+		t.Context(),
+		"s3://models/org/repo/model.gguf",
+		"s3-model",
+		nil, // no sourceSecretRef
+	)
+	if err == nil {
+		t.Fatal("ensureModel with an s3:// source and no sourceSecretRef should fail, not fall through to an anonymous GET")
+	}
+	if !strings.Contains(err.Error(), "sourceSecretRef") {
+		t.Errorf("error = %q, want it to mention sourceSecretRef", err.Error())
+	}
+}
+
+// An s3:// source whose secret is missing the access keys must fail clearly.
+func TestEnsureModel_S3IncompleteSecretFails(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	scheme := runtime.NewScheme()
+	if err := inferencev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add inference scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 scheme: %v", err)
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "partial-creds", Namespace: "default"},
+		Data: map[string][]byte{
+			// Access key present, secret key missing.
+			"AWS_ACCESS_KEY_ID": []byte("AKIAEXAMPLE0000000"),
+			"AWS_REGION":        []byte("us-east-1"),
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	executor := NewMetalExecutor("/bin/llama-server", tmpDir, newNopLogger(),
+		WithKubeClient("default", k8sClient, nil))
+
+	_, err := executor.ensureModel(
+		t.Context(),
+		"s3://models/org/repo/model.gguf",
+		"s3-model",
+		&corev1.LocalObjectReference{Name: "partial-creds"},
+	)
+	if err == nil {
+		t.Fatal("ensureModel with an s3:// source and an incomplete secret should fail")
+	}
+	if !strings.Contains(err.Error(), "AWS_SECRET_ACCESS_KEY") {
+		t.Errorf("error = %q, want it to name the missing AWS_SECRET_ACCESS_KEY", err.Error())
+	}
+}
+
+// isS3Source / parseS3Source must classify and split correctly, matching the
+// controller helpers they mirror.
+func TestS3SourceClassification(t *testing.T) {
+	cases := []struct {
+		source       string
+		wantIsS3     bool
+		wantBucket   string
+		wantKey      string
+		wantParseErr bool
+	}{
+		{"s3://bucket/key/model.gguf", true, "bucket", "key/model.gguf", false},
+		{"s3://models/org/repo/model-Q4_K_M.gguf", true, "models", "org/repo/model-Q4_K_M.gguf", false},
+		{"S3://bucket/key", true, "bucket", "key", false}, // case-folded
+		{"https://bucket/key", false, "", "", true},
+		{"s3://bucket", true, "", "", true}, // missing key
+		{"s3://", true, "", "", true},       // empty
+	}
+	for _, tc := range cases {
+		if got := isS3Source(tc.source); got != tc.wantIsS3 {
+			t.Errorf("isS3Source(%q) = %v, want %v", tc.source, got, tc.wantIsS3)
+		}
+		bucket, key, err := parseS3Source(tc.source)
+		if tc.wantParseErr {
+			if err == nil {
+				t.Errorf("parseS3Source(%q) = nil error, want error", tc.source)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseS3Source(%q) error: %v", tc.source, err)
+			continue
+		}
+		if bucket != tc.wantBucket || key != tc.wantKey {
+			t.Errorf("parseS3Source(%q) = (%q,%q), want (%q,%q)", tc.source, bucket, key, tc.wantBucket, tc.wantKey)
+		}
+	}
+}
+
+// The sigv4 round-tripper must attach a valid AWS SigV4 Authorization header to
+// every request (the in-process equivalent of the init container's signed
+// curl). This exercises sigv4RoundTripper.RoundTrip directly.
+func TestSigV4RoundTripperSignsRequest(t *testing.T) {
+	var gotAuth, gotDate, gotPayloadHash string
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotAuth = req.Header.Get("Authorization")
+		gotDate = req.Header.Get("x-amz-date")
+		gotPayloadHash = req.Header.Get("x-amz-content-sha256")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	signer := &sigv4RoundTripper{
+		base:      base,
+		accessKey: "AKIAEXAMPLE",
+		secretKey: "secret",
+		region:    "us-east-1",
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "http://minio.local/models/org/repo/model.gguf", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := signer.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("RoundTrip: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if !strings.HasPrefix(gotAuth, "AWS4-HMAC-SHA256 Credential=AKIAEXAMPLE/") {
+		t.Errorf("Authorization = %q, want AWS4-HMAC-SHA256 with access key", gotAuth)
+	}
+	if !strings.Contains(gotAuth, "/us-east-1/s3/aws4_request") {
+		t.Errorf("Authorization = %q, want region/service scope us-east-1/s3", gotAuth)
+	}
+	if !strings.Contains(gotAuth, "Signature=") {
+		t.Errorf("Authorization = %q, want a Signature", gotAuth)
+	}
+	if gotDate == "" {
+		t.Error("x-amz-date header not set")
+	}
+	if gotPayloadHash == "" {
+		t.Error("x-amz-content-sha256 header not set")
+	}
+}
+
+// roundTripFunc adapts a func to http.RoundTripper for tests.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -140,6 +140,7 @@ func TestEnsureModel_AlreadyExists(t *testing.T) {
 		t.Context(),
 		"https://huggingface.co/org/repo/resolve/main/model.gguf",
 		"test-model",
+		nil,
 	)
 	if err != nil {
 		t.Fatalf("ensureModel returned error: %v", err)
@@ -158,6 +159,7 @@ func TestEnsureModel_DownloadFails(t *testing.T) {
 		t.Context(),
 		"http://localhost:1/nonexistent-model.gguf",
 		"bad-model",
+		nil,
 	)
 	if err == nil {
 		t.Error("ensureModel with invalid URL should return error")
@@ -545,7 +547,7 @@ func TestEnsureModel_ZeroByteFileTriggersRedownload(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := executor.ensureModel(t.Context(), srv.URL+"/model.gguf", "stub-model")
+	_, err := executor.ensureModel(t.Context(), srv.URL+"/model.gguf", "stub-model", nil)
 	if err != nil {
 		t.Fatalf("ensureModel should succeed when stub is zero bytes: %v", err)
 	}

--- a/pkg/agent/s3.go
+++ b/pkg/agent/s3.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+// S3 support for the metal fetch path. The controller learned about s3:// in
+// #1098 / #1450 (internal/controller/source.go, model_controller.go), but the
+// metal-agent fetches on-node instead of deferring to the init container, so it
+// needs its own in-process sigv4 downloader. This mirrors that controller code
+// rather than inventing a second signing implementation: the same four secret
+// keys, the same path-style endpoint shape, the same SigV4 round-tripper.
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// s3Credentials holds the resolved AWS credentials/endpoint for an s3:// source.
+// Mirrors the controller's s3Creds (internal/controller/model_controller.go).
+type s3Credentials struct {
+	AccessKeyID     string
+	SecretAccessKey string
+	Region          string
+	Endpoint        string
+}
+
+// s3SecretRef is the Model's spec.sourceSecretRef, used to resolve credentials
+// for s3:// fetches on the metal path. It is a plain alias so the executor
+// signatures stay within the line limit.
+type s3SecretRef = *corev1.LocalObjectReference
+
+// isS3Source reports whether source is an s3:// URL. Case-folded to agree with
+// the controller's isS3Source (internal/controller/source.go): url.Parse
+// lowercases schemes, so a case-variant scheme ("S3://...") must not dodge this
+// classifier and fall through to the plain-GET path.
+func isS3Source(source string) bool {
+	return len(source) >= len("s3://") && strings.EqualFold(source[:len("s3://")], "s3://")
+}
+
+// parseS3Source splits s3://bucket/key into bucket and key. Endpoint, region,
+// and credentials are NOT in the URL; they come from the sourceSecretRef env
+// (AWS_ENDPOINT_URL, AWS_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY).
+// Mirrors the controller's parseS3Source (internal/controller/source.go).
+func parseS3Source(source string) (bucket, key string, err error) {
+	if !isS3Source(source) {
+		return "", "", fmt.Errorf("not an S3 source: %s", source)
+	}
+
+	// Slice off the scheme by length rather than TrimPrefix: isS3Source already
+	// guarantees the prefix is present and case-folded, and slicing (unlike a
+	// case-sensitive TrimPrefix) leaves a case-variant scheme ("S3://...") with
+	// its bucket/key intact. S3 bucket and key are case-sensitive, so the rest
+	// of the source must not be lower-cased.
+	rest := source[len("s3://"):]
+	if rest == "" {
+		return "", "", fmt.Errorf("empty S3 source: %s", source)
+	}
+
+	slashIdx := strings.Index(rest, "/")
+	if slashIdx < 0 {
+		return "", "", fmt.Errorf("S3 source must include a key: %s (expected s3://bucket/key)", source)
+	}
+
+	bucket = rest[:slashIdx]
+	key = rest[slashIdx+1:]
+
+	if bucket == "" {
+		return "", "", fmt.Errorf("S3 source has empty bucket: %s", source)
+	}
+	if key == "" {
+		return "", "", fmt.Errorf("S3 source has empty key: %s", source)
+	}
+
+	return bucket, key, nil
+}
+
+// resolveS3Credentials reads the AWS_* keys out of the Model's sourceSecretRef.
+// The secret lives in the Model's namespace (the namespace the executor was
+// constructed with). This mirrors the controller's s3Credentials
+// (internal/controller/model_controller.go), but reads through the agent's
+// controller-runtime client instead of a rest.Config. A missing secret or a
+// secret without both access keys is a hard error: it is better to fail here
+// with a clear message than to hand the raw source to an anonymous GET that
+// 403s confusingly (the bug this file exists to fix).
+func (e *MetalExecutor) resolveS3Credentials(ctx context.Context, source, secretName string) (s3Credentials, error) {
+	if e.k8sClient == nil {
+		return s3Credentials{}, fmt.Errorf("s3 source %q requires a Kubernetes client to resolve sourceSecretRef; "+
+			"the metal-agent could not resolve credentials", source)
+	}
+	if secretName == "" {
+		return s3Credentials{}, fmt.Errorf("s3 source %q requires spec.sourceSecretRef; "+
+			"no secret was provided to the agent", source)
+	}
+
+	secret := &corev1.Secret{}
+	if err := e.k8sClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: e.namespace}, secret); err != nil {
+		return s3Credentials{}, fmt.Errorf("read sourceSecretRef %q in namespace %q: %w", secretName, e.namespace, err)
+	}
+
+	creds := s3Credentials{
+		AccessKeyID:     string(secret.Data["AWS_ACCESS_KEY_ID"]),
+		SecretAccessKey: string(secret.Data["AWS_SECRET_ACCESS_KEY"]),
+		Region:          string(secret.Data["AWS_REGION"]),
+		Endpoint:        string(secret.Data["AWS_ENDPOINT_URL"]),
+	}
+	if creds.AccessKeyID == "" || creds.SecretAccessKey == "" {
+		return s3Credentials{}, fmt.Errorf("s3 source %q: secret %q is missing AWS_ACCESS_KEY_ID and/or "+
+			"AWS_SECRET_ACCESS_KEY; a signed request cannot be produced, so refusing to fall back to an "+
+			"anonymous GET", source, secretName)
+	}
+	return creds, nil
+}
+
+// s3DownloadClient builds an *http.Client that signs every request with AWS
+// SigV4 for the s3 service, routing through a transport that trusts the
+// configured custom CA (when any). objectURL is the path-style endpoint the
+// caller should GET: <endpoint>/<bucket>/<key>, matching the controller's
+// parseS3GGUFMetadata shape (internal/controller/model_controller.go).
+func (e *MetalExecutor) s3DownloadClient(source string, creds s3Credentials) (*http.Client, string, error) {
+	if creds.Endpoint == "" {
+		return nil, "", fmt.Errorf("s3 source %q: AWS_ENDPOINT_URL not set in secret; "+
+			"the agent cannot reach the object store without an endpoint", source)
+	}
+
+	// Path-style endpoint: <endpoint>/<bucket>/<key>. The init container's
+	// signed curl uses the same shape (${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}).
+	bucket, key, perr := parseS3Source(source)
+	if perr != nil {
+		return nil, "", perr
+	}
+	objectURL := strings.TrimRight(creds.Endpoint, "/") + "/" + bucket + "/" + key
+
+	var transport http.RoundTripper = http.DefaultTransport.(*http.Transport).Clone()
+	if len(e.caCerts) > 0 {
+		transport = withCACerts(transport, e.caCerts)
+	}
+
+	signer := &sigv4RoundTripper{
+		base:      transport,
+		accessKey: creds.AccessKeyID,
+		secretKey: creds.SecretAccessKey,
+		region:    creds.Region,
+	}
+	return &http.Client{Transport: signer}, objectURL, nil
+}
+
+// withCACerts returns a RoundTripper whose TLS config trusts the supplied PEM CA
+// bundles, in addition to the system roots. When the s3 endpoint is a private
+// MinIO behind a self-signed CA, this is what lets the agent trust it — the
+// in-process equivalent of the init container's CURL_CA_BUNDLE (addCACertVolume,
+// internal/controller/model_storage.go).
+func withCACerts(base http.RoundTripper, caCerts [][]byte) http.RoundTripper {
+	t, ok := base.(*http.Transport)
+	if !ok {
+		return base
+	}
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{} //nolint:gosec // MinVersion inherited from Clone()
+	}
+	t.TLSClientConfig.RootCAs = withCACertPool(t.TLSClientConfig.RootCAs, caCerts)
+	return t
+}
+
+// withCACertPool returns a cert pool seeded with the system roots plus any
+// supplied PEM CA bundles. When the s3 endpoint is a private MinIO behind a
+// self-signed CA, this is what lets the agent trust it — the in-process
+// equivalent of the init container's CURL_CA_BUNDLE (addCACertVolume,
+// internal/controller/model_storage.go).
+func withCACertPool(base *x509.CertPool, caCerts [][]byte) *x509.CertPool {
+	pool := base
+	if pool == nil {
+		pool, _ = x509.SystemCertPool()
+	}
+	if pool == nil {
+		pool = x509.NewCertPool()
+	}
+	for _, ca := range caCerts {
+		pool.AppendCertsFromPEM(ca)
+	}
+	return pool
+}
+
+// sigv4RoundTripper signs every request with AWS Signature Version 4 for the s3
+// service, then delegates to the wrapped transport. This is the in-process
+// equivalent of the init container's
+//
+//	curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" \
+//	  -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}"
+//
+// and is a faithful copy of the controller's sigv4RoundTripper
+// (internal/controller/model_controller.go).
+type sigv4RoundTripper struct {
+	base      http.RoundTripper
+	accessKey string
+	secretKey string
+	region    string
+}
+
+func (t *sigv4RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	now := time.Now().UTC()
+	amzDate := now.Format("20060102T150405Z")
+	dateStamp := now.Format("20060102")
+
+	// S3 GET/HEAD carry no body; the payload hash is the SHA256 of the empty
+	// string. Model downloads are body-less GETs.
+	payloadHash := sha256Hex(nil)
+
+	req.Header.Set("x-amz-date", amzDate)
+	req.Header.Set("x-amz-content-sha256", payloadHash)
+
+	canonicalHeaders, signedHeaders := canonicalHeaders(req)
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI(req.URL),
+		canonicalQuery(req.URL),
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	scope := dateStamp + "/" + t.region + "/s3/aws4_request"
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		amzDate,
+		scope,
+		sha256Hex([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := hmacSHA256([]byte("AWS4"+t.secretKey), dateStamp)
+	signingKey = hmacSHA256(signingKey, t.region)
+	signingKey = hmacSHA256(signingKey, "s3")
+	signingKey = hmacSHA256(signingKey, "aws4_request")
+
+	signature := hex.EncodeToString(hmacSHA256(signingKey, stringToSign))
+
+	auth := "AWS4-HMAC-SHA256 Credential=" + t.accessKey + "/" + scope +
+		", SignedHeaders=" + signedHeaders +
+		", Signature=" + signature
+	req.Header.Set("Authorization", auth)
+
+	return t.base.RoundTrip(req)
+}
+
+// canonicalURI percent-encodes each path segment, matching AWS SigV4's
+// requirement that the path be URI-encoded (S3 path-style bucket included).
+func canonicalURI(u *url.URL) string {
+	segments := strings.Split(u.EscapedPath(), "/")
+	for i, s := range segments {
+		if s == "" {
+			continue
+		}
+		segments[i] = url.PathEscape(s)
+	}
+	return strings.Join(segments, "/")
+}
+
+// canonicalQuery sorts and URI-encodes the query parameters per SigV4.
+func canonicalQuery(u *url.URL) string {
+	vals := u.Query()
+	keys := make([]string, 0, len(vals))
+	for k := range vals {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		b.WriteString(url.QueryEscape(k))
+		b.WriteByte('=')
+		b.WriteString(url.QueryEscape(vals[k][0]))
+	}
+	return b.String()
+}
+
+// canonicalHeaders returns the SigV4 canonical headers block and the
+// semicolon-joined signed-header list. Only the host and x-amz-* headers are
+// signed, which is sufficient for S3 and keeps the signature stable.
+func canonicalHeaders(req *http.Request) (string, string) {
+	headers := map[string]string{
+		"host":                 req.URL.Host,
+		"x-amz-date":           req.Header.Get("x-amz-date"),
+		"x-amz-content-sha256": req.Header.Get("x-amz-content-sha256"),
+	}
+	keys := make([]string, 0, len(headers))
+	for k := range headers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		b.WriteString(k)
+		b.WriteByte(':')
+		b.WriteString(strings.TrimSpace(headers[k]))
+		b.WriteByte('\n')
+	}
+	return b.String(), strings.Join(keys, ";")
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func hmacSHA256(key []byte, data string) []byte {
+	h := hmac.New(sha256.New, key)
+	_, _ = h.Write([]byte(data))
+	return h.Sum(nil)
+}


### PR DESCRIPTION
## What

`MetalExecutor.ensureModel` passed an `s3://` source straight to a plain `net/http` GET, so `s3://` model sources could not be served on metal. This adds an in-process SigV4 downloader to the agent and routes `s3://` through it.

## Why

Refs #1667.

`#1450` fixed this for the controller path, but as `#1449` notes, metal is deliberately one of the shapes that needs no controller-side download: the agent fetches on-node instead. That fetch landed in `pkg/agent/executor.go`, which never learned about S3, so a private MinIO or S3 endpoint returns 403.

**`Refs` rather than `Fixes`, deliberately.** The change is verified by build, vet, cross-arch lint, unit tests and a mutation check (below), but it has **not** been exercised end to end against a real MinIO endpoint on a real metal node. Closing the issue should wait for that.

## How

- `pkg/agent/s3.go`: `isS3Source` / `parseS3Source` classifiers, `resolveS3Credentials` reading the same four `AWS_*` keys from `sourceSecretRef`, a `sigv4RoundTripper`, and a CA-trust transport.
- `pkg/agent/executor.go`: `downloadFile` now dispatches on `isS3Source` to `downloadS3`. A missing secret or incomplete credentials fail with a message naming what is missing, rather than falling through to an anonymous GET that 403s confusingly.
- `sourceSecretRef` is threaded through `ExecutorConfig`, and the agent's Kubernetes client is wired into the executor so credentials can be resolved.

Design notes worth flagging for review:

- **No new dependency.** SigV4 is implemented against `crypto/sha256` and `crypto/hmac` rather than pulling in an AWS SDK. `go.mod` and `go.sum` are untouched.
- **It mirrors the existing Go implementation**, `sigv4RoundTripper` in `internal/controller/model_controller.go:1270`, rather than inventing a second signing scheme.
- **No `InsecureSkipVerify`.** The CA transport seeds the system roots and adds configured CAs, avoiding the trap documented at `model_storage.go:255` where relaxing TLS for one private endpoint silently breaks every public download.

## Verification

The Foreman gate on this branch reported `GATE-FAIL`, but **that was an infrastructure failure, not a code failure**:

```
=== install helm v3.13.0 ===
curl: (28) Failed to connect to get.helm.sh port 443 after 134656 ms
GATE FAIL: helm install
```

It exited before running any check, and the reviewer stage then cascade-failed on that verdict without reading the diff. The checks were therefore run locally instead:

| check | result |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./pkg/agent/...` | pass |
| `gofmt -l pkg/agent/` | clean |
| `go test ./pkg/agent/...` | pass |
| `GOOS=linux golangci-lint run ./pkg/agent/...` | 0 issues |
| generated files touched | none |

**Mutation check.** Neutering `isS3Source` to `return false` and re-running the package unfiltered fails 4 of the 5 new tests:

```
FAIL TestEnsureModel_S3UsesSigV4            — unsupported protocol scheme "s3"
FAIL TestEnsureModel_S3MissingSecretRefFails — want it to mention sourceSecretRef
FAIL TestEnsureModel_S3IncompleteSecretFails — want it to name AWS_SECRET_ACCESS_KEY
FAIL TestS3SourceClassification              — isS3Source(...) = false, want true
```

`TestSigV4RoundTripperSignsRequest` correctly survives, since it exercises the round-tripper directly and does not route through source detection.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (package-scoped: `go test ./pkg/agent/...`)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run ./pkg/agent/...`, 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance disclosed: the diff was authored end to end by an LLMKube Foreman coder agent (Ornith-1.5-397B served across three DGX Sparks). A human reviewed it before opening this PR, including the mutation check above, and owns the review conversation.
- [ ] Documentation updated: not applicable, no user-facing surface changes
