### PR TITLE
fix(foreman): preserve the workspace when the agent loop ends unsuccessfully

### DIFF
--- a/pkg/foreman/agent/executor_gate_preserve_test.go
+++ b/pkg/foreman/agent/executor_gate_preserve_test.go
@@ -171,3 +171,73 @@ func TestMaybePreserveGateFailedBranch(t *testing.T) {
 		}
 	})
 }
+
+// A cancelled parent context must still preserve the branch.
+//
+// Regression for a silent no-op: every repo call runs git through
+// exec.CommandContext, so before the fix a cancelled ctx failed the commit
+// instantly and the work was dropped without a trace. mapLoopError routes
+// context.Canceled / DeadlineExceeded into this path by name, so it was the
+// documented case that did not work. The loop's own LoopBudget cannot land
+// here (it derives its own context and returns a terminal envelope before
+// mapLoopError), so a cancelled ctx here means the parent is genuinely gone.
+func TestPreserveUnsuccessfulLoopBranch_CancelledParentStillPreserves(t *testing.T) {
+	ident := repo.Identity{Name: "Foreman Bot", Email: "bot@example.com"}
+	e := &NativeAgentLoopExecutor{CommitAuthor: ident, CommitCommitter: ident}
+
+	const branch = "foreman/wl-cancel/issue-1715"
+	ws, origin := gpSetupWorkspace(t, branch, true)
+
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 1715},
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // the parent is already dead, as on a cancelled task
+
+	r := &Result{}
+	got := e.preserveUnsuccessfulLoopBranch(ctx, logr.Discard(),
+		gpAgent(foremanv1alpha1.AgentRoleCoder), task, ws, branch, nil, r)
+
+	if !gpOriginHasBranch(t, origin, branch) {
+		t.Error("branch not preserved under a cancelled parent context")
+	}
+	// Asserted rather than assumed: the function returns *Result, which is
+	// nil-able, and a nil here would mean the non-nil r was dropped.
+	if got == nil {
+		t.Fatal("non-nil Result must be returned, got nil")
+	}
+	if got.Extra["preservedBranch"] != branch {
+		t.Errorf("preservedBranch = %v, want %q", got.Extra["preservedBranch"], branch)
+	}
+}
+
+// r is nil whenever mapLoopError took its default branch (an infrastructure
+// error returns (nil, loopErr)). Preserving must still happen -- that is the
+// case where the agent died without warning -- and the nil Result must pass
+// straight through rather than be dereferenced or replaced.
+func TestPreserveUnsuccessfulLoopBranch_NilResultStillPreserves(t *testing.T) {
+	ident := repo.Identity{Name: "Foreman Bot", Email: "bot@example.com"}
+	e := &NativeAgentLoopExecutor{CommitAuthor: ident, CommitCommitter: ident}
+
+	const branch = "foreman/wl-nilres/issue-1715"
+	ws, origin := gpSetupWorkspace(t, branch, true)
+
+	task := &foremanv1alpha1.AgenticTask{
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Payload: foremanv1alpha1.AgenticTaskPayload{Issue: 1715},
+		},
+	}
+
+	got := e.preserveUnsuccessfulLoopBranch(context.Background(), logr.Discard(),
+		gpAgent(foremanv1alpha1.AgentRoleCoder), task, ws, branch, nil, nil)
+
+	if got != nil {
+		t.Errorf("nil Result must pass through unchanged, got %+v", got)
+	}
+	if !gpOriginHasBranch(t, origin, branch) {
+		t.Error("branch not preserved when the loop failed with an infrastructure error")
+	}
+}

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -2379,12 +2379,24 @@ func (e *NativeAgentLoopExecutor) maybePreserveGateFailedBranch(
 		"branch", branch, "sha", sha, "issue", task.Spec.Payload.Issue)
 }
 
+// preserveBranchTimeout bounds the detached commit + push in
+// preserveUnsuccessfulLoopBranch. Long enough for a clone-local commit and a
+// push over a slow link, short enough that a shutting-down agent is not held
+// open waiting on a remote that is not answering.
+const preserveBranchTimeout = 30 * time.Second
+
 // preserveUnsuccessfulLoopBranch commits and pushes whatever the model wrote
 // to the workspace when the loop ended unsuccessfully (max turns exhausted,
