### PR TITLE
fix(controller): bound inference container memory with a limit, and validate the quantity at admission

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -901,6 +901,7 @@ type InferenceResourceRequirements struct {
 	CPU string `json:"cpu,omitempty"`
 
 	// Memory requests (e.g., "4Gi")
+	// +kubebuilder:validation:Pattern=`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`
 	// +optional
 	Memory string `json:"memory,omitempty"`
 
@@ -909,6 +910,7 @@ type InferenceResourceRequirements struct {
 	// Translated to pod resources.requests.memory, taking precedence over Memory when set.
 	// Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
 	// which can lead to OOM kills after model load.
+	// +kubebuilder:validation:Pattern=`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`
 	// +optional
 	HostMemory string `json:"hostMemory,omitempty"`
 
@@ -932,10 +934,7 @@ type InferenceResourceRequirements struct {
 	// everywhere and none is applied.
 	//
 	// The pattern is the Kubernetes quantity format, so a malformed value is
-	// rejected at admission. The sibling quantity fields above predate this and
-	// carry no pattern; they reach resource.MustParse, which panics on
-	// malformed input and takes the controller down for every workload rather
-	// than failing the one object at fault.
+	// rejected at admission.
 	// +kubebuilder:validation:Pattern=`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`
 	// +optional
 	EphemeralStorage string `json:"ephemeralStorage,omitempty"`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -4469,10 +4469,7 @@ spec:
                       everywhere and none is applied.
 
                       The pattern is the Kubernetes quantity format, so a malformed value is
-                      rejected at admission. The sibling quantity fields above predate this and
-                      carry no pattern; they reach resource.MustParse, which panics on
-                      malformed input and takes the controller down for every workload rather
-                      than failing the one object at fault.
+                      rejected at admission.
                     pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                   gpu:
@@ -4555,9 +4552,11 @@ spec:
                       Translated to pod resources.requests.memory, taking precedence over Memory when set.
                       Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
                       which can lead to OOM kills after model load.
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                   memory:
                     description: Memory requests (e.g., "4Gi")
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                 type: object
               revisionHistoryLimit:

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -4465,10 +4465,7 @@ spec:
                       everywhere and none is applied.
 
                       The pattern is the Kubernetes quantity format, so a malformed value is
-                      rejected at admission. The sibling quantity fields above predate this and
-                      carry no pattern; they reach resource.MustParse, which panics on
-                      malformed input and takes the controller down for every workload rather
-                      than failing the one object at fault.
+                      rejected at admission.
                     pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                   gpu:
@@ -4551,9 +4548,11 @@ spec:
                       Translated to pod resources.requests.memory, taking precedence over Memory when set.
                       Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
                       which can lead to OOM kills after model load.
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                   memory:
                     description: Memory requests (e.g., "4Gi")
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                 type: object
               revisionHistoryLimit:

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -720,10 +720,10 @@ func buildContainerResources(isvc *inferencev1alpha1.InferenceService, model *in
 		// Request AND limit, driven by whichever of hostMemory/memory wins.
 		// The limit is what keeps an overrun charged to this pod: without one an
 		// unbounded container crosses MemoryPressure and stops the kubelet posting
-		// status (the node goes NotReady) instead of being OOM-killed. Equal request
-		// and limit also yields Guaranteed QoS. ParseQuantity, not MustParse, for the
-		// same reason as ephemeralStorage below: a panic here takes the controller
-		// down for every workload rather than failing the one object at fault.
+		// status (the node goes NotReady) instead of being OOM-killed. ParseQuantity,
+		// not MustParse, for the same reason as ephemeralStorage below: a panic here
+		// takes the controller down for every workload rather than failing the one
+		// object at fault.
 		var memoryQ *resource.Quantity
 		if isvc.Spec.Resources.HostMemory != "" {
 			if q, err := resource.ParseQuantity(isvc.Spec.Resources.HostMemory); err == nil {

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -717,10 +717,26 @@ func buildContainerResources(isvc *inferencev1alpha1.InferenceService, model *in
 		if isvc.Spec.Resources.CPU != "" {
 			res.Requests[corev1.ResourceCPU] = resource.MustParse(isvc.Spec.Resources.CPU)
 		}
+		// Request AND limit, driven by whichever of hostMemory/memory wins.
+		// The limit is what keeps an overrun charged to this pod: without one an
+		// unbounded container crosses MemoryPressure and stops the kubelet posting
+		// status (the node goes NotReady) instead of being OOM-killed. Equal request
+		// and limit also yields Guaranteed QoS. ParseQuantity, not MustParse, for the
+		// same reason as ephemeralStorage below: a panic here takes the controller
+		// down for every workload rather than failing the one object at fault.
+		var memoryQ *resource.Quantity
 		if isvc.Spec.Resources.HostMemory != "" {
-			res.Requests[corev1.ResourceMemory] = resource.MustParse(isvc.Spec.Resources.HostMemory)
+			if q, err := resource.ParseQuantity(isvc.Spec.Resources.HostMemory); err == nil {
+				memoryQ = &q
+			}
 		} else if isvc.Spec.Resources.Memory != "" {
-			res.Requests[corev1.ResourceMemory] = resource.MustParse(isvc.Spec.Resources.Memory)
+			if q, err := resource.ParseQuantity(isvc.Spec.Resources.Memory); err == nil {
+				memoryQ = &q
+			}
+		}
+		if memoryQ != nil {
+			res.Requests[corev1.ResourceMemory] = *memoryQ
+			res.Limits[corev1.ResourceMemory] = *memoryQ
 		}
 		// Request AND limit. The request is what the scheduler reserves, so it
 		// stops placing further pods on a node this download is about to fill.

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
@@ -1411,6 +1412,61 @@ func TestInferPodSecurityContext_VulkanDRIRenderGID(t *testing.T) {
 			if g == renderGID {
 				t.Errorf("user override must not gain the operator render GID %d", renderGID)
 			}
+		}
+	})
+}
+
+// TestBuildContainerResources_MemoryLimit sets a memory LIMIT alongside the
+// request. Historically the builder set only Requests[memory], so a serving
+// container was unbounded: a model whose resident set exceeded available RAM
+// took the node down (kubelet stopped posting status, node went NotReady)
+// instead of being OOM-killed. See #1724.
+func TestBuildContainerResources_MemoryLimit(t *testing.T) {
+	build := func(isvc *inferencev1alpha1.InferenceService) corev1.ResourceRequirements {
+		return buildContainerResources(isvc, &inferencev1alpha1.Model{}, 0, "")
+	}
+
+	t.Run("memory sets equal request and limit", func(t *testing.T) {
+		res := build(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{Memory: "8Gi"},
+			},
+		})
+		want := resource.MustParse("8Gi")
+		if got := res.Requests[corev1.ResourceMemory]; !got.Equal(want) {
+			t.Errorf("Requests[memory] = %s, want %s", got.String(), want.String())
+		}
+		if got := res.Limits[corev1.ResourceMemory]; !got.Equal(want) {
+			t.Errorf("Limits[memory] = %s, want %s", got.String(), want.String())
+		}
+	})
+
+	t.Run("hostMemory wins and drives both request and limit", func(t *testing.T) {
+		res := build(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{Memory: "8Gi", HostMemory: "64Gi"},
+			},
+		})
+		want := resource.MustParse("64Gi")
+		if got := res.Requests[corev1.ResourceMemory]; !got.Equal(want) {
+			t.Errorf("Requests[memory] = %s, want %s", got.String(), want.String())
+		}
+		if got := res.Limits[corev1.ResourceMemory]; !got.Equal(want) {
+			t.Errorf("Limits[memory] = %s, want %s", got.String(), want.String())
+		}
+	})
+
+	t.Run("neither memory nor hostMemory sets no memory key", func(t *testing.T) {
+		res := build(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{CPU: "1"},
+			},
+		})
+		if v, ok := res.Requests[corev1.ResourceMemory]; ok {
+			t.Errorf("Requests has memory %s, want none", v.String())
+		}
+		if v, ok := res.Limits[corev1.ResourceMemory]; ok {
+			t.Errorf("Limits has memory %s, want none", v.String())
 		}
 	})
 }

