### PR TITLE
feat(foreman): diff-coverage gate for added lines no test executes

### DIFF
--- a/pkg/foreman/agent/coder_gate.go
+++ b/pkg/foreman/agent/coder_gate.go
@@ -309,6 +309,18 @@ func gateCheckRegistry(issueText, evidenceBaseSHA string, evidence []grounding.E
 			fn:   checkClaimEvidence(evidence, evidenceBaseSHA),
 		},
 		{
+			// Added lines that no test executes. Complements mutation-gate
+			// rather than duplicating it: that one asks whether a FUNCTION is
+			// referenced by a test, this one asks whether the BRANCHES the diff
+			// added actually run. Advisory until it has been quiet on real
+			// diffs; a new gate that blocks stalls the fleet on its first false
+			// positive.
+			name: "diff-coverage",
+			tier: tierAdvisory,
+			lang: foremanv1alpha1.GateLanguageGo,
+			fn:   checkDiffCoverage,
+		},
+		{
 			name: "grounding-breadth",
 			tier: tierAdvisory,
 			lang: foremanv1alpha1.GateLanguageGo,

--- a/pkg/foreman/agent/diff_coverage_gate.go
+++ b/pkg/foreman/agent/diff_coverage_gate.go
@@ -1,0 +1,279 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Diff-coverage gate: a branch the diff ADDED that no test ever executes.
+//
+// This exists because the existing gates check that a FUNCTION is tested, not
+// that its BRANCHES are, and three separate coder runs shipped defects through
+// that gap:
+//
+//   - a nil guard whose `return` no test ever took, so a transport failure
+//     silently discarded the coder's work
+//   - a `ParseQuantity` error path no test ever entered, so a malformed value
+//     produced a container with neither a memory request nor a limit, which is
+//     the exact unbounded condition the change was fixing
+//
+// mutationGate Layer 1 passed both: it requires a net-new function to be
+// REFERENCED by name in a changed test, and it exempts body-modified functions
+// entirely. A function can be referenced by a test, and body-modified, while
+// its new error path is never entered.
+//
+// The check is deliberately narrow. It reports only lines the diff added that
+// fall inside a coverage block Go recorded as executed ZERO times. It says
+// nothing about assertion quality, which is mutationGate's job.
+
+// coverageBlock is one line of a `go test -coverprofile` file. The format is
+//
+//	<import path>/<file>.go:<sLine>.<sCol>,<eLine>.<eCol> <numStmt> <count>
+//
+// count is the number of times the block executed, so count == 0 is the signal
+// this gate is built on.
+type coverageBlock struct {
+	file      string
+	startLine int
+	endLine   int
+	count     int
+}
+
+// parseCoverProfile parses coverprofile text into blocks, skipping the leading
+// "mode:" line and anything malformed. Parsing is lenient on purpose: a gate
+// that hard-errors on one odd line would block a coder run over a tooling
+// quirk, and a missed block only costs a missed finding.
+func parseCoverProfile(out string) []coverageBlock {
+	var blocks []coverageBlock
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "mode:") {
+			continue
+		}
+		// "<file>:<s>.<sc>,<e>.<ec> <n> <count>"
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			continue
+		}
+		count, err := strconv.Atoi(fields[2])
+		if err != nil {
+			continue
+		}
+		colon := strings.LastIndex(fields[0], ":")
+		if colon < 0 {
+			continue
+		}
+		file, span := fields[0][:colon], fields[0][colon+1:]
+		comma := strings.Index(span, ",")
+		if comma < 0 {
+			continue
+		}
+		start, ok1 := lineOfSpanPart(span[:comma])
+		end, ok2 := lineOfSpanPart(span[comma+1:])
+		if !ok1 || !ok2 {
+			continue
+		}
+		blocks = append(blocks, coverageBlock{file: file, startLine: start, endLine: end, count: count})
+	}
+	return blocks
+}
+
+// lineOfSpanPart pulls the line number out of a "<line>.<col>" half of a span.
+func lineOfSpanPart(s string) (int, bool) {
+	dot := strings.Index(s, ".")
+	if dot < 0 {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s[:dot])
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// uncoveredAddedLines returns, per repo-relative file, the added lines that sit
+// inside a coverage block that executed zero times.
+//
+// Two rules keep this from being noise:
+//
+//   - An added line inside NO block is ignored. Comments, blank lines, imports,
+//     declarations and func signatures are not statements and appear in no
+//     block. Flagging them would fire on every diff and the gate would be
+//     switched off within a day.
+//   - An added line inside ANY executed block is ignored, even if it also sits
+//     inside an unexecuted one. Go emits nested and overlapping blocks; treating
+//     a line as covered when any enclosing block ran avoids reporting a line a
+//     test demonstrably reaches.
+//
+// Coverprofile paths are import paths and diff paths are repo-relative, so
+// matching is by suffix.
+func uncoveredAddedLines(blocks []coverageBlock, added map[string]map[int]bool) map[string][]int {
+	out := map[string][]int{}
+	for file, lines := range added {
+		relevant := blocksForFile(blocks, file)
+		if len(relevant) == 0 {
+			// No coverage data for this file at all: the package may not have
+			// been tested. Report nothing rather than flagging every added
+			// line, which would be indistinguishable from a genuine finding.
+			continue
+		}
+		for line := range lines {
+			covered, inAnyBlock := false, false
+			for _, b := range relevant {
+				if line < b.startLine || line > b.endLine {
+					continue
+				}
+				inAnyBlock = true
+				if b.count > 0 {
+					covered = true
+					break
+				}
+			}
+			if inAnyBlock && !covered {
+				out[file] = append(out[file], line)
+			}
+		}
+		if len(out[file]) == 0 {
+			delete(out, file)
+		}
+	}
+	return out
+}
+
+// blocksForFile selects the coverage blocks belonging to a repo-relative path.
+// Suffix match with a separator guard so "controller/thing.go" cannot match
+// "othercontroller/thing.go".
+func blocksForFile(blocks []coverageBlock, relPath string) []coverageBlock {
+	var out []coverageBlock
+	for _, b := range blocks {
+		if b.file == relPath || strings.HasSuffix(b.file, "/"+relPath) {
+			out = append(out, b)
+		}
+	}
+	return out
+}
+
+// checkDiffCoverage runs the package tests with coverage and reports lines the
+// diff added that no test executes.
+//
+// ADVISORY, not blocking. A brand-new gate that fails a run is a good way to
+// stall the whole fleet on its first false positive; this surfaces to the
+// reviewer and the audit record instead. Promote it to tierBlock once it has
+// run quietly against real diffs for a while.
+//
+// Cost is one `go test -coverprofile` per changed package. The mutation gate
+// already re-runs package tests, so this is not a new class of expense.
+func checkDiffCoverage(ctx context.Context, workspace string, run commandRunner) (bool, string) {
+	files := changedNonTestGoFiles(ctx, workspace, run)
+	if len(files) == 0 {
+		return false, ""
+	}
+
+	// One coverage run per package, not per file: a package's tests cover all
+	// of its files at once, and re-running per file would multiply the cost.
+	pkgs := map[string][]string{}
+	for _, f := range files {
+		dir := filepath.Dir(f)
+		if dir == "." {
+			continue
+		}
+		pkgs[dir] = append(pkgs[dir], f)
+	}
+
+	var findings []string
+	for dir, dirFiles := range pkgs {
+		profile, err := os.CreateTemp("", "diffcov-*.out")
+		if err != nil {
+			continue
+		}
+		profilePath := profile.Name()
+		_ = profile.Close()
+
+		// A failing or absent test suite is NOT this gate's finding: the coder
+		// gate already runs build and test, and reporting here as well would
+		// double-report one problem under two names.
+		_, terr := run(ctx, workspace, nil, "go", "test", "-count=1", "-timeout=300s",
+			"-coverprofile="+profilePath, "./"+dir+"/")
+		if terr != nil {
+			_ = os.Remove(profilePath)
+			continue
+		}
+		raw, rerr := os.ReadFile(profilePath) //nolint:gosec // G304: path from os.CreateTemp
+		_ = os.Remove(profilePath)
+		if rerr != nil {
+			continue
+		}
+
+		added := map[string]map[int]bool{}
+		for _, f := range dirFiles {
+			if lines := changedNewLines(ctx, workspace, f, run); len(lines) > 0 {
+				added[f] = lines
+			}
+		}
+		if len(added) == 0 {
+			continue
+		}
+
+		for file, lines := range uncoveredAddedLines(parseCoverProfile(string(raw)), added) {
+			sort.Ints(lines)
+			findings = append(findings, fmt.Sprintf("%s: added lines never executed by any test: %s",
+				file, formatLineList(lines)))
+		}
+	}
+	if len(findings) == 0 {
+		return false, ""
+	}
+	sort.Strings(findings)
+	return true, "Added code that no test reaches:\n  " + strings.Join(findings, "\n  ") +
+		"\n\nThese lines were added by this change and ran zero times. An error path " +
+		"or guard that no test enters is not constrained by the suite: it can be " +
+		"wrong in either direction and every gate still passes."
+}
+
+// formatLineList renders line numbers compactly, collapsing runs into ranges so
+// a 40-line uncovered block reads as "120-159" rather than forty numbers.
+func formatLineList(lines []int) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	var parts []string
+	start, prev := lines[0], lines[0]
+	flush := func() {
+		if start == prev {
+			parts = append(parts, strconv.Itoa(start))
+			return
+		}
+		parts = append(parts, strconv.Itoa(start)+"-"+strconv.Itoa(prev))
+	}
+	for _, l := range lines[1:] {
+		if l == prev+1 {
+			prev = l
+			continue
+		}
+		flush()
+		start, prev = l, l
+	}
+	flush()
+	return strings.Join(parts, ", ")
+}