-// no tool call, truncation, context cancel). mapLoopError has already built
-// the unsuccessful result r; this does NOT change the verdict -- it only
-// makes that verdict land against a branch that exists, so a human can read
-// the diff, judge how far the run got, and finish or discard it (#1715).
+// no tool call, truncation, context cancel). This does NOT change the
+// verdict -- it only makes that verdict land against a branch that exists, so
+// a human can read the diff, judge how far the run got, and finish or discard
+// it (#1715).
+//
+// r MAY BE NIL. mapLoopError builds a Result for the model-behaviour
+// outcomes, but its default branch returns (nil, loopErr) for an
+// infrastructure / transport failure, and both call sites enter on
+// `r != nil || err != nil`. The branch is preserved either way; only the
+// r.Extra annotation is conditional. See the guard at the end.
 //
 // Nothing-to-commit is the EXPECTED case here (the model may have written
 // nothing before running out of turns), so ErrNothingToCommit is kept as the
@@ -2407,6 +2419,22 @@ func (e *NativeAgentLoopExecutor) preserveUnsuccessfulLoopBranch(
 	if agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer {
 		return r
 	}
+
+	// DETACH FROM THE INCOMING CONTEXT. mapLoopError reaches this function on
+	// context.Canceled / DeadlineExceeded, and every repo call below runs git
+	// through exec.CommandContext -- so on exactly that path a live ctx is
+	// already dead, every git command fails instantly, and the branch is
+	// silently not preserved. The loop's own LoopBudget cannot cause this (it
+	// derives its own context and returns a terminal envelope before
+	// mapLoopError), so arriving here cancelled means the PARENT is gone: a
+	// cancelled task, or the agent shutting down.
+	//
+	// Preserving the work is a few git commands and is worth finishing even
+	// then, so the deadline is short and best-effort: on SIGTERM the process
+	// may still die first, which loses nothing that was not already lost.
+	ctx, cancelPreserve := context.WithTimeout(
+		context.WithoutCancel(ctx), preserveBranchTimeout)
+	defer cancelPreserve()
 
 	hasChanges, err := repo.HasChanges(ctx, workspace)
 	if err != nil {
@@ -2462,11 +2490,25 @@ func (e *NativeAgentLoopExecutor) preserveUnsuccessfulLoopBranch(
 		return r
 	}
 
-	if r.Extra == nil {
-		r.Extra = map[string]any{}
+	// r IS NIL on the infrastructure-failure path, and that is the case this
+	// function matters most for. mapLoopError returns (nil, loopErr) from its
+	// default branch for any transport / system error, and BOTH call sites
+	// enter on `r != nil || err != nil` -- a guard that reads like a nil check
+	// but lets nil through. A transport drop mid-run is precisely when the
+	// agent dies without warning and the workspace is least recoverable, so
+	// the branch is still pushed above; only the annotation is skipped, since
+	// there is no Result to annotate.
+	//
+	// Do not "simplify" this into an early `if r == nil { return nil }` at the
+	// top of the function: that compiles, stops the panic, and silently throws
+	// away the work in the one scenario the issue was filed for.
+	if r != nil {
+		if r.Extra == nil {
+			r.Extra = map[string]any{}
+		}
+		r.Extra["preservedBranch"] = branch
+		r.Extra["commitSHA"] = sha
 	}
-	r.Extra["preservedBranch"] = branch
-	r.Extra["commitSHA"] = sha
 	log.Info("unsuccessful-loop preserve: pushed branch for human finish",
 		"branch", branch, "sha", sha, "issue", task.Spec.Payload.Issue)
 	return r

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -859,6 +859,13 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 	}
 
 	if r, err := e.mapLoopError(start, transcriptRef, loopRes, loopErr); r != nil || err != nil {
+		// An unsuccessful loop (max turns exhausted, no tool call,
+		// truncation, context cancel) still committed work to the
+		// workspace. Preserve it on a branch a human can read before
+		// returning the INCOMPLETE verdict (#1715): the verdict stays
+		// non-GO and the branch is not entered into the review pipeline.
+		r = e.preserveUnsuccessfulLoopBranch(ctx, log, agent, task,
+			workspace, branch, auth, r)
 		return r, err
 	}
 
@@ -1116,6 +1123,12 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			log.Error(twErr, "transcript write failed; continuing")
 		}
 		if r, err := e.mapLoopError(start, transcriptRef, loopRes, loopErr); r != nil || err != nil {
+			// A retry loop that fails structurally (max turns, no tool
+			// call, timeout) has the same preservation need as the initial
+			// loop: commit and push whatever the coder wrote before
+			// returning the unsuccessful verdict (#1715).
+			r = e.preserveUnsuccessfulLoopBranch(ctx, log, agent, task,
+				workspace, branch, auth, r)
 			return r, err
 		}
 		if loopRes.Terminal == nil {
@@ -2364,6 +2377,99 @@ func (e *NativeAgentLoopExecutor) maybePreserveGateFailedBranch(
 	r.Extra["commitSHA"] = sha
 	log.Info("gate-failed preserve: pushed branch for human finish",
 		"branch", branch, "sha", sha, "issue", task.Spec.Payload.Issue)
+}
+
+// preserveUnsuccessfulLoopBranch commits and pushes whatever the model wrote
+// to the workspace when the loop ended unsuccessfully (max turns exhausted,
+// no tool call, truncation, context cancel). mapLoopError has already built
+// the unsuccessful result r; this does NOT change the verdict -- it only
+// makes that verdict land against a branch that exists, so a human can read
+// the diff, judge how far the run got, and finish or discard it (#1715).
+//
+// Nothing-to-commit is the EXPECTED case here (the model may have written
+// nothing before running out of turns), so ErrNothingToCommit is kept as the
+// original loop-error verdict rather than becoming NO-CHANGES. A commit or
+// push failure is logged and swallowed: the unsuccessful verdict already
+// reports the loop outcome, and losing the branch must not mask that signal.
+//
+// The branch is NOT marked reviewable: unlike maybePreserveGateFailedBranch,
+// no "gateFailedBranch" key is set, so it does not enter the normal review
+// pipeline as a candidate. The preserved branch is recorded under
+// r.Extra["preservedBranch"] for observability only.
+//
+// Reviewers are read-only by design (no workspace edits), so this is a
+// no-op for them.
+func (e *NativeAgentLoopExecutor) preserveUnsuccessfulLoopBranch(
+	ctx context.Context, log logr.Logger,
+	agent *foremanv1alpha1.Agent, task *foremanv1alpha1.AgenticTask,
+	workspace, branch string, auth *repo.Auth, r *Result,
+) *Result {
+	if agent.Spec.Role == foremanv1alpha1.AgentRoleReviewer {
+		return r
+	}
+
+	hasChanges, err := repo.HasChanges(ctx, workspace)
+	if err != nil {
+		// Could not tell whether the model wrote anything. Keep the original
+		// unsuccessful verdict; a failed stat must not flip the outcome.
+		log.Error(err, "unsuccessful-loop preserve: HasChanges failed; not preserving branch")
+		return r
+	}
+	if !hasChanges {
+		// Nothing to preserve (the model left no uncommitted work). This is
+		// the expected nothing-to-commit case, NOT a failure: keep the plain
+		// loop-error result.
+		return r
+	}
+
+	// Synthesize a WIP subject that flags the branch as unfinished and does
+	// NOT auto-close the issue (Refs, not Fixes): the loop did not conclude,
+	// so this branch is preserved for a human to finish, not a GO to merge.
+	msg := fmt.Sprintf(
+		"wip(loop-incomplete): preserve unsuccessful attempt for issue #%d\n\n"+
+			"The agent loop ended unsuccessfully (max turns, no tool call, "+
+			"truncation, or cancel) before it could submit a verdict, so this "+
+			"branch is preserved (verdict INCOMPLETE, not a GO) for a human to "+
+			"finish or discard. Do not merge as-is.\n\nRefs #%d",
+		task.Spec.Payload.Issue, task.Spec.Payload.Issue)
+	sha, commitErr := repo.Commit(ctx, repo.CommitOptions{
+		Workspace: workspace,
+		Message:   msg,
+		Author:    e.CommitAuthor,
+		Committer: e.CommitCommitter,
+	})
+	if errors.Is(commitErr, repo.ErrNothingToCommit) {
+		// The model wrote nothing between the HasChanges check and the
+		// commit. Keep the original unsuccessful verdict rather than
+		// converting it to NO-CHANGES.
+		return r
+	}
+	if commitErr != nil {
+		log.Error(commitErr, "unsuccessful-loop preserve: commit failed; not preserving branch")
+		return r
+	}
+
+	if err := repo.Push(ctx, repo.PushOptions{
+		Workspace: workspace,
+		Branch:    branch,
+		Auth:      auth,
+		// Replace this task's own branch: it supersedes any prior partial
+		// attempt on the same name.
+		ReplaceOnReject: task.Spec.Payload.AllowOverwrite,
+	}); err != nil {
+		log.Error(err, "unsuccessful-loop preserve: push failed; branch not preserved",
+			"branch", branch)
+		return r
+	}
+
+	if r.Extra == nil {
+		r.Extra = map[string]any{}
+	}
+	r.Extra["preservedBranch"] = branch
+	r.Extra["commitSHA"] = sha
+	log.Info("unsuccessful-loop preserve: pushed branch for human finish",
+		"branch", branch, "sha", sha, "issue", task.Spec.Payload.Issue)
+	return r
 }
 
 func (e *NativeAgentLoopExecutor) modelDecidedResult(

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -2896,3 +2896,76 @@ func extraFindings(res *foremanagent.Result, key string) []string {
 	}
 	return out
 }
+
+// A transport failure mid-run must not take the agent process down.
+//
+// Regression for the nil-Result panic: mapLoopError returns (nil, loopErr)
+// from its default branch for any infrastructure / transport error, and both
+// preserve call sites enter on `r != nil || err != nil` -- a guard that reads
+// like a nil check but lets nil through. Before the fix this segfaulted in
+// preserveUnsuccessfulLoopBranch at the r.Extra write, crashing foreman-agent.
+//
+// Driven end to end through Execute rather than by calling the preserve
+// function directly: the defect was in what the call site passes, so a direct
+// call is the one shape that cannot prove the fix.
+func TestNativeExecutor_TransportErrorAfterWritesDoesNotPanic(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+
+	// Turn 1 serves a tool call; every later request 500s, as an inference
+	// server that drops mid-run does.
+	var n atomic.Int64
+	oaiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if n.Add(1) > 1 {
+			http.Error(w, "upstream gone", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte(chatJSONBodyToSSE(t, readTurnBody)))
+	}))
+	defer oaiSrv.Close()
+
+	agent, task := taskAndAgent("transport-fail")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+
+	// The tool call writes real work into the workspace before the drop, so
+	// there is something to preserve.
+	reg := &fakeRegistry{results: map[string]*foremanagent.ToolResult{}}
+	reg.touch = func(_ string, ws string) {
+		_ = os.WriteFile(filepath.Join(ws, "half-done.go"), []byte("package coder\n"), 0o644)
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	// A transport failure is an infrastructure error: it surfaces as an error
+	// return, not a verdict, and above all not a panic.
+	if _, err := execWithAgent(t, e, task); err == nil {
+		t.Fatal("want an error from a transport failure, got nil")
+	}
+
+	// The work must still be preserved, which is the whole point of #1715:
+	// this is the case where the agent died without warning.
+	out, gitErr := exec.Command("git", "-C", bare, "branch", "--list", "foreman/issue-9999").CombinedOutput()
+	if gitErr != nil {
+		t.Fatalf("branch list: %v: %s", gitErr, out)
+	}
+	if !strings.Contains(string(out), "foreman/issue-9999") {
+		t.Errorf("branch not preserved after a transport failure: %s", out)
+	}
+}

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -688,6 +688,169 @@ func TestNativeExecutor_NoStaticRemoteAndNoRepoIsHardError(t *testing.T) {
 	}
 }
 
