### PR TITLE
fix(foreman): pass upstreamURL to the coder post-push envtest gate

### DIFF
--- a/cmd/foreman-agent/envtest_runner_test.go
+++ b/cmd/foreman-agent/envtest_runner_test.go
@@ -74,6 +74,7 @@ func TestEnvtestJobRunnerStampsTaskName(t *testing.T) {
 		ctx, taskNS, taskName,
 		"defilantech/LLMKube", "foreman/issue-893",
 		"https://github.com/Defilan/LLMKube.git",
+		"https://github.com/defilantech/LLMKube.git",
 	)
 
 	var job batchv1.Job
@@ -91,5 +92,72 @@ func TestEnvtestJobRunnerStampsTaskName(t *testing.T) {
 	// Pod template labels must match so a pod can also be traced back.
 	if got := job.Spec.Template.Labels["foreman.llmkube.dev/task-name"]; got != taskName {
 		t.Errorf("gate Job pod template task-name label = %q, want %q", got, taskName)
+	}
+}
+
+// TestEnvtestJobRunnerPassesUpstreamURL is the #1731 regression: the coder's
+// post-push envtest gate must submit its Job with UPSTREAM_URL set, so the
+// gate script diffs against merge-base(HEAD, canonical base) rather than
+// falling back to the FORK's base ref.
+//
+// The assertion is on the created Job's env, not on the args map, because the
+// env var is what the gate script actually reads. Observed in production on
+// 2026-09-01: the var reached the Job with no value key at all, the script took
+// its documented "no upstream URL" branch, and change detection plus non-Go
+// lint silently skipped while the Job still reported GATE PASS.
+func TestEnvtestJobRunnerPassesUpstreamURL(t *testing.T) {
+	s := runtime.NewScheme()
+	if err := batchv1.AddToScheme(s); err != nil {
+		t.Fatalf("add batchv1 scheme: %v", err)
+	}
+	kc := fake.NewClientBuilder().WithScheme(s).Build()
+
+	const (
+		taskNS      = "foreman-system"
+		taskName    = "fix-issue-1731"
+		jobName     = "foreman-gate-fix-issue-1731-pinned"
+		upstreamURL = "https://github.com/defilantech/LLMKube.git"
+	)
+
+	runner := &envtestJobRunnerImpl{
+		tool: &foremantools.RunGateJobTool{
+			Client: kc,
+			Cfg: foremantools.RunGateJobToolConfig{
+				Namespace:    taskNS,
+				PollInterval: time.Millisecond,
+				PollTimeout:  5 * time.Millisecond,
+				NameFn:       func(string) string { return jobName },
+			},
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_, _, _ = runner.Run(
+		ctx, taskNS, taskName,
+		"defilantech/LLMKube", "foreman/issue-1731",
+		"https://github.com/Defilan/LLMKube.git",
+		upstreamURL,
+	)
+
+	var job batchv1.Job
+	key := types.NamespacedName{Namespace: taskNS, Name: jobName}
+	if err := kc.Get(context.Background(), key, &job); err != nil {
+		t.Fatalf("gate Job %s was not created: %v", key, err)
+	}
+
+	var got string
+	var found bool
+	for _, e := range job.Spec.Template.Spec.Containers[0].Env {
+		if e.Name == "UPSTREAM_URL" {
+			got, found = e.Value, true
+		}
+	}
+	if !found {
+		t.Fatalf("gate Job has no UPSTREAM_URL env var at all")
+	}
+	if got != upstreamURL {
+		t.Errorf("UPSTREAM_URL = %q, want %q (empty makes the gate resolve its "+
+			"base from the fork, which is the #1731 bug)", got, upstreamURL)
 	}
 }

--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -1046,13 +1046,21 @@ type envtestJobRunnerImpl struct {
 }
 
 func (e *envtestJobRunnerImpl) Run(
-	ctx context.Context, taskNamespace, taskName, repository, branch, cloneURL string,
+	ctx context.Context, taskNamespace, taskName, repository, branch, cloneURL, upstreamURL string,
 ) (pass bool, ran bool, feedback string) {
 	args, err := json.Marshal(map[string]any{
 		"repo":     repository,
 		"branch":   branch,
 		"checks":   []string{"test"},
 		"cloneURL": cloneURL,
+		// upstreamURL is what makes the gate diff against
+		// merge-base(HEAD, canonical base) instead of the FORK's base tip.
+		// Omitting it sends the gate script down its "no upstream URL"
+		// branch, where change detection and the non-Go lint silently skip
+		// while the Job still reports GATE PASS (#1731). run_gate_job
+		// validates the value against upstreamURLPattern and treats empty as
+		// "no upstream", so an unset repo slug degrades exactly as before.
+		"upstreamURL": upstreamURL,
 		// taskRef stamps the gate Job + pod with the originating AgenticTask
 		// identity (foreman.llmkube.dev/task-{namespace,name} labels) so a
 		// gate Job/pod can be traced back to its task (#893). Without it the

--- a/pkg/foreman/agent/envtest_gate.go
+++ b/pkg/foreman/agent/envtest_gate.go
@@ -20,9 +20,17 @@ type EnvtestJobRunner interface {
 	// submitted gate Job carries the foreman.llmkube.dev/task-{namespace,name}
 	// labels and a Job/pod can be traced back to its task (#893). They mirror
 	// the coder Job path's TaskNamespace/TaskName.
+	//
+	// upstreamURL is the CANONICAL repo clone URL, and it is separate from
+	// cloneURL on purpose: cloneURL is where the branch lives (the fork),
+	// upstreamURL is what the branch was cut from. The gate diffs against
+	// merge-base(HEAD, upstreamURL base) so a stale fork base ref cannot
+	// manufacture failures (#1259). Empty makes the gate Job fall back to the
+	// fork's base tip, which silently skips change detection and the bite
+	// check while still reporting GATE PASS (#1731).
 	Run(
 		ctx context.Context,
-		taskNamespace, taskName, repository, branch, cloneURL string,
+		taskNamespace, taskName, repository, branch, cloneURL, upstreamURL string,
 	) (pass bool, ran bool, feedback string)
 }
 
@@ -55,12 +63,13 @@ func evaluatePostPushEnvtest(
 	ctx context.Context,
 	envtestTouched bool,
 	runner EnvtestJobRunner,
-	taskNamespace, taskName, repository, branch, cloneURL string,
+	taskNamespace, taskName, repository, branch, cloneURL, upstreamURL string,
 ) (envtestGateVerdict, string) {
 	if !envtestTouched || runner == nil {
 		return envtestGateOK, ""
 	}
-	pass, ran, fb := runner.Run(ctx, taskNamespace, taskName, repository, branch, cloneURL)
+	pass, ran, fb := runner.Run(
+		ctx, taskNamespace, taskName, repository, branch, cloneURL, upstreamURL)
 	if !ran {
 		return envtestGateUnverified, ""
 	}

--- a/pkg/foreman/agent/envtest_gate_test.go
+++ b/pkg/foreman/agent/envtest_gate_test.go
@@ -14,46 +14,54 @@ type fakeEnvtestJobRunner struct {
 	// threaded through, so tests can assert it reaches the runner (#893).
 	gotTaskNamespace string
 	gotTaskName      string
+
+	// gotUpstreamURL captures the canonical repo URL the caller threaded
+	// through (#1731). Empty here means the gate Job would resolve its base
+	// from the fork instead of the merge-base against upstream.
+	gotUpstreamURL string
 }
 
-func (f *fakeEnvtestJobRunner) Run(_ context.Context, taskNamespace, taskName, _, _, _ string) (bool, bool, string) {
+func (f *fakeEnvtestJobRunner) Run(
+	_ context.Context, taskNamespace, taskName, _, _, _, upstreamURL string,
+) (bool, bool, string) {
 	f.called = true
 	f.gotTaskNamespace = taskNamespace
 	f.gotTaskName = taskName
+	f.gotUpstreamURL = upstreamURL
 	return f.pass, f.ran, f.feedback
 }
 
 func TestEvaluatePostPushEnvtest(t *testing.T) {
 	t.Run("not touched: runner not called, verdict OK", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{}
-		v, fb := evaluatePostPushEnvtest(context.Background(), false, r, "ns", "task", "repo", "br", "url")
+		v, fb := evaluatePostPushEnvtest(context.Background(), false, r, "ns", "task", "repo", "br", "url", "up")
 		if v != envtestGateOK || fb != "" || r.called {
 			t.Fatalf("got verdict=%v fb=%q called=%v", v, fb, r.called)
 		}
 	})
 	t.Run("nil runner: verdict OK", func(t *testing.T) {
-		v, fb := evaluatePostPushEnvtest(context.Background(), true, nil, "ns", "task", "repo", "br", "url")
+		v, fb := evaluatePostPushEnvtest(context.Background(), true, nil, "ns", "task", "repo", "br", "url", "up")
 		if v != envtestGateOK || fb != "" {
 			t.Fatalf("got verdict=%v fb=%q", v, fb)
 		}
 	})
 	t.Run("touched + pass: verdict OK", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: true, ran: true}
-		v, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
+		v, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url", "up")
 		if v != envtestGateOK || !r.called {
 			t.Fatalf("got verdict=%v called=%v", v, r.called)
 		}
 	})
 	t.Run("touched + ran + fail: verdict Failed with feedback", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: false, ran: true, feedback: "envtest broke"}
-		v, fb := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
+		v, fb := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url", "up")
 		if v != envtestGateFailed || fb != "envtest broke" {
 			t.Fatalf("got verdict=%v fb=%q", v, fb)
 		}
 	})
 	t.Run("touched + could-not-run: verdict Unverified (caller decides by attempt)", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: false, ran: false, feedback: "infra"}
-		v, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url")
+		v, _ := evaluatePostPushEnvtest(context.Background(), true, r, "ns", "task", "repo", "br", "url", "up")
 		if v != envtestGateUnverified {
 			t.Fatalf("could-not-run should be Unverified; got verdict=%v", v)
 		}
@@ -61,10 +69,21 @@ func TestEvaluatePostPushEnvtest(t *testing.T) {
 	t.Run("task identity is threaded to the runner (#893)", func(t *testing.T) {
 		r := &fakeEnvtestJobRunner{pass: true, ran: true}
 		evaluatePostPushEnvtest(context.Background(), true, r,
-			"foreman-system", "fix-issue-893", "repo", "br", "url")
+			"foreman-system", "fix-issue-893", "repo", "br", "url", "up")
 		if r.gotTaskNamespace != "foreman-system" || r.gotTaskName != "fix-issue-893" {
 			t.Fatalf("runner got task identity (%q,%q), want (foreman-system,fix-issue-893)",
 				r.gotTaskNamespace, r.gotTaskName)
+		}
+	})
+	t.Run("upstream URL is threaded to the runner (#1731)", func(t *testing.T) {
+		r := &fakeEnvtestJobRunner{pass: true, ran: true}
+		evaluatePostPushEnvtest(context.Background(), true, r,
+			"foreman-system", "fix-issue-1731", "repo", "br", "clone",
+			"https://github.com/defilantech/LLMKube.git")
+		if r.gotUpstreamURL != "https://github.com/defilantech/LLMKube.git" {
+			t.Fatalf("runner got upstreamURL %q, want the canonical repo URL; "+
+				"empty makes the gate Job resolve its base from the fork (#1731)",
+				r.gotUpstreamURL)
 		}
 	})
 }

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1228,10 +1228,16 @@ func (e *NativeAgentLoopExecutor) postPushGateDecision(
 	start time.Time, transcriptRef corev1.ObjectReference, loopRes *LoopResult,
 	gateAdvisories *[]advisory, cloneURL string,
 ) (settled bool, done *Result, feedback string) {
+	// resolveUpstreamForRun, not the bare slug: the gate needs the CANONICAL
+	// repo URL to diff against merge-base rather than the fork's base tip
+	// (#1731). Threading it here rather than through the parameter list keeps
+	// the existing callers unchanged and reuses the same seam the self-commit
+	// recovery path already uses, so a test override still applies.
 	gate, fb := evaluatePostPushEnvtest(
 		ctx, envtestTouched, e.EnvtestJobRunner,
 		task.Namespace, task.Name,
 		task.Spec.Payload.Repo, branch, cloneURL,
+		e.resolveUpstreamForRun(task),
 	)
 	if gate == envtestGateOK || (gate == envtestGateUnverified && attempt == 0) {
 		return true, nil, ""

--- a/pkg/foreman/agent/executor_native_envtest_loop_test.go
+++ b/pkg/foreman/agent/executor_native_envtest_loop_test.go
@@ -97,7 +97,7 @@ type envtestGateResult struct {
 }
 
 func (f *scriptedEnvtestRunner) Run(
-	_ context.Context, _, _, _, _, _ string,
+	_ context.Context, _, _, _, _, _, _ string,
 ) (pass bool, ran bool, feedback string) {
 	i := f.calls
 	if i >= len(f.results) {


### PR DESCRIPTION
## What

Thread the canonical repo URL through the coder's post-push envtest gate so its
gate Job diffs against `merge-base(HEAD, canonical base)` instead of falling
back to the fork's base tip.

## Why

Refs #1731

`EnvtestJobRunner.Run` had no parameter for the upstream URL, so the wiring
closure in `cmd/foreman-agent` could not supply one and the gate Job received
`UPSTREAM_URL=""`. The gate script then takes its documented branch:

> No upstream URL (freeform task without a repo slug): pre-#1259 behavior, fetch
> the base ref from origin and use its tip.

Origin is the fork. Once the fork's base ref drifts, the fallback diff looks
enormous, change detection is skipped, and the bite check and non-Go lint
silently do not run while the Job still reports `GATE PASS`.

The tasks were not missing a repo slug. All three carried
`payload.repo = defilantech/LLMKube`; the value simply had no route to the Job
on this path. #1259 fixed this exact failure mode for the verify path, which
resolves the URL in Go and passes it, but the coder self-gate path was never
threaded.

Observed live on 2026-09-01, split exactly on task kind:

```
verify-task gates (4)   UPSTREAM_URL SET -> https://github.com/defilantech/LLMKube.git
code-task gates   (3)   UPSTREAM_URL EMPTY (no value key)
```

and on `wl-1684-scope-inert-code-1684`:

```
GATE-WARN: change detection skipped (diff vs merge-base names 207 files; base resolution suspect)
non-go lint: skipped, no usable base to diff against
GATE PASS
```

207 was the file count between the fork's `main` and upstream `main`, 9 commits
apart at the time. That branch's real diff is 2 files.

What this costs is narrower than it first looks: `make test` still ran and
genuinely passed, so this was never a false test pass. What was lost is the
diff-scoped tier, including the bite check, which is the primary defense against
tests that assert nothing. It failed open and silent.

## How

Three changes, one per layer:

1. `pkg/foreman/agent/envtest_gate.go` adds `upstreamURL` to the
   `EnvtestJobRunner.Run` signature and threads it through
   `evaluatePostPushEnvtest`. The godoc spells out why it is separate from
   `cloneURL`: `cloneURL` is where the branch lives (the fork), `upstreamURL` is
   what it was cut from.
2. `pkg/foreman/agent/executor_native.go` resolves it at the call site with
   `resolveUpstreamForRun`, the same seam the self-commit recovery path uses, so
   an `UpstreamURLForRepo` test override still applies. Resolving inside
   `postPushGateDecision` rather than widening its parameter list keeps the
   existing callers untouched.
3. `cmd/foreman-agent/main.go` puts `upstreamURL` in the `run_gate_job` args
   map. `run_gate_job` already validates it against `upstreamURLPattern` and
   treats empty as "no upstream", so a genuinely absent repo slug degrades
   exactly as it does today.

Both new assertions are mutation-checked rather than assumed:

```
mutation 1 (args map -> empty):   test FAILED (caught)
mutation 2 (evaluator drops it):  test FAILED (caught)
```

The runner test asserts the created Job's `UPSTREAM_URL` env var, not the args
map, because the env var is what the gate script actually reads.

### Noted, deliberately not changed

`resolveUpstreamForRun` documents itself as mirroring the `resolveUpstream`
closure at the top of `Execute`, but it does not consult `e.CodeHost` the way
that closure does. That divergence predates this PR and affects the self-commit
recovery path today. Making them agree is a real change in behaviour when a
`CodeHost` is configured, so it does not belong bundled into a bug fix. Worth a
follow-up.

## Checklist

- [x] Tests added/updated
- [ ] `make test` passes locally — ran the affected packages
      (`cmd/foreman-agent`, `pkg/foreman/agent`, `pkg/foreman/agent/tools`), all
      green; the full suite has not been run locally, CI covers it
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run ./...`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: authored with Claude Code (band 3 under
      CONTRIBUTING.md). The root cause was diagnosed from live cluster state and
      the maintainer owns the review conversation.
- [ ] Documentation updated — no user-facing change

`Refs` rather than `Fixes`: the fix is unit-verified and mutation-checked, but
not yet confirmed end to end on the fleet. The issue should close once a coder
gate Job is observed carrying a non-empty `UPSTREAM_URL`.