--- a/pkg/foreman/agent/diff_coverage_gate_test.go
+++ b/pkg/foreman/agent/diff_coverage_gate_test.go
@@ -1,0 +1,138 @@
+package agent
+
+import "testing"
+
+// A Go coverprofile block is `importpath/file.go:sLine.sCol,eLine.eCol nStmt count`.
+// The paths are import paths; the diff gives repo-relative paths, so matching is
+// by suffix.
+const sampleProfile = `mode: set
+github.com/defilantech/llmkube/internal/controller/deployment_builder.go:717.32,720.3 2 1
+github.com/defilantech/llmkube/internal/controller/deployment_builder.go:721.4,723.5 1 0
+github.com/defilantech/llmkube/internal/controller/deployment_builder.go:730.2,732.16 3 5
+github.com/defilantech/llmkube/pkg/other/thing.go:10.1,12.2 1 0
+`
+
+func TestParseCoverProfile(t *testing.T) {
+	blocks := parseCoverProfile(sampleProfile)
+	if len(blocks) != 4 {
+		t.Fatalf("blocks: want 4 got %d", len(blocks))
+	}
+	b := blocks[1]
+	if b.startLine != 721 || b.endLine != 723 || b.count != 0 {
+		t.Errorf("block[1] = %+v, want start 721 end 723 count 0", b)
+	}
+	if b.file != "github.com/defilantech/llmkube/internal/controller/deployment_builder.go" {
+		t.Errorf("block[1].file = %q", b.file)
+	}
+}
+
+// The whole point of the gate: a line the diff ADDED that no test executes.
+func TestUncoveredAddedLines_FlagsAnUnexecutedAddedBranch(t *testing.T) {
+	added := map[string]map[int]bool{
+		"internal/controller/deployment_builder.go": {722: true},
+	}
+	got := uncoveredAddedLines(parseCoverProfile(sampleProfile), added)
+	if len(got["internal/controller/deployment_builder.go"]) != 1 ||
+		got["internal/controller/deployment_builder.go"][0] != 722 {
+		t.Errorf("want line 722 flagged, got %+v", got)
+	}
+}
+
+// An added line inside an EXECUTED block is fine.
+func TestUncoveredAddedLines_IgnoresCoveredLines(t *testing.T) {
+	added := map[string]map[int]bool{
+		"internal/controller/deployment_builder.go": {718: true, 731: true},
+	}
+	if got := uncoveredAddedLines(parseCoverProfile(sampleProfile), added); len(got) != 0 {
+		t.Errorf("covered lines must not be flagged, got %+v", got)
+	}
+}
+
+// Comments, blank lines, imports and func signatures are not statements and
+// appear in NO block. Flagging them would make the gate fire on every diff and
+// it would be turned off within a day.
+func TestUncoveredAddedLines_IgnoresNonStatementLines(t *testing.T) {
+	added := map[string]map[int]bool{
+		"internal/controller/deployment_builder.go": {700: true, 999: true},
+	}
+	if got := uncoveredAddedLines(parseCoverProfile(sampleProfile), added); len(got) != 0 {
+		t.Errorf("non-statement lines must not be flagged, got %+v", got)
+	}
+}
+
+// Blocks belonging to ANOTHER file must not be attributed to this one.
+//
+// The obvious version of this test ("pkg/other/thing.go is absent from the
+// output") is vacuous: output keys come from `added`, so an untouched file can
+// never appear no matter how broken the matcher is. It passed with the file
+// matching replaced by `if true`.
+//
+// This version has teeth. Line 11 sits inside thing.go's zero-count block
+// (10-12) and inside NO block of deployment_builder.go. Correct behaviour
+// leaves it unflagged, because a line in no block of its own file is a comment
+// or declaration. A matcher that ignores the filename attributes thing.go's
+// uncovered block to deployment_builder.go and reports a false positive.
+func TestUncoveredAddedLines_DoesNotAttributeOtherFilesBlocks(t *testing.T) {
+	added := map[string]map[int]bool{
+		"internal/controller/deployment_builder.go": {11: true},
+	}
+	got := uncoveredAddedLines(parseCoverProfile(sampleProfile), added)
+	if len(got) != 0 {
+		t.Errorf("line 11 is only in ANOTHER file's uncovered block; "+
+			"flagging it means blocks are matched without regard to filename: %+v", got)
+	}
+}
+
+// The real regression this gate exists for, using the shape of the #1724
+// pre-revision defect: a ParseQuantity error path that no test entered, which
+// silently produced a container with neither a memory request nor a limit.
+//
+// Go records the `err == nil` body as executed and the surrounding block as
+// partially unexecuted; the added line inside the zero-count block is the
+// finding.
+func TestUncoveredAddedLines_CatchesTheParseErrorPathFrom1724(t *testing.T) {
+	profile := `mode: set
+github.com/defilantech/llmkube/internal/controller/deployment_builder.go:720.36,722.4 1 1
+github.com/defilantech/llmkube/internal/controller/deployment_builder.go:723.4,725.5 1 0
+github.com/defilantech/llmkube/internal/controller/deployment_builder.go:727.19,730.3 2 1
+`
+	// The coder added all of 720-730; only 723-725 (the error path) never ran.
+	added := map[string]map[int]bool{
+		"internal/controller/deployment_builder.go": {
+			720: true, 721: true, 723: true, 724: true, 727: true, 728: true,
+		},
+	}
+	got := uncoveredAddedLines(parseCoverProfile(profile), added)
+	lines := got["internal/controller/deployment_builder.go"]
+	if len(lines) != 2 {
+		t.Fatalf("want the two error-path lines flagged, got %v", lines)
+	}
+	for _, want := range []int{723, 724} {
+		found := false
+		for _, l := range lines {
+			if l == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("line %d (unexecuted error path) not flagged; got %v", want, lines)
+		}
+	}
+}
+
+// Ranges keep a large uncovered block readable in the gate output.
+func TestFormatLineList_CollapsesRuns(t *testing.T) {
+	for _, tc := range []struct {
+		in   []int
+		want string
+	}{
+		{[]int{5}, "5"},
+		{[]int{5, 6, 7}, "5-7"},
+		{[]int{5, 7}, "5, 7"},
+		{[]int{1, 2, 3, 9, 20, 21}, "1-3, 9, 20-21"},
+	} {
+		if got := formatLineList(tc.in); got != tc.want {
+			t.Errorf("formatLineList(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

A new coder-gate check, `diff-coverage`: reports lines the diff **added** that
no test executes. Registered as **advisory**, not blocking.

## Why

Fixes #1727

The existing gates check that a FUNCTION is tested, not that its BRANCHES are.
Three coder runs went through that gap in one evening, each passing coder,
verify and reviewer:

1. A nil guard whose `return` no test ever took. An infrastructure failure
   silently discarded the coder's work rather than preserving it.
2. The same function in a second model's attempt: it caught the nil case but
   its tests never entered the branch either.
3. A `ParseQuantity` error path no test entered, so a malformed quantity
   produced a container with neither a memory request nor a limit. That is the
   exact unbounded condition the change was fixing (#1724).

`mutation-gate` passed all three by design. Layer 1 requires a net-new function
to be REFERENCED by name in a changed test, and it exempts body-modified
functions entirely. A function can be referenced by a test, and body-modified,
while the error path the diff just added is never entered.

This is the complement, not a replacement: mutation-gate asks whether
assertions constrain the code, this asks whether the new code runs at all.

## How

Per changed package: `go test -coverprofile`, then intersect the zero-count
blocks with the lines `git diff -U0 HEAD` reports as added.

Two rules keep it from being noise, and both are load-bearing:

- An added line inside **no** block is ignored. Comments, imports, declarations
  and func signatures are not statements and appear in no block. Flagging them
  would fire on every diff and the gate would be switched off within a day.
- An added line inside **any** executed block is ignored, even when it also sits
  inside an unexecuted one. Go emits nested and overlapping blocks.

A failing or absent test suite is deliberately **not** a finding here. The coder
gate already runs build and test; reporting it again would double-report one
problem under two names, which is how a gate loses credibility.

Line numbers are collapsed into ranges so a 40-line uncovered block reads as
`120-159` rather than forty numbers.

## Why advisory

A brand-new gate that fails runs stalls the whole fleet on its first false
positive. Findings go to the reviewer and the audit record via
`Result.Extra["gateAdvisories"]`. Promote to `tierBlock` once it has been quiet
against real diffs. It can also be switched off in the field with
`FOREMAN_DIFF_COVERAGE_GATE=0`, like every other check.

## Testing

Seven tests over the pure functions, including one built from the shape of the
#1724 defect: an added `ParseQuantity` error path inside a zero-count block,
with the surrounding added lines covered.

Mutation-checked, three guards, all caught:

- treating every block as covered (`count >= 0`)
- matching blocks without regard to filename
- inverting the in-any-block test

The filename test needed rewriting to earn that. The obvious version asserted
an untouched file was absent from the output, which is **vacuous**: output keys
come from the added-lines map, so an untouched file can never appear however
broken the matcher is. It passed with the matcher replaced by `if true`. The
version here puts a line inside another file's uncovered block and asserts it is
not attributed to the file under test, which does fail when the matcher breaks.

`make test` green, `GOOS=linux golangci-lint run ./...` 0 issues, agent package
green under `-race`.

## What this does not do

It says nothing about assertion quality. A test that executes a line and
asserts nothing satisfies this gate and is mutation-gate's problem. It is also
Go-only (`lang: GateLanguageGo`).

It would not have caught the first of the three failures above on its own: that
line WAS executed, by non-nil inputs, and the defect was an untested input
class rather than an unexecuted line. A nil-contract check is the separate
follow-up for that shape.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) - advisory gate output is
      self-describing; worth a docs entry when it is promoted to blocking

Assisted-by: Claude Code (wrote the implementation and tests). I reviewed the
whole change, ran `make test` and `make lint`, and mutation-checked all three
guards, which is what surfaced the vacuous filename test described above.