+// --- #1715: an unsuccessful loop still commits and pushes the workspace --
+
+// readTurnBody is a non-terminal turn: the model calls a read-only tool
+// (read_file) and never submits. Each such turn is a "progress" turn (it has
+// a tool_call), so the loop keeps going until MaxTurns, at which point it
+// surfaces ErrMaxTurnsExhausted. The fakeRegistry's touch writes a file on
+// every dispatch, so the workspace carries real work when the loop becomes
+// unsuccessful.
+const readTurnBody = `{
+  "id": "read",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "tool_calls": [{
+        "id": "tc-1",
+        "type": "function",
+        "function": {"name": "read_file", "arguments": "{\"path\":\"main.go\"}"}
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }]
+}`
+
+// TestNativeExecutor_UnsuccessfulLoopPreservesWorkspace proves that when the
+// loop ends unsuccessfully (here: MaxTurns exhausted without a submit_result),
+// the executor still commits and pushes whatever is in the workspace before
+// returning the INCOMPLETE verdict, rather than discarding the workspace with
+// the pod.
+func TestNativeExecutor_UnsuccessfulLoopPreservesWorkspace(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{readTurnBody})
+
+	agent, task := taskAndAgent("unsuccess")
+	// A small MaxTurns so the loop exhausts turns quickly. The model keeps
+	// reading (never submits), so it runs out of turns and surfaces
+	// ErrMaxTurnsExhausted.
+	agent.Spec.MaxTurns = 2
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(agent, task).
+		Build()
+
+	// fakeRegistry's touch writes a file to the workspace on every dispatch,
+	// simulating a coder that produced real work before the loop became
+	// unsuccessful.
+	reg := &fakeRegistry{results: map[string]*foremanagent.ToolResult{}}
+	reg.touch = func(name string, ws string) {
+		_ = os.WriteFile(filepath.Join(ws, "half-done.go"), []byte("package coder\n"), 0o644)
+	}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := execWithAgent(t, e, task)
+	if err != nil {
+		t.Fatalf("Execute returned a hard error; an unsuccessful loop must map to INCOMPLETE: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Fatalf("verdict: want INCOMPLETE got %s; result=%+v", res.Verdict, res)
+	}
+	// Must NOT be GO.
+	if res.Verdict == foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict must not be GO on an unsuccessful loop")
+	}
+	// The branch must exist on the remote with the workspace's contents.
+	out, err := exec.Command("git", "-C", bare, "branch", "--list", "foreman/issue-9999").CombinedOutput()
+	if err != nil {
+		t.Fatalf("post-preserve branch list: %v: %s", err, out)
+	}
+	if !strings.Contains(string(out), "foreman/issue-9999") {
+		t.Errorf("branch not pushed to remote: %s", out)
+	}
+	// The preserved branch is recorded for observability, but must NOT be
+	// marked reviewable (no gateFailedBranch key).
+	if got := res.Extra["preservedBranch"]; got != "foreman/issue-9999" {
+		t.Errorf("preservedBranch = %v; want foreman/issue-9999", got)
+	}
+	if _, ok := res.Extra["gateFailedBranch"]; ok {
+		t.Errorf("unsuccessful-loop branch must not be marked reviewable (gateFailedBranch set)")
+	}
+	// The branch should carry the half-done work.
+	_, err = exec.Command("git", "-C", bare, "show", "foreman/issue-9999:half-done.go").CombinedOutput()
+	if err != nil {
+		t.Errorf("half-done.go not present on the pushed branch: %v", err)
+	}
+}
+
+// TestNativeExecutor_UnsuccessfulLoopCleanWorkspaceNoError proves the
+// nothing-to-commit case: a loop that becomes unsuccessful with an empty
+// workspace (the model wrote nothing) must return the INCOMPLETE verdict
+// WITHOUT erroring on ErrNothingToCommit and WITHOUT converting the verdict
+// to NO-CHANGES.
+func TestNativeExecutor_UnsuccessfulLoopCleanWorkspaceNoError(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{readTurnBody})
+
+	agent, task := taskAndAgent("unsuccess-clean")
+	agent.Spec.MaxTurns = 2
+	c := fake.NewClientBuilder().
+		WithScheme(newScheme(t)).
+		WithObjects(agent, task).
+		Build()
+
+	// No touch: the workspace stays clean, so there is nothing to commit.
+	reg := &fakeRegistry{results: map[string]*foremanagent.ToolResult{}}
+
+	e := &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiSrv.URL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+	}
+
+	res, err := execWithAgent(t, e, task)
+	if err != nil {
+		t.Fatalf("Execute returned an error on a clean unsuccessful loop; nothing-to-commit is expected: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictIncomplete {
+		t.Fatalf("verdict: want INCOMPLETE got %s; result=%+v", res.Verdict, res)
+	}
+	// Must not become NO-CHANGES.
+	if got := res.Extra["outcome"]; got == "NO-CHANGES" {
+		t.Errorf("nothing-to-commit on an unsuccessful loop must keep the loop-error verdict, not NO-CHANGES")
+	}
+	// Nothing to push: no branch should have landed.
+	out, err := exec.Command("git", "-C", bare, "branch", "--list", "foreman/issue-9999").CombinedOutput()
+	if err != nil {
+		t.Fatalf("branch list: %v: %s", err, out)
+	}
+	if strings.Contains(string(out), "foreman/issue-9999") {
+		t.Errorf("branch should not be pushed when the workspace is clean")
+	}
+}
+
 // --- Loop returns no-change GO -> reported as NO-GO/NO-CHANGES -----------
 
 func TestNativeExecutor_ModelEmitsGoButNoChanges(t *testing.T) {


### PR DESCRIPTION
## What

Implements #1715 (preserve the workspace when the agent loop ends
unsuccessfully), and fixes two defects in that implementation.

