### PR TITLE
feat(foreman): live turn stream so a coder run can be watched as it happens

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -169,6 +169,10 @@ func main() {
 		// PR4 self-update flags
 		selfUpdateEnabled bool
 		installRoot       string
+
+		// Live turn streaming
+		turnStreamAddr     string
+		turnStreamCapacity int
 	)
 
 	flag.StringVar(&fleetNodeName, "fleet-node-name", "",
@@ -210,6 +214,31 @@ func main() {
 		"Advertised decode throughput in tok/s (0 = unset).")
 	flag.IntVar(&staticTotalRAMGB, "total-ram-gb", 0,
 		"Advertised total RAM on platforms without live memory probing (non-darwin only).")
+
+	// Live turn streaming. Serves THIS agent's in-process run over SSE so a
+	// viewer can watch turns as they land instead of waiting for the terminal
+	// transcript ConfigMap. "0" (or empty) disables, matching the convention
+	// the operator's metrics flag uses.
+	//
+	// LOOPBACK BY DEFAULT, DELIBERATELY. The endpoint has NO authentication
+	// and the turns it serves are the coder's full transcript: prompts, file
+	// contents, and raw tool output, which is exactly where a leaked token or
+	// customer path would show up. Two of the places this binary runs make
+	// ":8082" the wrong default -- a metal agent runs as a plain process on a
+	// personal Mac on the house LAN, and an in-cluster pod is reachable by
+	// anything with pod-network access.
+	//
+	// 127.0.0.1 costs the viewer nothing in either place: `kubectl
+	// port-forward` attaches to the POD's network namespace, so it reaches a
+	// loopback listener, and an on-box viewer is already on the box. Widening
+	// this to :8082 or 0.0.0.0 is a deliberate operator decision to serve an
+	// unauthenticated transcript feed to the network, so it is opt-in.
+	flag.StringVar(&turnStreamAddr, "turn-stream-bind-address", "127.0.0.1:8082",
+		"Address the live turn stream serves SSE on (GET /stream). Loopback by "+
+			"default: the endpoint is unauthenticated and serves the full "+
+			"transcript. \"0\" disables it.")
+	flag.IntVar(&turnStreamCapacity, "turn-stream-replay-turns", 64,
+		"How many recent turns the stream replays to a viewer that attaches mid-run.")
 
 	// M3 Phase F: default flipped to native. The stub executor is
 	// kept around for development + tests, but production foreman-
@@ -426,6 +455,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Live turn stream. Built before the executor so the native executor can
+	// hold it; nil when disabled, which keeps the loop's OnTurn hook nil and
+	// costs a non-streaming agent nothing.
+	//
+	// This is the WATCHER's executor, which is where the loop actually runs
+	// for every agent whose spec.execution.mode is not Job (the default, and
+	// what the whole current fleet uses). A Job-mode agent runs its loop in a
+	// separate coder Job pod via `run-task`, whose executor is built in
+	// RunTask and has no stream: streaming that path needs per-Job discovery
+	// and is deliberately out of scope here.
+	var turnStream *foremanagent.TurnStream
+	if turnStreamAddr != "" && turnStreamAddr != "0" {
+		turnStream = foremanagent.NewTurnStream(turnStreamCapacity)
+	}
+
 	// Executor: M2 stub or M3 native. Selection via --agent-mode.
 	var executor foremanagent.Executor
 	switch agentMode {
@@ -433,6 +477,7 @@ func main() {
 		executor = &foremanagent.StubExecutor{SleepDuration: stubSleep}
 	case "native":
 		executor = &foremanagent.NativeAgentLoopExecutor{
+			Stream:                       turnStream,
 			Client:                       kc,
 			WorkspaceRoot:                workspaceDir,
 			GitRemoteURL:                 gitRemoteURL,
@@ -516,6 +561,18 @@ func main() {
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error { return reg.Run(gctx) })
 	g.Go(func() error { return watcher.Run(gctx) })
+	// Serves the turn stream for as long as the agent runs. Start returns nil
+	// immediately-on-ctx when disabled, so this goroutine is harmless when the
+	// stream is off; it must NOT fail the group on a bind error taking the
+	// whole agent down, so a failure to listen is logged and swallowed --
+	// losing the view of a run is not a reason to stop doing the run.
+	g.Go(func() error {
+		srv := &foremanagent.TurnStreamServer{Addr: turnStreamAddr, Stream: turnStream}
+		if err := srv.Start(gctx); err != nil {
+			setupLog.Error(err, "turn stream server stopped", "addr", turnStreamAddr)
+		}
+		return nil
+	})
 
 	if err := g.Wait(); err != nil {
 		if errors.Is(err, foremanagent.ErrSelfUpdateRestart) {

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -204,6 +204,17 @@ type NativeAgentLoopExecutor struct {
 	// here. Nil skips the post-push envtest gate (e.g. the in-process
 	// run-task path, where the clean-room gate Job is the backstop).
 	EnvtestJobRunner EnvtestJobRunner
+
+	// Stream, when non-nil, receives each completed turn of the loop so a
+	// viewer can watch the run as it happens (see turnstream.go). Nil is the
+	// normal case and costs nothing: the loop's OnTurn hook stays nil, so no
+	// turn is ever copied.
+	//
+	// It is deliberately ONE stream per executor rather than one per task.
+	// An agent runs a single task at a time, so the executor's stream IS
+	// that run's stream; multiplexing by task would add a registry with a
+	// lifetime problem (when to evict a finished run) for no gain.
+	Stream *TurnStream
 }
 
 // codeHost returns the effective CodeHost seam: the injected CodeHost when
@@ -821,6 +832,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 		// template. Nil/empty omits the field on the wire so the request
 		// is byte-identical to today for agents that do not set it.
 		ChatTemplateKwargs: agent.Spec.ChatTemplateKwargs,
+		// Live turn streaming, opt-in. A method rather than an inline nil
+		// check because this function sits at the gocyclo ceiling; see
+		// turnHook for why the nil case must stay a nil hook.
+		OnTurn: e.turnHook(),
 	}
 
 	// Coder gate feedback loop (#749): coders verify their work through a

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -212,6 +212,20 @@ type LoopConfig struct {
 	// finish_reason=="stop" model that circled without acting. Resets after
 	// any tool-calling turn. <= 0 falls back to DefaultMaxTruncationRetries.
 	MaxTruncationRetries int
+
+	// OnTurn, when non-nil, is called once per completed turn with the
+	// 1-based turn number and the messages appended during that turn.
+	//
+	// It exists because the transcript ConfigMap is written once, at
+	// completion, so it cannot show a run in progress; and because a
+	// cancelled run writes no transcript at all. Without this hook the only
+	// way to watch a coder work is to tail the llama.cpp server log and poll
+	// git status inside the workspace pod.
+	//
+	// It MUST NOT block. It runs on the loop's own goroutine, so a slow
+	// consumer would stall the coder. Implementations send non-blocking and
+	// drop rather than wait.
+	OnTurn func(turn int, msgs []oai.Message)
 }
 
 // DefaultContextWindowTokens is the budget used when LoopConfig.ContextWindowTokens
@@ -784,7 +798,13 @@ func (l *Loop) Run(ctx context.Context, cfg LoopConfig) (*LoopResult, error) {
 	// verifyRetries counts coder-gate fix attempts spent so far (#749).
 	verifyRetries := 0
 
+	// Live turn emission. Kept in turnFlusher rather than a closure here so
+	// its branches do not count toward Run's cyclomatic budget.
+	flusher := &turnFlusher{onTurn: cfg.OnTurn, emitted: len(res.Transcript)}
+	defer flusher.flush(res)
+
 	for turn := 1; turn <= cfg.MaxTurns; turn++ {
+		flusher.flush(res)
 		res.Turns = turn
 
 		// During the forcing phase, advertise the restricted set (no grep,
@@ -1576,4 +1596,29 @@ func approxTokens(messages []oai.Message) int {
 		chars += 16
 	}
 	return chars / charsPerTokenApprox
+}
+
+// turnFlusher emits completed turns to LoopConfig.OnTurn as the loop runs.
+//
+// It flushes on transcript GROWTH rather than at a fixed point in the loop
+// body, because that body has nine exit paths (three continue, six return).
+// Emitting at the bottom would silently skip the retry-and-feedback turns,
+// which are exactly the ones worth watching live. Two call sites dominate all
+// nine: the top of each iteration flushes the turn that just ended however it
+// ended, and a deferred call flushes the final turn on any return.
+type turnFlusher struct {
+	onTurn func(turn int, msgs []oai.Message)
+	// emitted is the transcript length already sent. Seeded with the
+	// PRE-LOOP length, not zero: the system prompt and initial user message
+	// are in the transcript before turn 1 and are not a turn, so starting at
+	// zero emits them as a phantom turn 0.
+	emitted int
+}
+
+func (f *turnFlusher) flush(res *LoopResult) {
+	if f.onTurn == nil || len(res.Transcript) <= f.emitted {
+		return
+	}
+	f.onTurn(res.Turns, res.Transcript[f.emitted:])
+	f.emitted = len(res.Transcript)
 }

--- a/pkg/foreman/agent/loop_test.go
+++ b/pkg/foreman/agent/loop_test.go
@@ -1739,3 +1739,64 @@ func TestLoop_DoesNotRetryOnUnrelated400(t *testing.T) {
 		t.Errorf("an unrelated 400 must not be retried, saw %d requests", n)
 	}
 }
+
+// TestLoop_OnTurnCalledPerTurn covers the live-viewer seam: the loop must emit
+// each turn as it completes, because the transcript ConfigMap is written once
+// at the end and so cannot show a run in progress. Without this hook there is
+// no live surface at all: today watching a run means tailing llama.cpp server
+// logs and polling git status inside the workspace pod.
+func TestLoop_OnTurnCalledPerTurn(t *testing.T) {
+	srv, _ := scriptedOAIServer(t, []string{toolCallReadFile, toolCallReadFile, toolCallReadFile})
+	reg := &fakeRegistry{
+		results: map[string]*ToolResult{
+			"read_file": {Output: map[string]any{"content": "# README\n"}},
+		},
+	}
+
+	var turns []int
+	var msgCounts []int
+	loop := newTestLoop(srv, reg)
+	_, err := loop.Run(context.Background(), LoopConfig{
+		Model:    "test",
+		MaxTurns: 3,
+		OnTurn: func(turn int, msgs []oai.Message) {
+			turns = append(turns, turn)
+			msgCounts = append(msgCounts, len(msgs))
+		},
+	})
+	if !errors.Is(err, ErrMaxTurnsExhausted) {
+		t.Fatalf("expected ErrMaxTurnsExhausted, got %v", err)
+	}
+
+	if len(turns) == 0 {
+		t.Fatal("OnTurn was never called; a live viewer would show nothing")
+	}
+	for i, turn := range turns {
+		if turn != i+1 {
+			t.Fatalf("turn numbers must be sequential from 1, got %v", turns)
+		}
+	}
+	// Each turn must carry the messages appended during THAT turn, not an
+	// empty slice and not the whole transcript: a viewer renders the delta.
+	for i, n := range msgCounts {
+		if n == 0 {
+			t.Errorf("turn %d emitted 0 messages; nothing to render", turns[i])
+		}
+	}
+}
+
+// TestLoop_OnTurnNilIsSafe pins the hook as optional. Every existing caller
+// builds LoopConfig without it and must be unaffected.
+func TestLoop_OnTurnNilIsSafe(t *testing.T) {
+	srv, _ := scriptedOAIServer(t, []string{toolCallReadFile})
+	reg := &fakeRegistry{
+		results: map[string]*ToolResult{
+			"read_file": {Output: map[string]any{"content": "x"}},
+		},
+	}
+	loop := newTestLoop(srv, reg)
+	_, err := loop.Run(context.Background(), LoopConfig{Model: "test", MaxTurns: 1})
+	if !errors.Is(err, ErrMaxTurnsExhausted) {
+		t.Fatalf("a nil OnTurn must not change loop behaviour, got %v", err)
+	}
+}

--- a/pkg/foreman/agent/turnstream.go
+++ b/pkg/foreman/agent/turnstream.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"sync"
+	"time"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// TurnEvent is one completed turn, as it happened.
+type TurnEvent struct {
+	// Turn is the 1-based turn number this event completes.
+	Turn int `json:"turn"`
+	// Messages are the transcript entries appended during this turn: the
+	// assistant message (including its tool_calls, which is what makes the
+	// stream show WHAT the agent wrote rather than merely that it wrote) and
+	// the tool results that followed.
+	Messages []oai.Message `json:"messages"`
+	// At is when the turn completed, so a viewer can show pacing. Decode at
+	// ~14 tok/s on a 397B means minutes between turns; without timestamps a
+	// stalled run and a slow one look identical.
+	At time.Time `json:"at"`
+}
+
+// TurnStream fans completed turns out to live subscribers and keeps a bounded
+// replay buffer so a subscriber that joins mid-run sees what it missed.
+//
+// It deliberately does NOT persist anything. The transcript ConfigMap remains
+// the archive, written once at completion. Conflating the two is what forces
+// today's truncation compromise: transcripts are capped at the 1 MiB ConfigMap
+// budget and silently drop middle messages once a run gets long.
+//
+// A nil *TurnStream is usable: Publish is a no-op. That keeps the executor
+// wiring unconditional even when streaming is disabled.
+type TurnStream struct {
+	mu sync.Mutex
+	// ring holds the most recent events, oldest first, capped at capacity.
+	ring     []TurnEvent
+	capacity int
+	subs     map[*subscriber]struct{}
+}
+
+type subscriber struct {
+	ch   chan TurnEvent
+	once sync.Once
+}
+
+// NewTurnStream returns a stream retaining the last capacity turns for replay.
+func NewTurnStream(capacity int) *TurnStream {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &TurnStream{
+		ring:     make([]TurnEvent, 0, capacity),
+		capacity: capacity,
+		subs:     make(map[*subscriber]struct{}),
+	}
+}
+
+// Publish records a completed turn and delivers it to current subscribers.
+//
+// NEVER BLOCKS. It runs on the loop's own goroutine via LoopConfig.OnTurn, so
+// blocking here would stall the coder run itself. A subscriber whose buffer is
+// full misses the event rather than holding up the agent; the replay buffer
+// means a viewer that reconnects still catches up.
+func (s *TurnStream) Publish(turn int, msgs []oai.Message) {
+	if s == nil {
+		return
+	}
+	// Copy: the loop hands us a slice of its live transcript, which it keeps
+	// appending to. Retaining that slice would alias a growing backing array.
+	cp := make([]oai.Message, len(msgs))
+	copy(cp, msgs)
+	ev := TurnEvent{Turn: turn, Messages: cp, At: time.Now()}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.ring) == s.capacity {
+		s.ring = append(s.ring[:0], s.ring[1:]...)
+	}
+	s.ring = append(s.ring, ev)
+
+	for sub := range s.subs {
+		select {
+		case sub.ch <- ev:
+		default: // slow consumer; drop rather than stall the loop
+		}
+	}
+}
+
+// PublishTurn matches the LoopConfig.OnTurn signature so it can be assigned
+// directly, including from a nil *TurnStream.
+func (s *TurnStream) PublishTurn(turn int, msgs []oai.Message) {
+	s.Publish(turn, msgs)
+}
+
+// Subscribe returns a channel delivering the replay buffer followed by live
+// turns, and a cancel func that unsubscribes. cancel is idempotent, so an HTTP
+// handler can defer it and also return early.
+//
+// The replay is loaded into the channel buffer under the same lock that
+// registers the subscriber, so no turn is missed or duplicated across the
+// replay-to-live handover.
+func (s *TurnStream) Subscribe() (<-chan TurnEvent, func()) {
+	if s == nil {
+		ch := make(chan TurnEvent)
+		close(ch)
+		return ch, func() {}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Buffer the backlog plus headroom for live turns arriving while the
+	// consumer works through it.
+	sub := &subscriber{ch: make(chan TurnEvent, len(s.ring)+s.capacity)}
+	for _, ev := range s.ring {
+		sub.ch <- ev
+	}
+	s.subs[sub] = struct{}{}
+
+	return sub.ch, func() {
+		sub.once.Do(func() {
+			s.mu.Lock()
+			delete(s.subs, sub)
+			s.mu.Unlock()
+			close(sub.ch)
+		})
+	}
+}
+
+// SubscriberCount reports the number of live subscribers.
+func (s *TurnStream) SubscriberCount() int {
+	if s == nil {
+		return 0
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.subs)
+}

--- a/pkg/foreman/agent/turnstream.go
+++ b/pkg/foreman/agent/turnstream.go
@@ -139,3 +139,18 @@ func (s *TurnStream) SubscriberCount() int {
 	defer s.mu.Unlock()
 	return len(s.subs)
 }
+
+// turnHook returns the LoopConfig.OnTurn hook for this executor's stream, or
+// nil when no stream is attached.
+//
+// The nil case must stay NIL rather than a method value on a nil *TurnStream.
+// PublishTurn is safe to call on a nil receiver, but a method value is still a
+// non-nil func, so returning one unconditionally would make the loop's flusher
+// reslice the transcript on every turn of every run nobody is watching. The
+// loop checks this hook against nil precisely so an unwatched run pays nothing.
+func (e *NativeAgentLoopExecutor) turnHook() func(int, []oai.Message) {
+	if e.Stream == nil {
+		return nil
+	}
+	return e.Stream.PublishTurn
+}

--- a/pkg/foreman/agent/turnstream_http.go
+++ b/pkg/foreman/agent/turnstream_http.go
@@ -1,0 +1,127 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+)
+
+// turnStreamKeepalive is how often an idle stream emits an SSE comment.
+//
+// Not cosmetic. A 397B coder decodes at roughly 14 tok/s, so multi-minute gaps
+// between turns are normal, and an idle connection can otherwise be dropped by
+// a proxy or the client's own timeout. The comment keeps it alive and is
+// ignored by every SSE client.
+const turnStreamKeepalive = 30 * time.Second
+
+// Handler serves the stream as Server-Sent Events: the replay buffer first,
+// then live turns, until the client disconnects.
+//
+// SSE rather than a WebSocket deliberately. The traffic is one-directional,
+// SSE survives proxies without an upgrade dance, and `curl -N` is a first-class
+// client, which makes the endpoint useful before any UI exists.
+func (s *TurnStream) Handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		// Proxies that buffer would defeat the entire point.
+		w.Header().Set("X-Accel-Buffering", "no")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		events, cancel := s.Subscribe()
+		defer cancel()
+
+		ticker := time.NewTicker(turnStreamKeepalive)
+		defer ticker.Stop()
+
+		enc := json.NewEncoder(w)
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case ev, open := <-events:
+				if !open {
+					return
+				}
+				if _, err := w.Write([]byte("data: ")); err != nil {
+					return
+				}
+				// Encode writes a trailing newline; SSE needs a blank line to
+				// terminate the frame, hence the second one below.
+				if err := enc.Encode(ev); err != nil {
+					return
+				}
+				if _, err := w.Write([]byte("\n")); err != nil {
+					return
+				}
+				flusher.Flush()
+			case <-ticker.C:
+				if _, err := w.Write([]byte(": keepalive\n\n")); err != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+// TurnStreamServer serves a TurnStream over HTTP as a controller-runtime
+// Runnable, so the manager owns its lifecycle and shuts it down with everything
+// else. Mirrors how the audit reaper is registered.
+type TurnStreamServer struct {
+	// Addr is the bind address. Empty or "0" disables the server, matching
+	// the convention the metrics flag already uses.
+	Addr   string
+	Stream *TurnStream
+}
+
+// NeedLeaderElection reports false: this serves the LOCAL agent's own run, so
+// every replica must serve its own stream rather than only the leader.
+func (srv *TurnStreamServer) NeedLeaderElection() bool { return false }
+
+// Start satisfies manager.Runnable.
+func (srv *TurnStreamServer) Start(ctx context.Context) error {
+	if srv.Addr == "" || srv.Addr == "0" || srv.Stream == nil {
+		<-ctx.Done()
+		return nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/stream", srv.Stream.Handler())
+
+	h := &http.Server{
+		Addr:    srv.Addr,
+		Handler: mux,
+		// No WriteTimeout: an SSE response is open for the life of the run,
+		// and a write deadline would sever it mid-stream.
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := h.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		return h.Shutdown(shutdownCtx)
+	}
+}

--- a/pkg/foreman/agent/turnstream_http_test.go
+++ b/pkg/foreman/agent/turnstream_http_test.go
@@ -1,0 +1,124 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// readEvent reads one SSE "data:" frame and decodes it. Decoding rather than
+// substring-matching means a schema change fails the test instead of passing
+// by luck.
+func readEvent(t *testing.T, r *bufio.Reader) TurnEvent {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read stream: %v", err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" || strings.HasPrefix(line, ":") {
+			continue // blank separator or keepalive comment
+		}
+		payload, ok := strings.CutPrefix(line, "data: ")
+		if !ok {
+			t.Fatalf("unexpected SSE line: %q", line)
+		}
+		var ev TurnEvent
+		if err := json.Unmarshal([]byte(payload), &ev); err != nil {
+			t.Fatalf("decode event %q: %v", payload, err)
+		}
+		return ev
+	}
+	t.Fatal("timed out waiting for an SSE event")
+	return TurnEvent{}
+}
+
+func TestTurnStreamHandler_ReplaysThenTails(t *testing.T) {
+	s := NewTurnStream(8)
+	s.Publish(1, []oai.Message{{
+		Role:      oai.RoleAssistant,
+		ToolCalls: []oai.ToolCall{{Function: oai.ToolCallFunction{Name: "write_file", Arguments: `{"path":"a.go"}`}}},
+	}})
+
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := resp.Header.Get("Content-Type"); got != "text/event-stream" {
+		t.Errorf("Content-Type = %q, want text/event-stream", got)
+	}
+
+	r := bufio.NewReader(resp.Body)
+
+	// The buffered turn must arrive even though it was published before the
+	// client connected: that is the whole point of replay.
+	ev := readEvent(t, r)
+	if ev.Turn != 1 {
+		t.Fatalf("replayed turn = %d, want 1", ev.Turn)
+	}
+	// Tool CALL arguments must survive the wire. Showing what the agent wrote,
+	// not merely that it wrote, is what separates this from a log tail.
+	if len(ev.Messages) != 1 || len(ev.Messages[0].ToolCalls) != 1 {
+		t.Fatalf("tool calls lost in transit: %+v", ev.Messages)
+	}
+	if got := ev.Messages[0].ToolCalls[0].Function.Name; got != "write_file" {
+		t.Errorf("tool call name = %q, want write_file", got)
+	}
+	if !strings.Contains(ev.Messages[0].ToolCalls[0].Function.Arguments, "a.go") {
+		t.Errorf("tool call arguments lost: %q", ev.Messages[0].ToolCalls[0].Function.Arguments)
+	}
+
+	// And a turn published after connect must arrive live.
+	s.Publish(2, []oai.Message{{Role: oai.RoleAssistant, Content: "second"}})
+	if ev := readEvent(t, r); ev.Turn != 2 {
+		t.Errorf("live turn = %d, want 2", ev.Turn)
+	}
+}
+
+// TestTurnStreamHandler_ClientDisconnectUnsubscribes: a closed browser tab must
+// not leak a subscriber for the life of the agent process.
+func TestTurnStreamHandler_ClientDisconnectUnsubscribes(t *testing.T) {
+	s := NewTurnStream(4)
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	s.Publish(1, []oai.Message{{Role: oai.RoleAssistant, Content: "x"}})
+	r := bufio.NewReader(resp.Body)
+	_ = readEvent(t, r)
+
+	cancel()
+	_ = resp.Body.Close()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if s.SubscriberCount() == 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Errorf("subscriber still registered after disconnect: count = %d", s.SubscriberCount())
+}

--- a/pkg/foreman/agent/turnstream_test.go
+++ b/pkg/foreman/agent/turnstream_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"testing"
+	"time"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// TestTurnStream_ReplayThenTail is the property that makes a live viewer
+// usable: opening the page mid-run must show the whole run so far, then
+// continue live. Without replay the viewer only works if you were already
+// watching when the run started, which is never when you want it.
+func TestTurnStream_ReplayThenTail(t *testing.T) {
+	s := NewTurnStream(8)
+	s.Publish(1, []oai.Message{{Role: oai.RoleAssistant, Content: "one"}})
+	s.Publish(2, []oai.Message{{Role: oai.RoleAssistant, Content: "two"}})
+
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	for want := 1; want <= 2; want++ {
+		select {
+		case ev := <-ch:
+			if ev.Turn != want {
+				t.Fatalf("replay out of order: got turn %d want %d", ev.Turn, want)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("turn %d was never replayed to a late subscriber", want)
+		}
+	}
+
+	s.Publish(3, []oai.Message{{Role: oai.RoleAssistant, Content: "three"}})
+	select {
+	case ev := <-ch:
+		if ev.Turn != 3 {
+			t.Fatalf("live tail: got turn %d want 3", ev.Turn)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no live event after the replay handover")
+	}
+}
+
+// TestTurnStream_SlowSubscriberDoesNotBlockPublish pins the constraint that
+// matters most: OnTurn runs on the loop's own goroutine, so a browser tab that
+// stops reading must never stall a coder run.
+func TestTurnStream_SlowSubscriberDoesNotBlockPublish(t *testing.T) {
+	s := NewTurnStream(2)
+	_, cancel := s.Subscribe() // deliberately never drained
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		for i := 1; i <= 200; i++ {
+			s.Publish(i, []oai.Message{{Role: oai.RoleAssistant, Content: "x"}})
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Publish blocked on a slow subscriber; a stalled tab would stall the coder")
+	}
+}
+
+// TestTurnStream_RingBufferBounded: a long run must not grow memory without
+// bound, and the recent turns are the useful ones.
+func TestTurnStream_RingBufferBounded(t *testing.T) {
+	s := NewTurnStream(3)
+	for i := 1; i <= 10; i++ {
+		s.Publish(i, []oai.Message{{Role: oai.RoleAssistant, Content: "x"}})
+	}
+	ch, cancel := s.Subscribe()
+	defer cancel()
+
+	var got []int
+	for i := 0; i < 3; i++ {
+		select {
+		case ev := <-ch:
+			got = append(got, ev.Turn)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("replay stopped after %d events, want 3", len(got))
+		}
+	}
+	if len(got) != 3 || got[0] != 8 || got[2] != 10 {
+		t.Errorf("ring kept %v, want the last three turns (8,9,10)", got)
+	}
+	select {
+	case ev := <-ch:
+		t.Errorf("ring replayed more than its capacity: extra turn %d", ev.Turn)
+	default:
+	}
+}
+
+// TestTurnStream_CancelUnsubscribes: a disconnected viewer must not leak a
+// subscriber slot for the life of the process.
+func TestTurnStream_CancelUnsubscribes(t *testing.T) {
+	s := NewTurnStream(4)
+	_, cancel := s.Subscribe()
+	if n := s.SubscriberCount(); n != 1 {
+		t.Fatalf("subscriber count = %d, want 1", n)
+	}
+	cancel()
+	if n := s.SubscriberCount(); n != 0 {
+		t.Errorf("subscriber count after cancel = %d, want 0", n)
+	}
+	cancel() // must be idempotent; an HTTP handler may defer it and return early
+}
+
+// TestTurnStream_NilStreamPublishIsSafe: the executor may run without a stream
+// configured, and PublishTurn is wired straight to LoopConfig.OnTurn.
+func TestTurnStream_NilStreamPublishIsSafe(t *testing.T) {
+	var s *TurnStream
+	s.Publish(1, []oai.Message{{Role: oai.RoleAssistant, Content: "x"}})
+}

--- a/pkg/foreman/agent/turnstream_test.go
+++ b/pkg/foreman/agent/turnstream_test.go
@@ -114,3 +114,34 @@ func TestTurnStream_NilStreamPublishIsSafe(t *testing.T) {
 	var s *TurnStream
 	s.Publish(1, []oai.Message{{Role: oai.RoleAssistant, Content: "x"}})
 }
+
+// The nil case must return a nil hook, not a method value on a nil receiver.
+// Both are safe to call, but only nil lets the loop's flusher skip the work,
+// which is what keeps an unwatched run free. A method value would silently
+// pass a "does it panic" test while costing every run a reslice per turn.
+func TestTurnHook_NilStreamYieldsNilHook(t *testing.T) {
+	if hook := (&NativeAgentLoopExecutor{}).turnHook(); hook != nil {
+		t.Error("turnHook with no stream: want nil hook so the loop skips per-turn work, got non-nil")
+	}
+}
+
+func TestTurnHook_StreamYieldsWorkingHook(t *testing.T) {
+	s := NewTurnStream(4)
+	hook := (&NativeAgentLoopExecutor{Stream: s}).turnHook()
+	if hook == nil {
+		t.Fatal("turnHook with a stream: want a hook, got nil")
+	}
+
+	ch, cancel := s.Subscribe()
+	defer cancel()
+	hook(7, []oai.Message{{Role: oai.RoleAssistant, Content: "hi"}})
+
+	select {
+	case ev := <-ch:
+		if ev.Turn != 7 || len(ev.Messages) != 1 || ev.Messages[0].Content != "hi" {
+			t.Errorf("hook delivered %+v; want turn 7 carrying one assistant message", ev)
+		}
+	default:
+		t.Error("hook did not deliver the turn to a subscriber")
+	}
+}

--- a/pkg/foreman/agent/turnstream_wiring_test.go
+++ b/pkg/foreman/agent/turnstream_wiring_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	fake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/repo"
+)
+
+// These tests drive a REAL end-to-end coder pass (the same harness the envtest
+// loop tests use) rather than calling Publish directly, because the thing under
+// test is the wiring: that the executor actually hands loop turns to the
+// stream. A unit test that publishes by hand would pass with the hook
+// disconnected, which is the exact defect this guards.
+
+// streamWiringExecutor is envtestLoopExecutor minus the envtest runner, plus a
+// stream. It deliberately reuses the same fake OAI + fake registry harness so a
+// change that breaks the loop's turn accounting fails here too.
+func streamWiringExecutor(
+	t *testing.T, root, bare, oaiURL string, stream *foremanagent.TurnStream,
+) *foremanagent.NativeAgentLoopExecutor {
+	t.Helper()
+	agent, task := taskAndAgent("stream-wiring")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
+	reg := &seqEnvtestRegistry{verdicts: []string{"GO"}}
+	return &foremanagent.NativeAgentLoopExecutor{
+		Client:                   c,
+		WorkspaceRoot:            filepath.Join(root, "ws"),
+		GitRemoteURL:             bare,
+		UpstreamURLForRepo:       func(string) string { return bare },
+		InferenceBaseURLOverride: oaiURL + "/v1",
+		CommitAuthor:             repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		CommitCommitter:          repo.Identity{Name: "Foreman Bot", Email: "bot@foreman.test"},
+		RegistryFactory: func(
+			_ context.Context, ws string, _ *foremanv1alpha1.Agent, _ bool,
+		) (foremanagent.ToolRegistry, error) {
+			reg.workspace = ws
+			return reg, nil
+		},
+		AuthFactory: fakeAuth(t),
+		Stream:      stream,
+	}
+}
+
+// A run on an executor holding a stream publishes that run's real turns.
+func TestNativeExecutor_PublishesTurnsToStream(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+	stream := foremanagent.NewTurnStream(16)
+
+	e := streamWiringExecutor(t, root, bare, oaiSrv.URL, stream)
+	_, task := taskAndAgent("stream-wiring")
+	if _, err := execWithAgent(t, e, task); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Subscribe AFTER the run: the replay buffer is what makes a viewer that
+	// attaches mid-run (or just after) still see what happened, so draining it
+	// here exercises the same path the SSE handler uses.
+	ch, cancel := stream.Subscribe()
+	defer cancel()
+
+	var events []foremanagent.TurnEvent
+	for {
+		select {
+		case ev := <-ch:
+			events = append(events, ev)
+			continue
+		default:
+		}
+		break
+	}
+
+	if len(events) == 0 {
+		t.Fatal("stream received no turns; the executor never wired OnTurn to the stream")
+	}
+
+	// Turn 0 is the pre-loop system+user seed, not a turn the model took. It
+	// leaking into the stream was a real bug in the flusher (fixed by seeding
+	// emitted), so guard it here at the wired level too.
+	var sawSubmit bool
+	for i, ev := range events {
+		if ev.Turn < 1 {
+			t.Errorf("event %d has turn %d; turns are 1-based and the pre-loop seed must not publish", i, ev.Turn)
+		}
+		if len(ev.Messages) == 0 {
+			t.Errorf("event %d (turn %d) carries no messages", i, ev.Turn)
+		}
+		for _, m := range ev.Messages {
+			if m.Role != oai.RoleAssistant {
+				continue
+			}
+			for _, tc := range m.ToolCalls {
+				if tc.Function.Name == "submit_result" {
+					sawSubmit = true
+				}
+			}
+		}
+	}
+
+	// Proves the events carry the RUN's transcript and not empty scaffolding.
+	if !sawSubmit {
+		t.Errorf("no assistant submit_result tool call in %d published event(s); "+
+			"the stream is not carrying the real transcript", len(events))
+	}
+}
+
+// A nil stream must leave the loop untouched: the streaming path is opt-in and
+// every existing deployment runs with it unset.
+func TestNativeExecutor_NilStreamDoesNotPanic(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	oaiSrv := scriptedOAI(t, []string{submitGoBody})
+
+	e := streamWiringExecutor(t, root, bare, oaiSrv.URL, nil)
+	_, task := taskAndAgent("stream-wiring")
+	res, err := execWithAgent(t, e, task)
+	if err != nil {
+		t.Fatalf("Execute with nil stream: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("verdict with nil stream: want GO got %s", res.Verdict)
+	}
+}


### PR DESCRIPTION
## What

A live turn stream for the Foreman agent: each completed turn of a coder run is
published over SSE while the run is still going, so a run can be watched instead
of read afterwards from the terminal transcript ConfigMap.

Four commits, kept separate because each is independently reviewable:

- `9c6f22713` `LoopConfig.OnTurn` hook plus the flusher that drives it
- `eb4c851c3` `TurnStream`: a bounded broadcaster with replay-then-tail
- `b5dc7c4e8` the SSE handler and a `manager.Runnable` to serve it
- `e8daaee6c` wiring into the executor and `cmd/foreman-agent`

## Why

Today a Foreman run is opaque until it ends. The transcript ConfigMap is written
at terminal, and it is not written at all for a cancelled run, so a long coder
job is a black box precisely while you most want to see it.

Concretely: during a 122-minute run on this fleet the only way to tell whether
the coder was working or spinning was to read token counts out of the inference
server's log and infer turn boundaries from them. That is not observability.

## How

**The hook (`OnTurn`).** `Loop.Run` calls it once per completed turn with the
messages appended during that turn. The flusher is a small type rather than a
closure because its branches pushed `Loop.Run` past the gocyclo ceiling; it is
seeded with `len(res.Transcript)` so the pre-loop system+user messages do not
publish as a phantom "turn 0", and it runs from a `defer` plus the top of each
iteration so all nine exit paths are covered.

**The stream.** `Publish` NEVER blocks: it runs on the loop's own goroutine, so
blocking there would stall the coder run itself. A subscriber whose buffer is
full misses the event rather than holding up the agent. It copies the slice,
because the loop hands over a window into its live transcript that it keeps
appending to. The replay buffer is loaded into the channel under the same lock
that registers the subscriber, so no turn is missed or duplicated across the
replay-to-live handover.

**The server.** No `WriteTimeout`, since an SSE response is open for the life of
the run and a write deadline would sever it mid-stream. `NeedLeaderElection`
returns false: this serves the LOCAL agent's own run, so every replica serves
its own stream rather than only the leader.

**The wiring.** The plan this came from named `cmd/foreman-operator`. That was
wrong: the operator runs no loops. The executor lives in `cmd/foreman-agent`,
which has no controller-runtime manager, so the Runnable starts in the existing
errgroup rather than via `mgr.Add`. Its goroutine logs and swallows a bind
error: losing the view of a run is not a reason to stop doing the run.

`turnHook()` exists so the nil case stays a NIL hook. `PublishTurn` is safe to
call on a nil `*TurnStream`, but a method value is still a non-nil func, so
returning one unconditionally would make the flusher reslice the transcript
every turn of every run nobody is watching.

### Scope

Streaming covers agents whose loop runs in-process in the watcher, which is
every agent whose `spec.execution.mode` is not `Job` (the default, and what the
whole current fleet uses). A Job-mode agent runs its loop in a separate coder
Job pod whose executor is built in `RunTask` and has no stream; that path needs
per-Job discovery and is deliberately out of scope.

### Security: loopback by default

`--turn-stream-bind-address` defaults to `127.0.0.1:8082`, not `:8082`.

The endpoint has **no authentication** and what it serves is the coder's full
transcript: prompts, file contents, and raw tool output, which is exactly where
a leaked token or a customer path would show up. Two of the places this binary
runs make `:8082` the wrong default. A metal agent runs as a plain process on a
personal machine on a house LAN. An in-cluster pod is reachable by anything with
pod-network access.

Loopback costs a viewer nothing in either place: `kubectl port-forward` attaches
to the pod's network namespace and so reaches a loopback listener, and an on-box
viewer is already on the box. Widening it is a deliberate operator decision to
serve an unauthenticated transcript feed to the network, so it is opt-in.

## Testing

The wiring test drives a real end-to-end coder pass through `Execute` rather
than calling `Publish` by hand, because a hand-published unit test passes with
the hook disconnected, which is the exact defect it guards.

Mutation-checked rather than assumed: setting `OnTurn` to nil fails the wiring
test, and making `turnHook` return a method value unconditionally fails the
nil-hook test.

Not yet done, and the reason this is worth reviewing before it lands: the stream
has NOT been verified against a live coder on the fleet. That needs a rebuilt
agent image and a redeploy, which would kill a run in progress. The unit and
integration coverage is real, but "I watched turns arrive over `curl -N`" is
still outstanding.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) - flag docs are inline; a
      viewer-facing doc belongs with the UI that consumes this

Assisted-by: Claude Code (wrote the implementation and tests from a plan I
reviewed). I reviewed the whole change, ran `make test` and `make lint`, and
mutation-checked both guards.
