### PR TITLE
fix(foreman): report the packages the diff-coverage gate could not measure

### DIFF
--- a/pkg/foreman/agent/diff_coverage_gate.go
+++ b/pkg/foreman/agent/diff_coverage_gate.go
@@ -202,29 +202,15 @@ func checkDiffCoverage(ctx context.Context, workspace string, run commandRunner)
 	}
 
 	var findings []string
+	// notEvaluated collects packages this check could not measure. Reporting
+	// them is the whole point of #1733: a silent skip renders identically to a
+	// clean result, so "we could not look" becomes indistinguishable from "we
+	// looked and found nothing" -- the exact failure class this gate exists to
+	// catch, occurring inside the gate.
+	var notEvaluated []string
 	for dir, dirFiles := range pkgs {
-		profile, err := os.CreateTemp("", "diffcov-*.out")
-		if err != nil {
-			continue
-		}
-		profilePath := profile.Name()
-		_ = profile.Close()
-
-		// A failing or absent test suite is NOT this gate's finding: the coder
-		// gate already runs build and test, and reporting here as well would
-		// double-report one problem under two names.
-		_, terr := run(ctx, workspace, nil, "go", "test", "-count=1", "-timeout=300s",
-			"-coverprofile="+profilePath, "./"+dir+"/")
-		if terr != nil {
-			_ = os.Remove(profilePath)
-			continue
-		}
-		raw, rerr := os.ReadFile(profilePath) //nolint:gosec // G304: path from os.CreateTemp
-		_ = os.Remove(profilePath)
-		if rerr != nil {
-			continue
-		}
-
+		// Added lines FIRST, before any coverage run. A package whose diff adds
+		// no statements cannot produce a finding, so testing it is pure cost.
 		added := map[string]map[int]bool{}
 		for _, f := range dirFiles {
 			if lines := changedNewLines(ctx, workspace, f, run); len(lines) > 0 {
@@ -235,20 +221,79 @@ func checkDiffCoverage(ctx context.Context, workspace string, run commandRunner)
 			continue
 		}
 
+		pkgPath := "./" + dir + "/"
+
+		// Envtest-backed packages are classified, not discovered by failing.
+		// envtestPackagePrefixes exists because the coder workspace has no
+		// KUBEBUILDER_ASSETS, and the fast unit-test tier already skips these
+		// for the same reason. Running them here would fail in BeforeSuite
+		// after burning the timeout.
+		//
+		// The post-push gate Job DOES run these with envtest assets, but it
+		// runs `make test`, not diff coverage. So for these packages this
+		// check happens nowhere, and saying so is the honest report.
+		if isEnvtestPackage(pkgPath) {
+			notEvaluated = append(notEvaluated,
+				dir+" (envtest package; not measurable in the coder workspace)")
+			continue
+		}
+
+		profile, err := os.CreateTemp("", "diffcov-*.out")
+		if err != nil {
+			notEvaluated = append(notEvaluated, dir+" (could not create a coverage profile)")
+			continue
+		}
+		profilePath := profile.Name()
+		_ = profile.Close()
+
+		// A failing or absent test suite is NOT this gate's finding: the coder
+		// gate already runs build and test, and reporting the failure here as
+		// well would double-report one problem under two names. What IS this
+		// gate's business is that coverage went unmeasured, so the package is
+		// recorded rather than dropped.
+		_, terr := run(ctx, workspace, nil, "go", "test", "-count=1", "-timeout=300s",
+			"-coverprofile="+profilePath, pkgPath)
+		if terr != nil {
+			_ = os.Remove(profilePath)
+			notEvaluated = append(notEvaluated, dir+" (its tests did not run here)")
+			continue
+		}
+		raw, rerr := os.ReadFile(profilePath) //nolint:gosec // G304: path from os.CreateTemp
+		_ = os.Remove(profilePath)
+		if rerr != nil {
+			notEvaluated = append(notEvaluated, dir+" (coverage profile unreadable)")
+			continue
+		}
+
 		for file, lines := range uncoveredAddedLines(parseCoverProfile(string(raw)), added) {
 			sort.Ints(lines)
 			findings = append(findings, fmt.Sprintf("%s: added lines never executed by any test: %s",
 				file, formatLineList(lines)))
 		}
 	}
-	if len(findings) == 0 {
+	if len(findings) == 0 && len(notEvaluated) == 0 {
 		return false, ""
 	}
 	sort.Strings(findings)
-	return true, "Added code that no test reaches:\n  " + strings.Join(findings, "\n  ") +
-		"\n\nThese lines were added by this change and ran zero times. An error path " +
-		"or guard that no test enters is not constrained by the suite: it can be " +
-		"wrong in either direction and every gate still passes."
+	sort.Strings(notEvaluated)
+
+	var b strings.Builder
+	if len(findings) > 0 {
+		b.WriteString("Added code that no test reaches:\n  " + strings.Join(findings, "\n  "))
+		b.WriteString("\n\nThese lines were added by this change and ran zero times. An error path " +
+			"or guard that no test enters is not constrained by the suite: it can be " +
+			"wrong in either direction and every gate still passes.")
+	}
+	if len(notEvaluated) > 0 {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		b.WriteString("Coverage NOT evaluated for:\n  " + strings.Join(notEvaluated, "\n  "))
+		b.WriteString("\n\nThis is not a finding about the code, it is the limit of this check. " +
+			"These packages were added to by this change and their diff coverage was " +
+			"never measured, so a silent pass here says nothing about them either way.")
+	}
+	return true, b.String()
 }
 
 // formatLineList renders line numbers compactly, collapsing runs into ranges so

--- a/pkg/foreman/agent/diff_coverage_gate_test.go
+++ b/pkg/foreman/agent/diff_coverage_gate_test.go
@@ -1,6 +1,11 @@
 package agent
 
-import "testing"
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
 
 // A Go coverprofile block is `importpath/file.go:sLine.sCol,eLine.eCol nStmt count`.
 // The paths are import paths; the diff gives repo-relative paths, so matching is
@@ -134,5 +139,112 @@ func TestFormatLineList_CollapsesRuns(t *testing.T) {
 		if got := formatLineList(tc.in); got != tc.want {
 			t.Errorf("formatLineList(%v) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+// coverageFakeRunner answers the three command shapes checkDiffCoverage drives:
+// `git status -z` for the changed-file list, `git diff -U0 HEAD -- <file>` for a
+// file's added lines, and `go test` for the coverage run. goTestErr keys are
+// package dirs whose test run should fail. Every `go test` invocation is
+// recorded in *ran so a test can assert a package was NOT tested.
+func coverageFakeRunner(
+	status string, diffs map[string]string, goTestErr map[string]bool, ran *[]string,
+) commandRunner {
+	return func(_ context.Context, _ string, _ []string, name string, args ...string) (string, error) {
+		if name == "git" && len(args) >= 2 && args[0] == "status" {
+			return status, nil
+		}
+		if name == "git" && len(args) >= 1 && args[0] == "diff" {
+			file := args[len(args)-1]
+			return diffs[file], nil
+		}
+		if name == "go" && len(args) >= 1 && args[0] == "test" {
+			pkg := args[len(args)-1]
+			*ran = append(*ran, pkg)
+			if goTestErr[pkg] {
+				return "BeforeSuite failed: no such file or directory", errFakeGoTest
+			}
+			return "ok", nil
+		}
+		return "", nil
+	}
+}
+
+var errFakeGoTest = fmt.Errorf("exit status 1")
+
+// addedLineDiff builds the minimal `git diff -U0` shape parseAddedLines reads.
+func addedLineDiff(start int, n int) string {
+	d := fmt.Sprintf("@@ -%d,0 +%d,%d @@\n", start-1, start, n)
+	for i := 0; i < n; i++ {
+		d += "+\tsomeStatement()\n"
+	}
+	return d
+}
+
+// TestCheckDiffCoverage_ReportsEnvtestPackagesAsNotEvaluated is the #1733
+// regression. An envtest-backed package cannot be measured in the coder
+// workspace (no KUBEBUILDER_ASSETS), and the gate must SAY so. Emitting nothing
+// makes "could not look" render exactly like "looked and found nothing", which
+// is the failure class this gate exists to catch.
+func TestCheckDiffCoverage_ReportsEnvtestPackagesAsNotEvaluated(t *testing.T) {
+	file := "internal/foreman/controller/agentictask_controller.go"
+	var ran []string
+	run := coverageFakeRunner(
+		file,
+		map[string]string{file: addedLineDiff(591, 3)},
+		nil, &ran,
+	)
+
+	found, msg := checkDiffCoverage(context.Background(), t.TempDir(), run)
+	if !found {
+		t.Fatalf("envtest package went unreported; got found=false msg=%q", msg)
+	}
+	if !strings.Contains(msg, "internal/foreman/controller") {
+		t.Errorf("advisory does not name the unevaluated package: %q", msg)
+	}
+	// It must not even attempt the run: the fast tier skips these because
+	// running them in the coder workspace hangs or fails in BeforeSuite.
+	for _, p := range ran {
+		if strings.Contains(p, "internal/foreman/controller") {
+			t.Errorf("ran go test on an envtest package (%q); it should be "+
+				"classified via isEnvtestPackage, not discovered by failing", p)
+		}
+	}
+}
+
+// TestCheckDiffCoverage_ReportsAFailedTestRunAsNotEvaluated covers the other
+// way the check can be blind: a non-envtest package whose tests do not run.
+func TestCheckDiffCoverage_ReportsAFailedTestRunAsNotEvaluated(t *testing.T) {
+	file := "pkg/foreman/agent/thing.go"
+	var ran []string
+	run := coverageFakeRunner(
+		file,
+		map[string]string{file: addedLineDiff(10, 2)},
+		map[string]bool{"./pkg/foreman/agent/": true}, &ran,
+	)
+
+	found, msg := checkDiffCoverage(context.Background(), t.TempDir(), run)
+	if !found {
+		t.Fatalf("a package whose tests did not run went unreported: msg=%q", msg)
+	}
+	if !strings.Contains(msg, "pkg/foreman/agent") {
+		t.Errorf("advisory does not name the unevaluated package: %q", msg)
+	}
+}
+
+// TestCheckDiffCoverage_NoAddedLinesRunsNoTests asserts the ordering change:
+// added lines are computed BEFORE the coverage run, so a package whose diff
+// cannot produce a finding costs no `go test`.
+func TestCheckDiffCoverage_NoAddedLinesRunsNoTests(t *testing.T) {
+	file := "pkg/foreman/agent/thing.go"
+	var ran []string
+	run := coverageFakeRunner(file, map[string]string{file: ""}, nil, &ran)
+
+	found, msg := checkDiffCoverage(context.Background(), t.TempDir(), run)
+	if found {
+		t.Errorf("reported something for a diff with no added lines: %q", msg)
+	}
+	if len(ran) != 0 {
+		t.Errorf("ran %v; a package with no added lines needs no coverage run", ran)
 	}
 }


### PR DESCRIPTION
## What

Make the diff-coverage gate report the packages it could not measure, instead of
dropping them silently.

## Why

Refs #1733

#1728 added the gate. Its skip path was silent, so a package whose tests did not
run produced byte-identical output to a package that was measured and found
clean. For `internal/controller/` and `internal/foreman/controller/` that is
every single run: the coder workspace has no `KUBEBUILDER_ASSETS`, the Ginkgo
suite fails in `BeforeSuite`, and `terr != nil` continued without a trace.

Confirmed live on `wl-1729-depwait-default-code-1729`, whose diff was entirely
inside `internal/foreman/controller`:

```
advisories: 2
  - caller-impact
  - issue-example
diff-coverage present: False
```

The advisory machinery was fine. The check simply had nothing to say because it
never ran, and nothing anywhere said so.

Measured in a fresh worktree with no `bin/`, which is what the agent's clone
looks like:

```
internal/controller           go test FAILS  -> gate blind
internal/foreman/controller   go test FAILS  -> gate blind
pkg/cli                       go test passes -> gate evaluates
pkg/foreman/agent             go test passes -> gate evaluates
pkg/foreman/agent/tools       go test passes -> gate evaluates
```

This is the exact failure the gate was built to catch, happening inside the
gate: "could not look" rendering identically to "looked and found nothing".

## How

**Order.** Added lines are computed before the coverage run, and a package that
adds no statements is skipped without one. Such a package cannot produce a
finding, so the run was pure cost.

**Classification, not discovery by failure.** Envtest-backed packages are
detected with the existing `isEnvtestPackage`. `envtestPackagePrefixes` already
exists precisely because "the coder workspace does not have KUBEBUILDER_ASSETS",
and the fast unit-test tier already skips them on that basis. Reusing it avoids
burning a 300s timeout to rediscover what the package already knows, and keeps
one source of truth for which packages are unmeasurable here.

**Reporting.** Unmeasured packages get their own section of the advisory, worded
so it reads as the limit of the check rather than a finding about the code:

```
Coverage NOT evaluated for:
  internal/foreman/controller (envtest package; not measurable in the coder workspace)

This is not a finding about the code, it is the limit of this check. These
packages were added to by this change and their diff coverage was never
measured, so a silent pass here says nothing about them either way.
```

The envtest wording is deliberately blunt about the gap: the post-push gate Job
does run these packages with assets, but it runs `make test`, not diff coverage.
So for them this check happens nowhere.

A failing test run for any other reason is reported the same way. That does not
double-report the failure itself, which the gate's build and test tiers already
own; what is reported here is that coverage went unmeasured.

### Deliberately not done

Provisioning envtest assets in the coder workspace so these packages can actually
be measured. That is heavier, network dependent, and a separate decision. Honest
reporting is the fix for the silence; measuring those packages is a feature.

## Verification

Tests written first and observed RED with the right messages:

```
envtest package went unreported; got found=false msg=""
a package whose tests did not run went unreported: msg=""
ran [./pkg/foreman/agent/]; a package with no added lines needs no coverage run
```

Then GREEN, then mutation-checked:

```
envtest classification removed             FAILED (caught)
failed-run report removed (silent skip)    FAILED (caught)
added-lines early exit removed             FAILED (caught)
```

## Checklist

- [x] Tests added/updated
- [ ] `make test` passes locally — ran the affected package
      (`pkg/foreman/agent`, full, 56s) plus a clean `go build ./...`; the full
      suite has not been run locally, CI covers it
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run ./...`, 0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: authored with Claude Code (band 3 under
      CONTRIBUTING.md). The gap was found by checking the gate's own output on a
      live run; the maintainer owns the review conversation.
- [ ] Documentation updated — no user-facing change

`Refs` rather than `Fixes`: unit-verified and mutation-checked, but the
end-to-end confirmation is a coder run touching an envtest package that reports
a "Coverage NOT evaluated" advisory. #1733 should close on that observation.