Two commits, deliberately kept separate:

- `0a4280d5` is the Foreman coder's original implementation, unmodified.
- `c744bf98` is the fix, so the defect and its correction stay legible in
  history rather than being squashed out of existence.

## Why

Fixes #1715

A loop that ends in an error (max turns exhausted, no tool call, truncation,
cancel) returned before the commit and push block, so the workspace was
discarded with the pod and any work the model had done was lost. An INCOMPLETE
verdict on a pushed branch is strictly more useful than an INCOMPLETE verdict
on nothing.

The first commit does that. It then had a bug that crashed the agent.

## How

### The original change

`preserveUnsuccessfulLoopBranch` runs at both `mapLoopError` early-return sites
in `runLLMPath`. It does not touch the verdict, and deliberately does not set
the `gateFailedBranch` key, so a preserved branch does not enter the review
pipeline as a candidate. Nothing-to-commit is treated as the expected case
rather than as `NO-CHANGES`. The synthesized commit uses `Refs #`, not
`Fixes #`, so a preserved branch cannot auto-close the issue.

### Defect 1: nil `Result` dereference, crashed the agent process

`mapLoopError` builds a `Result` only for the model-behaviour outcomes. Its
`default:` branch returns `(nil, loopErr)` for any infrastructure or transport
failure, and both call sites enter on:

