### PR TITLE
fix(foreman): bound the dependency wait when TimeoutSeconds is unset

### DIFF
--- a/internal/foreman/controller/agentictask_controller.go
+++ b/internal/foreman/controller/agentictask_controller.go
@@ -89,6 +89,16 @@ const requeueNoFit = 10 * time.Second
 // still pre-terminal.
 const requeueWaitingForDeps = 10 * time.Second
 
+// defaultDepWaitBudget bounds the wait for an absent dependency when the task
+// does not set spec.TimeoutSeconds. One hour is deliberate, not arbitrary:
+// this guard measures a dependency that is ABSENT, not one that is slow. The
+// planner emits every task in a batch together, so a dependency that has not
+// appeared within an hour was deleted or never emitted -- waiting longer
+// cannot help it appear. Without this bound an unset TimeoutSeconds leaves the
+// wait unbounded and a task whose dependency vanished stays Pending forever
+// (#1729).
+const defaultDepWaitBudget = 1 * time.Hour
+
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=agentictasks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=agentictasks/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=foreman.llmkube.dev,resources=agentictasks/finalizers,verbs=update
@@ -586,12 +596,14 @@ func (r *AgenticTaskReconciler) recordMissingDepCondition(ctx context.Context, t
 //     be written, so the condition clock is reachable.
 //
 // No condition means the wait has not been recorded yet, so nothing has
-// elapsed. An unset or zero TimeoutSeconds leaves the wait unbounded (the dep
-// is legal to wait for), which is the pre-1687 default and still correct.
+// elapsed. An unset or zero TimeoutSeconds falls back to the package-level
+// defaultDepWaitBudget so the wait is bounded even on paths (such as the
+// planner) that never stamp the field; an explicitly set positive
+// TimeoutSeconds always wins.
 func depWaitExpired(task *foremanv1alpha1.AgenticTask) bool {
 	budget := time.Duration(task.Spec.TimeoutSeconds) * time.Second
 	if budget <= 0 {
-		return false
+		budget = defaultDepWaitBudget
 	}
 	started := apimeta.FindStatusCondition(task.Status.Conditions, "DepWaitStarted")
 	if started == nil || started.LastTransitionTime.IsZero() {

--- a/internal/foreman/controller/agentictask_missing_dep_test.go
+++ b/internal/foreman/controller/agentictask_missing_dep_test.go
@@ -174,9 +174,31 @@ func TestDepWaitExpired(t *testing.T) {
 		want        bool
 	}{
 		{
-			name:        "zero timeout never expires (unbounded wait)",
+			// TimeoutSeconds unset with a wait older than the default one-hour
+			// fallback: the wait has outlasted the bounded budget, so the
+			// missing-dependency cascade-fail must fire (#1729).
+			name:        "unset timeout past fallback budget expires",
 			timeoutSec:  0,
-			waitStarted: metav1.NewTime(now.Add(-100 * time.Hour)),
+			waitStarted: metav1.NewTime(now.Add(-2 * time.Hour)),
+			want:        true,
+		},
+		{
+			// TimeoutSeconds unset with a recent wait: still inside the
+			// default one-hour fallback, so the create-ordering race is
+			// preserved and the wait must NOT expire.
+			name:        "unset timeout within fallback budget does not expire",
+			timeoutSec:  0,
+			waitStarted: metav1.NewTime(now.Add(-1 * time.Minute)),
+			want:        false,
+		},
+		{
+			// An explicitly set positive TimeoutSeconds must keep governing:
+			// a 2-hour budget with a 90-minute wait has not elapsed, even
+			// though the wait is already past the one-hour fallback. The
+			// fallback must never silently replace an explicit value.
+			name:        "explicit timeout governs over fallback",
+			timeoutSec:  7200,
+			waitStarted: metav1.NewTime(now.Add(-90 * time.Minute)),
 			want:        false,
 		},
 		{


### PR DESCRIPTION
## What

Bound the missing-dependency wait when `spec.TimeoutSeconds` is unset, so
#1687's cascade-fail can actually fire for planner-emitted tasks.

## Why

Refs #1729

`depWaitExpired` treated an unset or zero `TimeoutSeconds` as an unbounded wait
and returned `false` immediately. The Workload planner never stamps the field,
so every planner-emitted dependent task took that path and #1687's cascade-fail
was dead code for them. A task whose dependency was deleted stayed Pending
forever, and the Workload kept reporting it as in-flight.

Stale objects are not cosmetic on a MicroK8s/dqlite control plane: accumulated
dead objects here have previously bloated dqlite and frozen kubelet's pod watch,
so tasks that can never terminate carry real operational cost.

## How

`depWaitExpired` falls back to a new package-level `defaultDepWaitBudget` of one
hour when the field is `<= 0`. An explicitly set positive `TimeoutSeconds` still
wins unchanged.

The issue left the choice open between stamping a default in the planner and
falling back in `depWaitExpired`. The fallback was chosen: stamping only fixes
today's emitter, while the fallback closes the hole for any future caller that
also forgets to set the field.

One hour is reasoned rather than picked: this guard measures a dependency that
is **absent**, not one that is slow. The planner emits every task in a batch
together, so a dependency that has not appeared within an hour was deleted or
never emitted, and waiting longer cannot help it appear.

The godoc above `depWaitExpired` previously stated that unset leaves the wait
unbounded. That became false, so it was rewritten rather than left to mislead.

### Scope

Piece 1 of the issue only. #1729 also asks for the Workload's Dispatched
condition to reconcile its child count against the planned count, so a missing
child reads as a problem instead of as in-flight work. That is a different file
and a different condition, and it is deliberately left for its own change.

Reviewers should expect the automated reviewer's finding about that second half.
It is accurate about the issue and out of scope for this branch; the finding
cites `workload_controller.go:805`, which this diff does not touch, so the
grounded-finding rail correctly left the verdict standing.

## Tests

Three regression cases in `agentictask_missing_dep_test.go`:

- unset `TimeoutSeconds` with `DepWaitStarted` older than the fallback: expired
- unset with a recent `DepWaitStarted`: not expired
- an explicit positive `TimeoutSeconds` still governs and is not replaced by the
  fallback

The third is the safety boundary. The coder's own mutation check reverted the
fallback and confirmed case 1 fails without it, and the gate's independent bite
check reported "tests fail against pre-change production (biting test, good)".

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — the full suite ran in the clean-room gate Job
      for this branch (GATE PASS), including the envtest packages
- [x] `make lint` passes locally — same gate Job runs fmt, vet, lint and
      lint-deadcode
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: authored by the Foreman coder agent
      (DeepSeek V4 Flash, self-hosted) under band 3 of CONTRIBUTING.md, reviewed
      by the automated reviewer and by the maintainer, who owns this review
      conversation.
- [ ] Documentation updated — no user-facing change

`Refs` rather than `Fixes`, since #1729 also covers the child-count reconciliation
that this branch deliberately does not address.
