### PR TITLE
fix(controller): make zero-findings scope-overlap demotion inert

### DIFF
--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -167,8 +167,8 @@ func taskStepLabel(t *foremanv1alpha1.AgenticTask) string {
 	return t.Name
 }
 
-// inertDemotion reports whether a NO-GO was manufactured by the issueAsk
-// rail rather than asserted by the reviewer, AND carries nothing to act on
+// inertDemotion reports whether a NO-GO was manufactured by a harness rail
+// rather than asserted by the reviewer, AND carries nothing to act on
 // (#1636). It returns the rail's demotionReason so the caller can record
 // why the fix iteration did not run.
 //
@@ -183,10 +183,14 @@ func taskStepLabel(t *foremanv1alpha1.AgenticTask) string {
 // Three conditions are required, and each one excludes a NO-GO the coder
 // CAN act on:
 //
-//   - verdictDemotedBy is the issueAsk rail. enforceReviewerScopeOverlap
-//     (scope_overlap.go) also demotes, but its verdict says the diff
-//     touches none of the files the issue names, which is real work.
-//     Keying off the bare verdictDemoted flag would suppress those too.
+//   - verdictDemotedBy is the issueAsk or scope-overlap rail. A rail that
+//     rewrites a GO without findings manufactures a rejection the coder
+//     cannot act on: re-running cannot make an unverifiable issueAsk verify,
+//     and an issue that names the symptom file rather than the fix site is
+//     scope drift the coder already answered by fixing the cause (#1684).
+//     Keying off the bare verdictDemoted flag alone would not distinguish
+//     these two rails from each other, but both are inert when they carry
+//     no findings, so the single condition below accepts either name.
 //   - verdictClaimed is GO, i.e. the rail really did rewrite the verdict.
 //     enforceReviewerIssueAsk stamps the demotion fields on a path where
 //     it does NOT: an unverified non-GO review is marked untrusted and the
@@ -213,7 +217,7 @@ func inertDemotion(t *foremanv1alpha1.AgenticTask) (reason string, inert bool) {
 		return "", false
 	}
 	modelExtra := envelope.Extra.ModelExtra
-	if by, _ := modelExtra["verdictDemotedBy"].(string); by != reviewer.RailIssueAsk {
+	if by, _ := modelExtra["verdictDemotedBy"].(string); by != reviewer.RailIssueAsk && by != reviewer.RailScopeOverlap {
 		return "", false
 	}
 	if claimed, _ := modelExtra["verdictClaimed"].(string); claimed != string(foremanv1alpha1.AgenticTaskVerdictGo) {

--- a/internal/foreman/controller/workload_iteration_test.go
+++ b/internal/foreman/controller/workload_iteration_test.go
@@ -223,19 +223,37 @@ func TestReviewIterationSteps(t *testing.T) {
 			wantIterated: []int32{641},
 		},
 		{
-			// Rail-identity guard (#1641): enforceReviewerScopeOverlap also
-			// demotes a GO to NO-GO and also stamps verdictDemoted, but its
-			// verdict says the diff touches none of the files the issue
-			// names. That IS actionable, so it must iterate even with no
-			// structured findings. A predicate keyed off the bare
-			// verdictDemoted flag would swallow it.
-			name: "scope-overlap demotion of a GO with no findings still iterates",
+			// #1684: a scope-overlap demotion of a GO carrying NO findings
+			// is inert, exactly like the issueAsk case (#1636). An issue
+			// that names the file where a bug is OBSERVED while the fix
+			// belongs where the bug is CAUSED demotes the correct diff; the
+			// coder cannot act on the bare drift, so suppressing the
+			// iteration (instead of opening an unconvergeable revision
+			// cycle) is the right consequence. Detection still happens; only
+			// the consequence weakens.
+			name: "scope-overlap demotion of a GO with no findings is inert",
 			w:    iterationWorkload([]int32{641}, 1, nil),
 			children: []foremanv1alpha1.AgenticTask{
 				child("code-641", succeeded, goVerdict),
 				child("verify-641", succeeded, gatePass),
 				railDemotedNoGoChild(reviewer.RailScopeOverlap, string(goVerdict),
 					demotionReasonScopeDrift, "APPROVE: looks good to me", `[]`),
+			},
+			wantSuppressed: []string{reviewStep},
+		},
+		{
+			// #1684 safety boundary: a scope-overlap demotion is only inert
+			// when it carries nothing to fix. A demotion WITH findings names
+			// concrete work the coder can address, so it must still open an
+			// iteration even though the rail is scope-overlap.
+			name: "scope-overlap demotion carrying findings still iterates",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				railDemotedNoGoChild(reviewer.RailScopeOverlap, string(goVerdict),
+					demotionReasonScopeDrift, "scope drift plus a real defect",
+					`[{"severity":"major","area":"scope","message":"the fix must also touch the config loader"}]`),
 			},
 			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
 			wantIterated: []int32{641},


### PR DESCRIPTION
## What

Make a zero-findings scope-overlap demotion inert, so it annotates the verdict
instead of opening a revision iteration.

## Why

Refs #1684

`enforceReviewerScopeOverlap` demotes a GO when the diff touches none of the
files the issue body names. That is the right check for a coder that wandered
off target, but it systematically false-positives on a common and legitimate
issue shape: **an issue names the file where a bug is observed, while the fix
belongs where the bug is caused.**

Because scope drift is normally actionable, `inertDemotion` does not suppress
it, so a revision iteration opens and the coder either redoes correct work or
returns `ALREADY-RESOLVED` after rediscovering its own fix. Three occurrences in
a single day, all on correct diffs. One cycle cost 21 minutes of GPU, another 3.

It also penalises exactly the diffs we want: a coder that traced a symptom to
its cause and fixed the cause is punished, while one that patched the symptom in
the named file passes.

## The decision this PR makes

#1684 deliberately did not choose a fix. Its Expected Behavior section says the
choice "should be made by a human, not inferred", and lists three:

1. **Widen the anchor.** Accept a diff touching the same package, or files
   reachable from the named symbol.
2. **Weaken the consequence.** Keep detecting drift, but make a zero-findings
   scope demotion inert.
3. **Fix it at the source.** Require issues destined for agents to name the fix
   site.

**This PR implements option 2**, chosen by the maintainer.

The precedent already shipped and lives in the same function. `inertDemotion`
already treats a zero-findings **issueAsk** demotion as inert (`4ac7e6be`, #1641,
closing #1636). A zero-findings **scope-overlap** demotion has the identical
property: it rewrites a verdict without handing the coder anything actionable.
Putting it in the same set is one condition rather than new machinery.

Option 1 means inventing heuristics with their own false-positive profiles and
no data to tune against. Option 3 is a process change, cannot be enforced, and
does nothing for the existing backlog.

## How

One condition widened in `inertDemotion`:

```go
-if by, _ := modelExtra["verdictDemotedBy"].(string); by != reviewer.RailIssueAsk {
+if by, _ := modelExtra["verdictDemotedBy"].(string); by != reviewer.RailIssueAsk && by != reviewer.RailScopeOverlap {
```

Every other condition is untouched: the `verdictClaimed == GO` check, the
`ParseFindings` length check, and the raw-findings shape fallback all still gate
inertness. Detection in `enforceReviewerScopeOverlap` is unchanged; only the
consequence weakens.

The godoc above `inertDemotion` previously argued the opposite case explicitly,
saying a scope-overlap verdict "is real work" and must not be suppressed. That
reasoning is now false, so it was rewritten rather than left to contradict the
code.

## What this gives up

Worth stating plainly. A **genuine** scope drift that carries no findings no
longer opens a revision cycle; it becomes an annotation. A coder that really did
wander off target, in a case where the reviewer also produced zero structured
findings, now passes quietly.

Two things bound that. Detection still runs and the demotion is still recorded
in the envelope, so it stays visible in the audit trail. And a scope-overlap
demotion **with** findings still opens an iteration, which is the safety
property this change must not break.

## Tests

The existing case asserting "scope-overlap demotion of a GO with no findings
still iterates" is inverted, since that behaviour is what changed. A new case is
added for the boundary: a scope-overlap demotion **carrying findings** still
iterates.

The coder's mutation check reverted the one-line widening and confirmed the new
case fails without it (`suppressed = [], want [review-641-0]`).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — the full suite ran in the clean-room gate Job
      for this branch (GATE PASS), including the envtest packages
- [x] `make lint` passes locally — same gate Job runs fmt, vet, lint and
      lint-deadcode
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: authored by the Foreman coder agent
      (DeepSeek V4 Flash, self-hosted) under band 3 of CONTRIBUTING.md. The
      design decision between the issue's three options was made by the
      maintainer, not the agent, and the maintainer owns this review
      conversation.
- [ ] Documentation updated — no user-facing change

`Refs` rather than `Fixes`: the false-positive rate in practice is the real
measure, and #1684 should close once scope-drift revision cycles are observed to
have stopped on real runs.