```go
if r, err := e.mapLoopError(...); r != nil || err != nil {
```

That guard contains the token `r != nil` and so reads like a nil check, while
the `||` lets nil through. The function then dereferenced `r.Extra`, giving a
SIGSEGV that took the whole `foreman-agent` process down. It is reachable from
an ordinary mid-run inference drop after the model has written files.

The fix preserves the branch on that path and skips only the annotation. An
early `if r == nil { return nil }` also stops the panic, but throws the work
away in exactly the scenario the issue was filed for, where the agent died
without warning and the work is least recoverable.

### Defect 2: the documented context-cancel case silently preserved nothing

Every `repo` call runs git through `exec.CommandContext`. `mapLoopError` routes
`context.Canceled` / `DeadlineExceeded` into this path by name, so on that path
a cancelled ctx failed the commit instantly and the branch was dropped without
a trace. The loop's own `LoopBudget` cannot land here (it derives its own
context and returns a terminal envelope before `mapLoopError`), so arriving
cancelled means the parent is genuinely gone. The commit and push now run
detached with a 30s bound, best-effort.

The doc comment's premise "mapLoopError has already built the unsuccessful
result r" is what produced defect 1, and is corrected to state that r may be
nil.

### Notes for reviewers

The transport-failure regression test drives the executor end to end through
`Execute` rather than calling `preserveUnsuccessfulLoopBranch` directly. The
defect was in what the call site passes, so a direct call is the one test shape
that cannot prove the fix.

Both fixes were mutation-checked: reverting the nil guard restores the panic,
and reverting the context detach restores the silent no-op.

Worth knowing for anyone reaching for a linter here: neither govet's `nilness`
(intraprocedural) nor `nilaway` (interprocedural) flags this, and `make lint`
reports 0 issues on the unfixed branch.

### One nilaway report that is NOT a bug

For anyone who runs `nilaway` over this package: it reports a nil dereference
at `executor_native.go:2279` / `:2297`, where `openPullRequest` calls a method
on `codeHost()`'s result, which `:222` can return as nil. That one is a false
positive. The only production caller, `maybeOpenPullRequest`, guards with
`e.codeHost(authToken(auth)) == nil` and returns early; nilaway cannot connect
the guard to the call because `codeHost()` is invoked twice. Left alone here
deliberately, and noted so nobody "fixes" a guarded path.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) - no user-facing surface changes

Assisted-by: Foreman (ornith-397b-coder) generated commit 0a4280d5 in full;
Claude Code found both defects, wrote the regression tests and commit c744bf98.
I reviewed the whole change, ran `make test` and `make lint`, and verified the
panic end to end before and after the fix.
