### PR TITLE
fix(foreman): report rejected submissions on max-turns INCOMPLETE

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -2494,9 +2494,24 @@ func (e *NativeAgentLoopExecutor) mapLoopError(
 	}
 	switch {
 	case errors.Is(loopErr, ErrMaxTurnsExhausted):
+		// The summary must describe the actual terminal state, not assume
+		// the model stayed silent. A max-turns exhaustion has two distinct
+		// causes: the model never reached submit_result (SubmissionsRejected
+		// == 0), or it did and the verification gate vetoed every attempt
+		// (SubmissionsRejected > 0) — the #1713 case, where the model called
+		// submit_result three times, was accepted each time, yet the loop
+		// kept running to MaxTurns. Both are INCOMPLETE outcomes, but the
+		// fixes differ: a bigger budget versus a gate that keeps rejecting.
+		var summary string
+		if lr.SubmissionsRejected > 0 {
+			summary = fmt.Sprintf(
+				"model submitted %d time(s), each rejected by the verification "+
+					"gate; turns exhausted", lr.SubmissionsRejected)
+		} else {
+			summary = "model did not call submit_result within max_turns"
+		}
 		return e.incompleteResult(start, tref, lr,
-			foremanv1alpha1.FailureMaxTurnsExhausted,
-			"model did not call submit_result within max_turns"), nil
+			foremanv1alpha1.FailureMaxTurnsExhausted, summary), nil
 	case errors.Is(loopErr, ErrAssistantNoToolCalls):
 		return e.incompleteResult(start, tref, lr,
 			foremanv1alpha1.FailureModelMisunderstood,

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -589,6 +589,42 @@ func TestIncompleteResult_EmitsStructuredFailureReason(t *testing.T) {
 	}
 }
 
+// TestMapLoopError_MaxTurns_SubmissionCount pins the #1713 fix: a max-turns
+// exhaustion reports the actual terminal state. When the model submitted
+// and the gate rejected it (SubmissionsRejected > 0), the summary says so
+// and says how many — it must NOT claim the model never called
+// submit_result. When no submission was rejected, the original "never
+// concluded" wording is kept.
+func TestMapLoopError_MaxTurns_SubmissionCount(t *testing.T) {
+	e := &NativeAgentLoopExecutor{}
+	tref := corev1.ObjectReference{Name: "transcript"}
+
+	// No rejection: the model never concluded.
+	r, err := e.mapLoopError(time.Time{}, tref, &LoopResult{Turns: 5}, ErrMaxTurnsExhausted)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if r.Summary != "model did not call submit_result within max_turns" {
+		t.Errorf("summary: want the never-concluded wording, got %q", r.Summary)
+	}
+
+	// Rejections: the model concluded repeatedly and was refused.
+	r, err = e.mapLoopError(time.Time{}, tref,
+		&LoopResult{Turns: 5, SubmissionsRejected: 3}, ErrMaxTurnsExhausted)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(r.Summary, "3 time(s)") {
+		t.Errorf("summary: want it to report 3 rejected submissions, got %q", r.Summary)
+	}
+	if !strings.Contains(r.Summary, "verification gate") {
+		t.Errorf("summary: want it to name the gate, got %q", r.Summary)
+	}
+	if strings.Contains(r.Summary, "did not call submit_result") {
+		t.Errorf("summary: must not claim the model never submitted, got %q", r.Summary)
+	}
+}
+
 // TestResolveProviderEndpoint covers the v0.2 cloud-proxy resolution
 // path: providerConfig must carry baseURL + model, the optional
 // APIKeySecretRef must reference a real Secret, and missing fields

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -291,6 +291,14 @@ type LoopResult struct {
 	Terminal *ToolResult
 	// Turns is the count of completed chat-completions calls.
 	Turns int
+	// SubmissionsRejected counts the terminal submit_result calls the
+	// verification gate vetoed (applyTerminalGate returning "continue"),
+	// after which the loop kept running. It is the signal that lets a
+	// max-turns INCOMPLETE distinguish "the model never concluded" from
+	// "the model concluded but the gate refused it" — two different
+	// problems with different fixes. Zero when no terminal was ever
+	// reached, or when the gate is disabled.
+	SubmissionsRejected int
 }
 
 // ErrMaxTurnsExhausted is returned when the loop hits MaxTurns without
