### PR TITLE
fix(foreman): validate resolvedBy before ALREADY-RESOLVED skips verification

### DIFF
--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1057,7 +1057,8 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			applyCrossStageContradictionsForTask(ctx, log, workspace, reviewBase,
 				reviewDiff, reviewDiffErr, loopRes, verdict)
 		}
-		r := e.modelDecidedResult(start, transcriptRef, loopRes, verdict)
+		r := e.modelDecidedResult(ctx, start, transcriptRef, loopRes, verdict,
+			workspace, baseBranchOrDefault(task.Spec.Payload.BaseBranch))
 		// #1109: preserve a coder's near-complete work when its in-loop
 		// verification gate never passed. A CODER-GATE-FAILED terminal builds
 		// and only trips the fast gate (fmt/vet/build/lint); without this the
@@ -1418,7 +1419,8 @@ func (e *NativeAgentLoopExecutor) retryCoderTerminalResult(
 	verdict foremanv1alpha1.AgenticTaskVerdict, normReason foremanv1alpha1.AgenticTaskFailureReason,
 	cloneURL string,
 ) *Result {
-	r := e.modelDecidedResult(start, tref, lr, verdict)
+	r := e.modelDecidedResult(ctx, start, tref, lr, verdict,
+		workspace, baseBranchOrDefault(task.Spec.Payload.BaseBranch))
 	e.maybePreserveGateFailedBranch(ctx, log, agent, task, workspace, branch, auth, lr, r)
 	// No reviewer rails ran on this path, so there is no resolved review base
 	// to ground the summary against; #1411's check degrades open on the empty
@@ -2530,8 +2532,8 @@ func (e *NativeAgentLoopExecutor) preserveUnsuccessfulLoopBranch(
 }
 
 func (e *NativeAgentLoopExecutor) modelDecidedResult(
-	start time.Time, tref corev1.ObjectReference, lr *LoopResult,
-	verdict foremanv1alpha1.AgenticTaskVerdict,
+	ctx context.Context, start time.Time, tref corev1.ObjectReference, lr *LoopResult,
+	verdict foremanv1alpha1.AgenticTaskVerdict, workspace, baseBranch string,
 ) *Result {
 	r := NewResult(e.Kind(), verdict, lr.Terminal.Summary, time.Since(start))
 	r.Extra = map[string]any{
@@ -2540,7 +2542,7 @@ func (e *NativeAgentLoopExecutor) modelDecidedResult(
 		"turnCount":     lr.Turns,
 		"modelExtra":    lr.Terminal.Extra,
 	}
-	promoteTerminalOutcome(r.Extra, lr.Terminal.Extra)
+	promoteTerminalOutcome(ctx, r.Extra, lr.Terminal.Extra, workspace, execCommandRunner, baseBranch)
 	return r
 }
 
@@ -2570,7 +2572,10 @@ func (e *NativeAgentLoopExecutor) modelDecidedResult(
 // "unverified" is promoted for parity and observability, and its readers
 // are all in this package (loop.go, verdict_policy.go). The full modelExtra nesting is left untouched for
 // observability (terminalExtra is the same map referenced there).
-func promoteTerminalOutcome(extra, terminalExtra map[string]any) {
+func promoteTerminalOutcome(
+	ctx context.Context, extra, terminalExtra map[string]any,
+	workspace string, run commandRunner, baseBranch string,
+) {
 	outcome, _ := terminalExtra["outcome"].(string)
 	switch outcome {
 	case needsVerificationOutcome:
@@ -2580,10 +2585,58 @@ func promoteTerminalOutcome(extra, terminalExtra map[string]any) {
 		}
 	case alreadyResolvedOutcome:
 		extra["outcome"] = alreadyResolvedOutcome
+		// resolvedBy is evidence, not narrative (#1692). ALREADY-RESOLVED
+		// is the one verdict that skips verification entirely (the controller
+		// cascade-skips the verify task, #970), so an unvalidated free-text
+		// claim would be the most consequential unverified assertion in the
+		// pipeline. Validate the claim here, at the promotion site, where the
+		// agent still has the repo checked out and git is available (the
+		// controller cannot run git and would have to trust the string
+		// regardless): the claimed commit must resolve AND be an ancestor of
+		// the task's base branch. Anything else -- a well-formed SHA that is
+		// not an ancestor, a SHA that does not resolve, or free text -- is
+		// downgraded to NEEDS-VERIFICATION so the work is still gated rather
+		// than skipped. The claim is not silently dropped and the task is not
+		// failed outright: a coder that is right but cites the commit badly
+		// still gets its work checked (the NEEDS-VERIFICATION outcome is
+		// itself a terminal non-failure NO-GO). The claim survives under
+		// extra["resolvedByClaimed"] for the audit record.
 		if v, ok := terminalExtra["resolvedBy"]; ok {
-			extra["resolvedBy"] = v
+			resolvedBy, _ := v.(string)
+			if resolvedBy != "" && resolvedByResolvesAndIsAncestor(
+				ctx, workspace, run, resolvedBy, baseBranch,
+			) {
+				extra["resolvedBy"] = v
+			} else {
+				extra["outcome"] = needsVerificationOutcome
+				if resolvedBy != "" {
+					extra["resolvedByClaimed"] = resolvedBy
+				}
+			}
 		}
 	}
+}
+
+// resolvedByResolvesAndIsAncestor reports whether claimed names a commit
+// that (1) resolves (`git cat-file -e <sha>^{commit}`) and (2) is an
+// ancestor of baseBranch (`git merge-base --is-ancestor <sha> <baseBranch>`).
+// These are the two checks #1692 requires before an ALREADY-RESOLVED
+// verdict is allowed to skip verification. Any git failure or empty input
+// fails closed (returns false) so an unverifiable claim is never honoured.
+func resolvedByResolvesAndIsAncestor(
+	ctx context.Context, workspace string, run commandRunner, claimed, baseBranch string,
+) bool {
+	claimed = strings.TrimSpace(claimed)
+	if claimed == "" || baseBranch == "" || workspace == "" {
+		return false
+	}
+	if _, err := run(ctx, workspace, nil, "git", "cat-file", "-e", claimed+"^{commit}"); err != nil {
+		return false
+	}
+	if _, err := run(ctx, workspace, nil, "git", "merge-base", "--is-ancestor", claimed, baseBranch); err != nil {
+		return false
+	}
+	return true
 }
 
 func (e *NativeAgentLoopExecutor) noChangesResult(

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1587,7 +1587,7 @@ func TestIssueAskDemotionLandsUnderModelExtra(t *testing.T) {
 		Turns: 7,
 	}
 	e := &NativeAgentLoopExecutor{}
-	res := e.modelDecidedResult(time.Now(), corev1.ObjectReference{Name: "t"}, lr, verdict)
+	res := e.modelDecidedResult(context.Background(), time.Now(), corev1.ObjectReference{Name: "t"}, lr, verdict, "", "")
 	raw, err := json.Marshal(res)
 	if err != nil {
 		t.Fatalf("marshal result: %v", err)
@@ -3250,6 +3250,169 @@ func TestOpenPRsAsDraft(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := openPRsAsDraft(tc.agent); got != tc.want {
 				t.Fatalf("openPRsAsDraft() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ---- ALREADY-RESOLVED resolvedBy validation (#1692) ----
+
+// setupResolvedByFixtureRepo builds a real git repo used by
+// TestPromoteTerminalOutcome_AlreadyResolvedResolvedByValidation:
+//
+//	main:  baseSHA -> mainTipSHA (HEAD)
+//	side:  sideSHA (cut from baseSHA, not an ancestor of main)
+//
+// baseBranch is "main". mainTipSHA and baseSHA are ancestors of main;
+// sideSHA resolves but is not an ancestor; "deadbeef..." is a well-formed
+// SHA that does not resolve.
+func setupResolvedByFixtureRepo(t *testing.T) (ws string, baseSHA, mainTipSHA, sideSHA string) {
+	t.Helper()
+	ws = t.TempDir()
+	ctx := context.Background()
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Dir = ws
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	write := func(rel, content string) {
+		t.Helper()
+		full := filepath.Join(ws, rel)
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	run("init", "-b", "main")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+	write("a.go", "package a\n")
+	run("add", ".")
+	run("commit", "-m", "base")
+	baseSHA = run("rev-parse", "HEAD")
+
+	write("b.go", "package b\n")
+	run("add", ".")
+	run("commit", "-m", "main tip")
+	mainTipSHA = run("rev-parse", "HEAD")
+
+	run("checkout", "-b", "side")
+	write("c.go", "package c\n")
+	run("add", ".")
+	run("commit", "-m", "side work")
+	sideSHA = run("rev-parse", "HEAD")
+	return ws, baseSHA, mainTipSHA, sideSHA
+}
+
+// TestPromoteTerminalOutcome_AlreadyResolvedResolvedByValidation pins the
+// #1692 guard: an ALREADY-RESOLVED terminal is only allowed to keep its
+// verdict when extra.resolvedBy names a commit that resolves AND is an
+// ancestor of the task's base branch. Everything else is downgraded to
+// NEEDS-VERIFICATION (the shared needsVerificationOutcome constant) so the
+// work is still gated rather than skipped. The claim is preserved under
+// resolvedByClaimed for the audit record; it is never silently dropped.
+//
+// Mutation this test kills: delete the ancestor check (or the whole
+// resolvedBy validation) and the free-text case below stops being
+// downgraded -- the exact failure #1692 describes.
+func TestPromoteTerminalOutcome_AlreadyResolvedResolvedByValidation(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	ws, baseSHA, mainTipSHA, sideSHA := setupResolvedByFixtureRepo(t)
+
+	// The two live strings from the #1692 report. The false claim's branch
+	// name + prose is used verbatim as the free-text case; the true one
+	// (88c85cce, a real ancestor commit) cannot be reproduced by SHA in a
+	// fresh fixture, so its semantic -- a valid ancestor -- is covered by
+	// the fixture's mainTipSHA / baseSHA cases instead.
+	const liveFalseClaim = "issue-1676-prefetch-claimname (working tree clean; full controller suite passes with envtest 1.31.0 and 1.32.x)"
+
+	wellFormedUnknownSHA := strings.Repeat("0", 40)
+
+	cases := []struct {
+		name          string
+		resolvedBy    string
+		wantOutcome   string
+		wantKeepClaim bool // whether resolvedBy is promoted verbatim
+		wantClaimed   string
+	}{
+		{
+			name:          "valid ancestor SHA stays ALREADY-RESOLVED",
+			resolvedBy:    mainTipSHA,
+			wantOutcome:   alreadyResolvedOutcome,
+			wantKeepClaim: true,
+		},
+		{
+			name:          "earlier ancestor SHA stays ALREADY-RESOLVED",
+			resolvedBy:    baseSHA,
+			wantOutcome:   alreadyResolvedOutcome,
+			wantKeepClaim: true,
+		},
+		{
+			name:        "well-formed SHA that is not an ancestor is downgraded",
+			resolvedBy:  sideSHA,
+			wantOutcome: needsVerificationOutcome,
+			wantClaimed: sideSHA,
+		},
+		{
+			name:        "SHA that does not resolve is downgraded",
+			resolvedBy:  wellFormedUnknownSHA,
+			wantOutcome: needsVerificationOutcome,
+			wantClaimed: wellFormedUnknownSHA,
+		},
+		{
+			name:        "free text (live false claim) is downgraded",
+			resolvedBy:  liveFalseClaim,
+			wantOutcome: needsVerificationOutcome,
+			wantClaimed: liveFalseClaim,
+		},
+		{
+			name:        "empty resolvedBy is downgraded and drops nothing",
+			resolvedBy:  "",
+			wantOutcome: needsVerificationOutcome,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			terminalExtra := map[string]any{
+				"outcome":    alreadyResolvedOutcome,
+				"resolvedBy": tc.resolvedBy,
+			}
+			extra := map[string]any{}
+			promoteTerminalOutcome(context.Background(), extra, terminalExtra,
+				ws, execCommandRunner, "main")
+
+			if got, _ := extra["outcome"].(string); got != tc.wantOutcome {
+				t.Fatalf("extra.outcome = %q, want %q", got, tc.wantOutcome)
+			}
+
+			gotResolvedBy, hasResolvedBy := extra["resolvedBy"].(string)
+			if tc.wantKeepClaim {
+				if !hasResolvedBy || gotResolvedBy != tc.resolvedBy {
+					t.Errorf("resolvedBy should be promoted verbatim; got %q (present=%v)",
+						gotResolvedBy, hasResolvedBy)
+				}
+				if _, claimed := extra["resolvedByClaimed"]; claimed {
+					t.Errorf("resolvedByClaimed should NOT be set on the happy path")
+				}
+			} else {
+				if hasResolvedBy {
+					t.Errorf("resolvedBy should not be promoted after downgrade; got %q", gotResolvedBy)
+				}
+				if gotClaimed, _ := extra["resolvedByClaimed"].(string); gotClaimed != tc.wantClaimed {
+					t.Errorf("resolvedByClaimed = %q, want %q", gotClaimed, tc.wantClaimed)
+				}
 			}
 		})
 	}

--- a/pkg/foreman/agent/executor_native_test.go
+++ b/pkg/foreman/agent/executor_native_test.go
@@ -1070,6 +1070,24 @@ func executeCoderTask(
 	gitOrSkip(t)
 	root := t.TempDir()
 	bare := initBareWithSeed(t, root)
+	return executeCoderTaskInRepo(t, agent, task, reg, oaiBody, noUpstream, bare)
+}
+
+// executeCoderTaskInRepo is executeCoderTask against a caller-provided bare
+// repo. Some tests need the seed commit SHA (an ancestor of main) before they
+// build their fake registry, e.g. to name a valid resolvedBy for #1692, so
+// they create the repo, resolve the SHA, and pass the bare path here.
+func executeCoderTaskInRepo(
+	t *testing.T,
+	agent *foremanv1alpha1.Agent,
+	task *foremanv1alpha1.AgenticTask,
+	reg *fakeRegistry,
+	oaiBody string,
+	noUpstream bool,
+	bare string,
+) *foremanagent.Result {
+	t.Helper()
+	root := filepath.Dir(bare)
 	oaiSrv := scriptedOAI(t, []string{oaiBody})
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
 
@@ -1151,20 +1169,29 @@ func TestNativeExecutor_PromotesNeedsVerificationOutcome(t *testing.T) {
 // the needs-verification promotion test: a model-emitted NO-GO with
 // outcome=ALREADY-RESOLVED and resolvedBy evidence must surface both at
 // the top level for isAlreadyResolvedCoder and the Workload rollup.
+//
+// Since #1692, resolvedBy is validated at the promotion site: it must name
+// a commit that resolves AND is an ancestor of the task's base branch. The
+// seed commit SHA (an ancestor of main in the fixture repo) satisfies both
+// checks, so the promotion still holds for a genuine claim.
 func TestNativeExecutor_PromotesAlreadyResolvedOutcome(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
 	agent, task := taskAndAgent("already-resolved")
+	seedSHA := seedCommitSHA(t, bare)
 	reg := &fakeRegistry{
 		results: map[string]*foremanagent.ToolResult{
 			"submit_result": {
-				Terminal: true, Verdict: "NO-GO", Summary: "already resolved by prior fix e97d0ca",
+				Terminal: true, Verdict: "NO-GO", Summary: "already resolved by prior fix " + seedSHA,
 				Extra: map[string]any{
 					"outcome":    "ALREADY-RESOLVED",
-					"resolvedBy": "e97d0ca",
+					"resolvedBy": seedSHA,
 				},
 			},
 		},
 	}
-	res := executeCoderTask(t, agent, task, reg, submitNoGoBody, false)
+	res := executeCoderTaskInRepo(t, agent, task, reg, submitNoGoBody, false, bare)
 
 	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("verdict: want NO-GO got %s", res.Verdict)
@@ -1172,8 +1199,8 @@ func TestNativeExecutor_PromotesAlreadyResolvedOutcome(t *testing.T) {
 	if got := res.Extra["outcome"]; got != "ALREADY-RESOLVED" {
 		t.Errorf("top-level outcome: want ALREADY-RESOLVED got %v", got)
 	}
-	if got := res.Extra["resolvedBy"]; got != "e97d0ca" {
-		t.Errorf("top-level resolvedBy: want e97d0ca got %v", got)
+	if got := res.Extra["resolvedBy"]; got != seedSHA {
+		t.Errorf("top-level resolvedBy: want %s got %v", seedSHA, got)
 	}
 	me, ok := res.Extra["modelExtra"].(map[string]any)
 	if !ok || me["outcome"] != "ALREADY-RESOLVED" {
@@ -2511,14 +2538,17 @@ func TestNativeExecutor_ModelNoGoAlreadyResolved_PromotesOutcome(t *testing.T) {
 	agent, task := taskAndAgent("nogo-resolved")
 	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(agent, task).Build()
 
+	// resolvedBy must name a real ancestor commit since #1692; the seed
+	// commit is the ancestor of main in this fixture.
+	seedSHA := seedCommitSHA(t, bare)
 	reg := &fakeRegistry{
 		results: map[string]*foremanagent.ToolResult{
 			"submit_result": {
 				Terminal: true, Verdict: "NO-GO",
-				Summary: "already fixed by abc1234",
+				Summary: "already fixed by " + seedSHA,
 				Extra: map[string]any{
 					"outcome":    "ALREADY-RESOLVED",
-					"resolvedBy": "abc1234",
+					"resolvedBy": seedSHA,
 				},
 			},
 		},
@@ -2548,13 +2578,26 @@ func TestNativeExecutor_ModelNoGoAlreadyResolved_PromotesOutcome(t *testing.T) {
 	if got := res.Extra["outcome"]; got != "ALREADY-RESOLVED" {
 		t.Errorf("top-level outcome: want ALREADY-RESOLVED got %v", got)
 	}
-	if got := res.Extra["resolvedBy"]; got != "abc1234" {
-		t.Errorf("top-level resolvedBy: want abc1234 got %v", got)
+	if got := res.Extra["resolvedBy"]; got != seedSHA {
+		t.Errorf("top-level resolvedBy: want %s got %v", seedSHA, got)
 	}
 	me, ok := res.Extra["modelExtra"].(map[string]any)
 	if !ok || me["outcome"] != "ALREADY-RESOLVED" {
 		t.Errorf("modelExtra should keep the nested outcome for observability, got %v", res.Extra["modelExtra"])
 	}
+}
+
+// seedCommitSHA returns the full SHA of the seed commit on a bare repo
+// created by initBareWithSeed. It is an ancestor of `main`, so a #1692
+// resolvedBy naming it passes both validation checks (resolves + ancestor).
+func seedCommitSHA(t *testing.T, bare string) string {
+	t.Helper()
+	gitOrSkip(t)
+	out, err := exec.Command("git", "--git-dir", bare, "rev-parse", "main").CombinedOutput()
+	if err != nil {
+		t.Fatalf("git rev-parse main: %v: %s", err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // Issue #1526: a submit_result carrying edits but an empty CommitMessage used


### PR DESCRIPTION
## What

Validates `extra.resolvedBy` before an ALREADY-RESOLVED verdict is allowed to
skip verification. A claim that does not resolve to a commit, or resolves but is
not an ancestor of the base branch, is downgraded to NEEDS-VERIFICATION instead
of being honoured.

## Why

Fixes #1692

`extra.resolvedBy` is free text written by the model. Nothing checked that it
named a real commit, so ALREADY-RESOLVED — the one verdict that skips
verification entirely — was unfalsifiable. The single most consequential claim a
coder can make was the only claim the pipeline never tested.

## How

`resolvedByResolvesAndIsAncestor` in `pkg/foreman/agent/executor_native.go` runs
two git checks at the promotion site, where the repo is still checked out:

```go
git cat-file -e <claimed>^{commit}                    // does it resolve
git merge-base --is-ancestor <claimed> <baseBranch>   // is it on the branch
```

Validation lives in the agent rather than the controller deliberately: the
controller cannot run git and would have to trust the string regardless.

Any git failure or empty input fails closed, so an unverifiable claim is never
honoured.

On rejection the outcome becomes `needsVerificationOutcome` and the rejected
string is preserved under `extra["resolvedByClaimed"]`, so the audit record
keeps the evidence without acting on it.

`coderResolvedBy` in `internal/foreman/controller/workload_coder_escalation.go`
is unchanged and still returns the string as-is; this does not move validation
into the controller.

## Testing

Six table cases against a real git fixture repo, covering every path the issue
named plus two more:

- valid ancestor SHA stays ALREADY-RESOLVED
- earlier ancestor SHA stays ALREADY-RESOLVED
- well-formed SHA that is not an ancestor is downgraded
- SHA that does not resolve is downgraded
- free text (the live false claim from the issue) is downgraded
- empty resolvedBy is downgraded and drops nothing

**The mutation the issue specifies must fail, does.** Deleting the
`merge-base --is-ancestor` check fails
`well-formed_SHA_that_is_not_an_ancestor_is_downgraded`. A happy-path-only test
would pass with the bug fully present, so this was checked rather than assumed.

Adversarial probes, since `resolvedBy` is model-written text passed to git:

```
--batch     exit 129  downgraded    (not parsed as a git flag)
-h          exit 129  downgraded
not-a-sha   exit 128  downgraded
HEAD        resolves, not an ancestor, downgraded
```

No argument-injection path; `run` uses argv, not a shell.

`make test` green, `GOOS=linux golangci-lint run` 0 issues.

## Known limitation

The check accepts any revision that resolves AND is an ancestor, so a symbolic
ref such as `HEAD` would pass in a workspace where the coder committed nothing.
The issue's intent was "names a real commit"; requiring a hex-SHA shape would
close that. Left as-is because the scenario is close to a legitimate
ALREADY-RESOLVED and the fail-closed direction is preserved, but it is worth
knowing before relying on this as a security boundary rather than an honesty
check.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) - behaviour change is in the
      verdict pipeline; no doc page describes ALREADY-RESOLVED handling today

Assisted-by: Foreman (DeepSeek-V4-Flash coder) wrote the implementation and
tests unaided; this needed no revision pass, unlike the other coder work today.
I reviewed the diff, ran the issue's specified mutation to confirm the tests
catch it, probed the git-argument handling with adversarial inputs, and ran
`make test` and `make lint`.
