### PR TITLE
fix(foreman): clear Dispatched condition on terminal Workloads

### DIFF
--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -96,6 +96,13 @@ const conditionTypeTruncated = "Truncated"
 // a terminal way.
 const conditionTypeCompleted = "Completed"
 
+// conditionTypeDispatched is True while children are still in flight, and
+// flips to False (with a reason naming the terminal outcome) when the
+// Workload reaches a terminal phase. Keeping it as a False condition (rather
+// than deleting it) keeps `kubectl wait --for=condition=Dispatched=false`
+// usable and records when dispatch actually ended via LastTransitionTime.
+const conditionTypeDispatched = "Dispatched"
+
 // conditionTypeCloudReviewersSuppressed is True when the sovereignty
 // gates (operator --allow-cloud-providers + Workload AllowCloudReviewers)
 // caused the reconciler to omit one or more reviewer Agents from the
@@ -755,6 +762,7 @@ func computeTerminalState(w *foremanv1alpha1.Workload, c childCounts, now metav1
 			Message:            fmt.Sprintf("%d/%d child tasks on-target Succeeded", c.succeeded, c.total),
 			LastTransitionTime: now,
 		})
+		setDispatchedTerminal(&w.Status.Conditions, "AllChildrenSucceeded", now)
 	case c.inFlight == 0 && c.failed == 0 && c.incomplete == 0 && c.succeeded == 0 && c.alreadyResolved > 0:
 		// Pure ALREADY-RESOLVED workload — nothing actually attempted.
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseCompleted
@@ -767,6 +775,7 @@ func computeTerminalState(w *foremanv1alpha1.Workload, c childCounts, now metav1
 			Message:            msg,
 			LastTransitionTime: now,
 		})
+		setDispatchedTerminal(&w.Status.Conditions, "AllAlreadyResolved", now)
 	case c.inFlight == 0 && c.failed == 0 && c.incomplete == 0:
 		// Mixed: at least one on-target succeeded AND at least one
 		// already-resolved. Still Completed; mention both.
@@ -780,6 +789,7 @@ func computeTerminalState(w *foremanv1alpha1.Workload, c childCounts, now metav1
 			Message:            msg,
 			LastTransitionTime: now,
 		})
+		setDispatchedTerminal(&w.Status.Conditions, "AllChildrenSucceeded", now)
 	case c.inFlight == 0 && (c.failed > 0 || c.incomplete > 0):
 		// Any incomplete OR failed child rolls the Workload to Failed
 		// terminal state. ALREADY-RESOLVED and Skipped children do not
@@ -797,10 +807,11 @@ func computeTerminalState(w *foremanv1alpha1.Workload, c childCounts, now metav1
 				c.succeeded, c.incomplete, c.failed, c.total, c.alreadyResolved),
 			LastTransitionTime: now,
 		})
+		setDispatchedTerminal(&w.Status.Conditions, reason, now)
 	default:
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseDispatched
 		setCondition(&w.Status.Conditions, metav1.Condition{
-			Type:   "Dispatched",
+			Type:   conditionTypeDispatched,
 			Status: metav1.ConditionTrue,
 			Reason: "ChildrenInFlight",
 			Message: fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed, %d already-resolved",
@@ -808,6 +819,21 @@ func computeTerminalState(w *foremanv1alpha1.Workload, c childCounts, now metav1
 			LastTransitionTime: now,
 		})
 	}
+}
+
+// setDispatchedTerminal flips the Dispatched condition to False with a
+// Reason naming the terminal outcome once a Workload reaches a terminal
+// phase. The condition is kept (not deleted) so
+// `kubectl wait --for=condition=Dispatched=false` stays usable and
+// LastTransitionTime records when dispatch actually ended (#1739).
+func setDispatchedTerminal(conds *[]metav1.Condition, reason string, now metav1.Time) {
+	setCondition(conds, metav1.Condition{
+		Type:               conditionTypeDispatched,
+		Status:             metav1.ConditionFalse,
+		Reason:             reason,
+		Message:            "dispatch ended; workload reached a terminal phase",
+		LastTransitionTime: now,
+	})
 }
 
 // emitAlreadyResolvedCondition sets the CoderAlreadyResolved condition

--- a/internal/foreman/controller/workload_rollup_slicer_test.go
+++ b/internal/foreman/controller/workload_rollup_slicer_test.go
@@ -67,6 +67,87 @@ func TestClassifyChildren_SlicerVerdicts(t *testing.T) {
 	}
 }
 