@@ -1093,6 +1101,13 @@ func (l *Loop) applyTerminalGate(
 	}
 	if *verifyRetries < cfg.MaxVerifyRetries {
 		*verifyRetries++
+		// Count this vetoed submission so a later max-turns INCOMPLETE
+		// can report that the model DID conclude (and was refused by the
+		// gate), rather than falsely claiming it never called
+		// submit_result. Only gate-vetoed continues reach here: a
+		// terminal the gate accepts returns false above and the loop
+		// exits, so this counter never over-counts.
+		res.SubmissionsRejected++
 		res.Transcript = append(res.Transcript, oai.Message{
 			Role:    oai.RoleUser,
 			Content: feedback,

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -432,6 +432,47 @@ func TestLoop_MaxTurnsExhausted(t *testing.T) {
 	}
 }
 
+// TestLoop_MaxTurnsExhausted_AfterRejectedSubmissions is the #1713
+// regression. The model calls submit_result and is accepted by the harness
+// each time, but the verification gate vetoes the terminal and the loop
+// keeps running until MaxTurns. The resulting INCOMPLETE summary must not
+// claim the model never submitted: the loop threads a rejection count
+// through LoopResult so mapLoopError can report what actually happened.
+func TestLoop_MaxTurnsExhausted_AfterRejectedSubmissions(t *testing.T) {
+	// read_file, submit (vetoed), read_file, submit (vetoed), read_file.
+	// With MaxTurns=5 and a gate that always rejects, the two submit
+	// attempts are vetoed and the loop exhausts turns on the final read.
+	srv, _ := scriptedOAIServer(t, []string{
+		toolCallReadFile, toolCallSubmitGo, toolCallReadFile, toolCallSubmitGo, toolCallReadFile,
+	})
+	reg := &fakeRegistry{
+		results: map[string]*ToolResult{
+			"read_file":     {Output: map[string]any{"content": "# README\n"}},
+			"submit_result": {Terminal: true, Verdict: "GO", Summary: "done"},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model:    "test",
+		MaxTurns: 5,
+		// A gate that always vetoes the terminal with retries to spare,
+		// forcing the loop to continue after each submission.
+		VerifyTerminal: func(_ context.Context, _ *ToolResult, _ []oai.Message) (bool, string, error) {
+			return false, "gate: change does not compile", nil
+		},
+		MaxVerifyRetries: 10,
+	})
+	if !errors.Is(err, ErrMaxTurnsExhausted) {
+		t.Fatalf("expected ErrMaxTurnsExhausted, got %v", err)
+	}
+	if res.SubmissionsRejected != 2 {
+		t.Errorf("submissions rejected: want 2 got %d", res.SubmissionsRejected)
+	}
+	if res.Terminal != nil {
+		t.Errorf("did not expect a terminal: %+v", res.Terminal)
+	}
+}
+
 func TestLoop_UnknownToolBecomesToolErrorMessage(t *testing.T) {
 	srv, _ := scriptedOAIServer(t, []string{toolCallUnknownTool, toolCallSubmitGo})
 	reg := &fakeRegistry{


### PR DESCRIPTION
## What

`mapLoopError`'s `ErrMaxTurnsExhausted` arm recorded `"model did not call submit_result within max_turns"` unconditionally. It now distinguishes the two causes of a max-turns exhaustion and reports which one occurred.

109 insertions across 4 files: two source, two test.

## Why

Fixes #1713.

The message was false in an observed run and sent triage in the wrong direction. The model called `submit_result` three times, the harness acknowledged each with `{"accepted":true,"verdict":"GO"}`, and the recorded summary still asserted it never submitted. Anyone reading that verdict concludes the model failed to conclude; the actual problem was that the loop would not stop.

The two causes need different fixes, which is why the distinction matters rather than just the wording:

- never reached `submit_result` → the turn budget is too small
- submitted and was vetoed → the gate keeps rejecting

## How

`LoopResult` gains a `SubmissionsRejected` counter, incremented on the rejection path. `mapLoopError` branches on it:

```go
if lr.SubmissionsRejected > 0 {
    summary = fmt.Sprintf("model submitted %d time(s), each rejected by the "+
        "verification gate; turns exhausted", lr.SubmissionsRejected)
} else {
    summary = "model did not call submit_result within max_turns"
}
```

The original wording is preserved for the genuine never-submitted case rather than replaced outright, since that case is real and its message was already correct.

Two tests, one per changed file. `TestMapLoopError_MaxTurns_SubmissionCount` covers both branches and asserts the summary "must not claim the model never submitted". `TestLoop_MaxTurnsExhausted_AfterRejectedSubmissions` exercises the loop end to end, so it verifies the counter is actually incremented rather than only that the formatter reads a field.

## Scope

**This is a partial fix for #1712 and that issue should stay open.** It corrects the misleading summary. It does not address the deadlock itself (`ForceSubmitMessage` at `progress.go:346` withdraws every tool except `submit_result`, then `coder_gate.go:613` tells the model to fix issues and resubmit), nor the fact that the branch is never pushed on that path despite `pushFailedResult` existing at `executor_native.go:2539`.

Split out as its own issue rather than sliced, because a sliced Workload is judged against the whole issue and always fails (#1679).

## Verification

Foreman pipeline, all three stages clean:

| stage | verdict |
| --- | --- |
| coder | GO |
| gate | GATE-PASS |
| reviewer | GO / APPROVE, 0 findings |

The gate ran its own bite check, compiling the new tests against pre-change production and confirming they fail: `bite check: tests fail against pre-change production (biting test, good)`.

Verified again independently on the pushed branch:

| check | result |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./pkg/foreman/agent/` | pass |
| `gofmt` | clean |
| `GOOS=linux golangci-lint run ./pkg/foreman/agent/...` | 0 issues |
| new tests | 2/2 pass |
| pre-existing `TestLoop_MaxTurnsExhausted` | still passes |

**Mutation check.** Restoring the unconditional summary fails the test with the assertion that names the bug:

```
summary: must not claim the model never submitted,
         got "model did not call submit_result within max_turns"
```

## Provenance

Authored by an LLMKube Foreman coder agent (Ornith-1.5-397B served across three DGX Sparks via llama.cpp RPC). The agent found `loop.go` and the `LoopResult` threading itself; the intent named neither the file nor the field, only that it should look at how `LoopResult` already carries state before inventing a new mechanism.

Reviewed by a human before opening, including the mutation check above.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (package-scoped: `go test ./pkg/foreman/agent/`)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint`, 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance disclosed under Provenance above
- [x] Documentation updated: not applicable, internal diagnostic message only