--- a/internal/controller/inferenceservice_memory_validation_test.go
+++ b/internal/controller/inferenceservice_memory_validation_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// These specs exercise the InferenceService CRD's server-side validation for
+// spec.resources.memory and spec.resources.hostMemory (the Kubernetes quantity
+// pattern). The builder sets the memory limit from whichever of the two wins,
+// and relies on this schema to reject a malformed value at admission so it can
+// never silently drop the request and leave a container unbounded. They run
+// against the envtest apiserver, so a failure here means the generated CRD
+// schema does not enforce what the type claims. See #1724.
+var _ = Describe("InferenceService memory CRD validation", func() {
+	ctx := context.Background()
+
+	newISvc := func(name string, resources *inferencev1alpha1.InferenceResourceRequirements) *inferencev1alpha1.InferenceService {
+		return &inferencev1alpha1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				ModelRef:  "memory-validation-model",
+				Resources: resources,
+			},
+		}
+	}
+
+	It("admits a well-formed memory quantity", func() {
+		isvc := newISvc("mem-valid", &inferencev1alpha1.InferenceResourceRequirements{Memory: "8Gi"})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("admits a well-formed hostMemory quantity", func() {
+		isvc := newISvc("mem-valid-hostmem", &inferencev1alpha1.InferenceResourceRequirements{HostMemory: "64Gi"})
+		Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+		Expect(k8sClient.Delete(ctx, isvc)).To(Succeed())
+	})
+
+	It("rejects a malformed memory value", func() {
+		isvc := newISvc("mem-invalid", &inferencev1alpha1.InferenceResourceRequirements{Memory: "8GiB"})
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("rejects a malformed hostMemory value", func() {
+		isvc := newISvc("mem-invalid-hostmem", &inferencev1alpha1.InferenceResourceRequirements{HostMemory: "8GiB"})
+		err := k8sClient.Create(ctx, isvc)
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## What

Sets a memory **limit** alongside the existing memory request on inference
containers, and adds CRD pattern validation to `memory` / `hostMemory` so a
malformed quantity is rejected at admission rather than silently dropped.

## Why

Fixes #1724

`buildContainerResources` set a memory request and never a limit, so every
serving container was unbounded. A model whose resident set exceeds available
RAM takes the node down instead of being OOM-killed.

That is not hypothetical. It wedged a GB10 node in our lab: the kubelet stopped
posting status 30 seconds after the container started, the node went
`NotReady`, SSH timed out during banner exchange while ICMP still answered at
0.4 ms, and recovery needed a power cycle.

The correct pattern already existed twenty lines below in the same function.
`ephemeralStorage` sets request AND limit, with a comment arguing exactly why:
without a limit the overrun is charged to the node instead of the pod. That
argument applies to RAM, and RAM is worse, because crossing MemoryPressure with
an unbounded container does not evict politely by QoS class.

## How

`hostMemory` still wins over `memory`, but the winning value is now parsed once
and drives both the request and the limit, so the two cannot diverge.
`ParseQuantity` replaces `MustParse` for the same reason the `ephemeralStorage`
block gives: a panic there takes the controller down for every workload rather
than failing the one object at fault.

### Why the CRD pattern is part of this change

Swapping `MustParse` for a skip-on-error is not safe on its own, and this is
the part worth reviewing closely.

`ephemeralStorage` can skip on parse error because a CRD pattern rejects
malformed values at admission, so the skip is unreachable. `memory` and
`hostMemory` had **no pattern**. Copying the skip without the pattern moved the
failure from a loud panic to a silent one: a malformed value produced a
container with neither a request nor a limit, which is precisely the unbounded
condition this issue exists to prevent.

Verified before and after with `Memory: "8GiB"` (not a valid Kubernetes
suffix): the intermediate version produced `request set=false limit set=false`.
The pattern now rejects it at admission, which makes the skip genuinely
unreachable rather than merely tolerated.

Accepts `8Gi`, `64Gi`, `118Gi`, `100m`. Rejects `8GiB`, `abc`, `8 Gi`.

## Testing

- Three unit tests on the builder: memory sets equal request and limit,
  `hostMemory` wins and drives both, neither set produces no memory key.
- Four envtest admission tests: well-formed `memory` and `hostMemory` admitted,
  malformed values rejected. These exercise the real API server, which is the
  layer the defense now lives at.
- `make manifests` and `make chart-crds` both run, so `config/crd/bases` and
  the chart CRDs carry the pattern and do not drift.

`make test`: 38 packages, 0 failures, `internal/controller` running its envtest
suite in ~300s.

## Migration note

Existing InferenceServices gain a memory limit equal to their request. A
workload that previously survived by bursting above its request into node
reserves will now be OOM-killed instead. That is the intended behaviour, but it
is a behaviour change worth knowing about before upgrading a busy node.

The comment does not claim Guaranteed QoS: CPU still sets a request without a
limit, so these pods remain Burstable.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) - the migration note above
      is the user-facing change; no doc page covers resource defaults today

Assisted-by: Foreman (DeepSeek-V4-Flash coder) wrote both the initial
implementation and the revision. Human review after the gates passed found two
defects the coder-verify-review pipeline did not: the silent-drop regression
described above, and a false claim that equal request and limit yields
Guaranteed QoS. Both were fed back and fixed in one revision pass. I reviewed
the result, verified the pattern's accept/reject behaviour directly, and ran
`make test` and `make lint`.