+// TestComputeTerminalState_DispatchedCondition locks in #1739: a terminal
+// Workload flips Dispatched to ConditionFalse (with a reason naming the
+// terminal outcome) instead of leaving it True, while an in-flight Workload
+// keeps Dispatched True. The condition is set (not deleted) on every
+// terminal branch so `kubectl wait --for=condition=Dispatched=false` stays
+// usable and LastTransitionTime records when dispatch ended.
+func TestComputeTerminalState_DispatchedCondition(t *testing.T) {
+	now := metav1.Now()
+
+	tests := []struct {
+		name            string
+		counts          childCounts
+		wantPhase       foremanv1alpha1.WorkloadPhase
+		wantDispatched  metav1.ConditionStatus
+		wantDispatchRsn string
+	}{
+		{
+			name:            "all children succeeded is terminal",
+			counts:          childCounts{succeeded: 3, total: 3},
+			wantPhase:       foremanv1alpha1.WorkloadPhaseCompleted,
+			wantDispatched:  metav1.ConditionFalse,
+			wantDispatchRsn: "AllChildrenSucceeded",
+		},
+		{
+			name:            "pure already-resolved is terminal",
+			counts:          childCounts{alreadyResolved: 1, resolvedIssues: []int32{42}, total: 1},
+			wantPhase:       foremanv1alpha1.WorkloadPhaseCompleted,
+			wantDispatched:  metav1.ConditionFalse,
+			wantDispatchRsn: "AllAlreadyResolved",
+		},
+		{
+			name:            "mixed on-target and already-resolved is terminal",
+			counts:          childCounts{succeeded: 2, alreadyResolved: 1, resolvedIssues: []int32{7}, total: 3},
+			wantPhase:       foremanv1alpha1.WorkloadPhaseCompleted,
+			wantDispatched:  metav1.ConditionFalse,
+			wantDispatchRsn: "AllChildrenSucceeded",
+		},
+		{
+			name:            "failed child rolls to Failed",
+			counts:          childCounts{failed: 1, succeeded: 2, total: 3},
+			wantPhase:       foremanv1alpha1.WorkloadPhaseFailed,
+			wantDispatched:  metav1.ConditionFalse,
+			wantDispatchRsn: "ChildrenFailed",
+		},
+		{
+			name:            "incomplete child rolls to Failed",
+			counts:          childCounts{incomplete: 1, total: 1},
+			wantPhase:       foremanv1alpha1.WorkloadPhaseFailed,
+			wantDispatched:  metav1.ConditionFalse,
+			wantDispatchRsn: "ChildrenIncomplete",
+		},
+		{
+			name:            "in-flight child stays Dispatched",
+			counts:          childCounts{inFlight: 1, total: 1},
+			wantPhase:       foremanv1alpha1.WorkloadPhaseDispatched,
+			wantDispatched:  metav1.ConditionTrue,
+			wantDispatchRsn: "ChildrenInFlight",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			w := &foremanv1alpha1.Workload{}
+			computeTerminalState(w, tc.counts, now)
+
+			if w.Status.Phase != tc.wantPhase {
+				t.Errorf("Phase = %q, want %q", w.Status.Phase, tc.wantPhase)
+			}
+			cond := apimeta.FindStatusCondition(w.Status.Conditions, conditionTypeDispatched)
+			if cond == nil {
+				t.Fatalf("Dispatched condition not present")
+			}
+			if cond.Status != tc.wantDispatched {
+				t.Errorf("Dispatched status = %q, want %q", cond.Status, tc.wantDispatched)
+			}
+			if cond.Reason != tc.wantDispatchRsn {
+				t.Errorf("Dispatched reason = %q, want %q", cond.Reason, tc.wantDispatchRsn)
+			}
+		})
+	}
+}
+
 // withContradictionsEnvelope builds a complete result envelope that
 // carries the given cross-stage contradiction strings under
 // extra.crossStageContradictions (the shape the detector writes).


### PR DESCRIPTION
## What

Flip the `Dispatched` condition to `False` when a Workload reaches a terminal
phase, so a Completed Workload stops advertising work in flight.

## Why

Refs #1739

`"Dispatched"` was written in exactly one place, the `default:` branch of the
terminal-state switch, and never touched again. The terminal branches set the
`Completed` condition and left `Dispatched` holding whatever the last in-flight
pass wrote. The condition was write-only on one path and never reconciled on the
others.

Observed on `wl-1729-depwait-default`, and identically on `wl-1684-scope-inert`:

```
phase: Completed
  Dispatched True   1 in-flight, 2 on-target, 0 incomplete, 0 failed, 0 already-resolved
  Completed  True   3/3 child tasks on-target Succeeded
```

All three children had reached Succeeded. The Workload is Completed. The
condition still claimed one child was in flight.

## How

A `setDispatchedTerminal` helper sets the condition to `ConditionFalse` with a
`Reason` naming the terminal outcome, called from **every** branch that sets a
terminal phase: all-succeeded, pure already-resolved, the mixed
succeeded-plus-already-resolved case, and the failed case. Missing any one of
them would leave the same stale condition on that path.

The condition is flipped rather than deleted. A condition that disappears is
harder to consume than one that reads False: `kubectl wait
--for=condition=Dispatched=false` stays usable, and `LastTransitionTime` then
records when dispatch actually ended. Leaving it True with corrected counts
would still misreport the state, which is the bug.

The string literal is also replaced with a `conditionTypeDispatched` constant,
matching how `conditionTypeCompleted` and the other condition types in this file
are already declared.

## Scope

Deliberately separate from #1738, which reconciles the child count against the
planned count. Both touch this switch, but they are different branches,
different fixes and different tests. `classifyChildren` is untouched and the
`Completed` condition's reason and message are unchanged.

## Tests

- a Workload that reaches a terminal phase: `Dispatched` is present and
  `ConditionFalse`
- a Workload still in flight: `Dispatched` remains `ConditionTrue`

The second case is what stops a naive implementation from simply hard-coding the
condition to False.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — ran in full in the clean-room gate Job for
      this branch (GATE-PASS), including the envtest packages
- [x] `make lint` passes locally — the same gate Job runs fmt, vet, lint and
      lint-deadcode
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: authored by the Foreman coder agent
      (DeepSeek V4 Flash, self-hosted) under band 3 of CONTRIBUTING.md, reviewed
      by the automated reviewer and by the maintainer, who owns this review
      conversation.
- [ ] Documentation updated — no user-facing change

Note for merging: this PR and the one for #1738 both edit the `default:` branch
of the same switch and **do** conflict. Merge one, then rebase the other.
