### PR TITLE
fix(agent): skip comment-only hunks in the per-hunk mutation pass

### DIFF
--- a/pkg/foreman/agent/mutation_gate.go
+++ b/pkg/foreman/agent/mutation_gate.go
@@ -959,6 +959,22 @@ type productionHunk struct {
 //
 // The diff is taken against base (the fork point), not the plain working-tree
 // diff, so it is independent of whether an earlier gate staged the tree.
+//
+// A hunk is only a candidate when at least one of its lines is a plausible Go
+// statement: after strings.TrimSpace it is non-empty and does not start with
+// "//". A comment-only hunk is dropped here, in flush, not in the caller: the
+// per-hunk pass reverts each candidate and reports it uncovered when the
+// package's tests stay green, and reverting a comment can never turn a test
+// red, so an unfiltered comment-only hunk is reported as uncovered forever
+// (the #1735 false positive on a godoc that had to change). Filtering in flush
+// also keeps CheckPerHunkCoverage's maxPerHunkHunks budget honest: a hunk that
+// was never a candidate should not consume the budget.
+//
+// Gap accepted deliberately: a `/* */` block comment is not caught by a "//"
+// prefix test. Tracking block-comment state line by line is out of scope here;
+// the "//" case is the one actually being hit, and a block-comment-only hunk
+// is a far rarer shape that the same false positive would surface if it ever
+// matters.
 func splitProductionHunks(ctx context.Context, workspace, base, file string, run commandRunner) []productionHunk {
 	out, err := run(ctx, workspace, nil, "git", "diff", "-U0", base, "HEAD", "--", file)
 	if err != nil {
@@ -969,8 +985,22 @@ func splitProductionHunks(ctx context.Context, workspace, base, file string, run
 	var start int
 	flush := func() {
 		if len(cur) > 0 {
-			end := start + len(cur) - 1
-			hunks = append(hunks, productionHunk{Lines: cur, LineRange: fmt.Sprintf("%d-%d", start, end)})
+			// Drop hunks with no plausible statement (only comments and/or
+			// blank lines): reverting them can never turn a test red, so they
+			// would be reported uncovered forever, and they should not consume
+			// the caller's hunk budget.
+			plausible := false
+			for _, l := range cur {
+				trimmed := strings.TrimSpace(l)
+				if trimmed != "" && !strings.HasPrefix(trimmed, "//") {
+					plausible = true
+					break
+				}
+			}
+			if plausible {
+				end := start + len(cur) - 1
+				hunks = append(hunks, productionHunk{Lines: cur, LineRange: fmt.Sprintf("%d-%d", start, end)})
+			}
 			cur = nil
 		}
 	}

--- a/pkg/foreman/agent/mutation_gate_test.go
+++ b/pkg/foreman/agent/mutation_gate_test.go
@@ -697,3 +697,54 @@ func TestCheckPerHunkCoverage_BoundedAndReportsTruncation(t *testing.T) {
 		t.Fatalf("checked %d packages, bound is %d", pkgFindings, maxPerHunkPackages)
 	}
 }
+
+// TestSplitProductionHunks_DropsCommentOnlyHunk is the regression test for
+// #1735: an added block that contains only "//" comment lines carries no Go
+// statement, so reverting it can never turn a test red and the per-hunk pass
+// would report it uncovered forever. splitProductionHunks must not emit it as
+// a candidate at all.
+func TestSplitProductionHunks_DropsCommentOnlyHunk(t *testing.T) {
+	diff := "diff --git a/x/x.go b/x/x.go\n" +
+		"@@ -0,0 +3,2 @@\n+// first comment\n+// second comment\n"
+	run := func(_ context.Context, _ string, _ []string, _ string, _ ...string) (string, error) {
+		return diff, nil
+	}
+	got := splitProductionHunks(context.Background(), "/ws", "main", "x/x.go", run)
+	if len(got) != 0 {
+		t.Fatalf("comment-only hunk must be dropped, got %d hunks: %#v", len(got), got)
+	}
+}
+
+// TestSplitProductionHunks_KeepsMixedHunk is the boundary test: a hunk that
+// mixes a comment line and a real statement still contains a plausible Go
+// statement, so it MUST be kept. Dropping it would silently stop checking real
+// code that happens to sit next to a comment.
+func TestSplitProductionHunks_KeepsMixedHunk(t *testing.T) {
+	diff := "diff --git a/x/x.go b/x/x.go\n" +
+		"@@ -0,0 +3,2 @@\n+// comment above the statement\n+\t_ = compute()\n"
+	run := func(_ context.Context, _ string, _ []string, _ string, _ ...string) (string, error) {
+		return diff, nil
+	}
+	got := splitProductionHunks(context.Background(), "/ws", "main", "x/x.go", run)
+	if len(got) != 1 {
+		t.Fatalf("mixed hunk must be kept, got %d hunks: %#v", len(got), got)
+	}
+	if got[0].LineRange != "3-4" {
+		t.Errorf("LineRange = %q, want 3-4", got[0].LineRange)
+	}
+}
+
+// TestSplitProductionHunks_DropsBlankOnlyHunk verifies a hunk of only blank
+// lines is also not a candidate: it carries no statement either, so it would
+// hit the same false positive.
+func TestSplitProductionHunks_DropsBlankOnlyHunk(t *testing.T) {
+	diff := "diff --git a/x/x.go b/x/x.go\n" +
+		"@@ -0,0 +3,2 @@\n+\n+\n"
+	run := func(_ context.Context, _ string, _ []string, _ string, _ ...string) (string, error) {
+		return diff, nil
+	}
+	got := splitProductionHunks(context.Background(), "/ws", "main", "x/x.go", run)
+	if len(got) != 0 {
+		t.Fatalf("blank-only hunk must be dropped, got %d hunks: %#v", len(got), got)
+	}
+}


### PR DESCRIPTION
## What

Skip comment-only hunks in the per-hunk mutation coverage pass, so updating a
stale godoc stops earning a `GATE-WARN`.

## Why

Refs #1735

The pass reverts each added hunk and reports it uncovered when the package's
tests stay green. Reverting a comment can never turn a test red, so **every**
comment-only hunk is reported as uncovered, on every run, forever. This is
systematic rather than occasional.

Observed on `wl-1729-depwait-default-verify-1729`:

```
=== per-hunk mutation coverage (base=2b35d71454058abe91cdf5a22c5a42e6890ebceb) ===
GATE-WARN: hunk check: package internal/foreman/controller has an uncovered hunk
           in internal/foreman/controller/agentictask_controller.go:599-602
```

Lines 599-602 on that branch contain **zero** non-comment lines. They are the
godoc above `depWaitExpired`, updated in the same change because the previous
text ("An unset or zero TimeoutSeconds leaves the wait unbounded") had been made
false by that change.

So the check penalised exactly the behaviour we ask coders for. The real
behavioural change in that diff was not flagged, correctly: the same run's
all-or-nothing bite check reported "tests fail against pre-change production
(biting test, good)".

`CheckPerHunkCoverage`'s own godoc says it is "Reporting only ... until the
false-positive rate on real diffs is known". On the first real diff observed,
the only finding it produced was a false positive.

## How

`splitProductionHunks` records a hunk only when at least one of its lines,
after `strings.TrimSpace`, is non-empty and does not begin with `//`.

The filter lives in the `flush` closure, not in the caller. That placement is
deliberate: a hunk dropped in `flush` never becomes a `productionHunk`, so it
also never consumes `CheckPerHunkCoverage`'s `maxPerHunkHunks` budget. A hunk
that was never a candidate should not use up the budget that bounds how many
real candidates get checked.

`CheckPerHunkCoverage`'s classification logic is untouched. What changes is
which hunks become candidates, not what makes a candidate uncovered.

### Accepted gap, documented in the godoc

A `/* */` block comment is not caught by a `//` prefix test. Tracking
block-comment state line by line is out of scope here, and the godoc says so
rather than implying the filter is complete. The `//` case is the one actually
being hit; a block-comment-only hunk would surface the same false positive and
can be handled if it ever appears.

## Tests

- an added block of only `//` comment lines: no hunk
- an added block mixing a comment line and a real statement: one hunk, **not**
  dropped
- an added block of only blank lines: no hunk

The mixed case is the boundary that matters. Dropping a mixed hunk would
silently stop checking real code, which would turn a noisy check into a blind
one.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally — ran in full in the clean-room gate Job for
      this branch (GATE-PASS)
- [x] `make lint` passes locally — the same gate Job runs fmt, vet, lint and
      lint-deadcode
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: authored by the Foreman coder agent
      (DeepSeek V4 Flash, self-hosted) under band 3 of CONTRIBUTING.md, reviewed
      by the automated reviewer and by the maintainer, who owns this review
      conversation.
- [ ] Documentation updated — no user-facing change
