### PR TITLE
feat(foreman): report missing planned children in Dispatched condition

### DIFF
--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -584,6 +584,12 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 // the wiring.
 func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
 	cls := classifyChildren(children)
+	// Report planned children the Workload can no longer observe. This
+	// must match by NAME, never by count (#1738): escalation and
+	// iteration synthesize EXTRA placeholder children that are not in
+	// w.Status.Tasks, so len(children) can legitimately exceed the
+	// planned count and a length comparison would flap.
+	cls.missingTasks = missingPlannedTasks(w.Status.Tasks, children)
 
 	// Capture the patch BEFORE mutating w.Status — the patch's
 	// "original" snapshot must reflect the on-cluster state for the
@@ -633,6 +639,28 @@ type childCounts struct {
 	resolvedIssues                          []int32
 	resolvedByList                          []string
 	total                                   int32
+	missingTasks                            []string
+}
+
+// missingPlannedTasks returns the names of the Workload's planned task
+// references (w.Status.Tasks) that are absent from the observed children,
+// sorted for a stable message. It matches by name only and ignores any
+// observed child that is not a planned ref, so synthetic placeholder
+// children (escalation / iteration / informer-lag) never read as a
+// missing child (#1738).
+func missingPlannedTasks(planned []corev1.ObjectReference, children []foremanv1alpha1.AgenticTask) []string {
+	observed := make(map[string]struct{}, len(children))
+	for i := range children {
+		observed[children[i].Name] = struct{}{}
+	}
+	var missing []string
+	for _, ref := range planned {
+		if _, ok := observed[ref.Name]; !ok {
+			missing = append(missing, ref.Name)
+		}
+	}
+	sort.Strings(missing)
+	return missing
 }
 
 // classifyChildren walks the children slice and returns the bucket
@@ -810,12 +838,22 @@ func computeTerminalState(w *foremanv1alpha1.Workload, c childCounts, now metav1
 		setDispatchedTerminal(&w.Status.Conditions, reason, now)
 	default:
 		w.Status.Phase = foremanv1alpha1.WorkloadPhaseDispatched
+		reason := "ChildrenInFlight"
+		message := fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed, %d already-resolved",
+			c.inFlight, c.succeeded, c.incomplete, c.failed, c.alreadyResolved)
+		if len(c.missingTasks) > 0 {
+			// A planned child is gone (deleted by hand or otherwise).
+			// This is diagnosability, not enforcement: the Workload
+			// stays Dispatched and its phase is unchanged (#1738).
+			reason = "ChildrenMissing"
+			message = fmt.Sprintf("%d planned child task(s) missing: %s; %s",
+				len(c.missingTasks), strings.Join(c.missingTasks, ", "), message)
+		}
 		setCondition(&w.Status.Conditions, metav1.Condition{
-			Type:   conditionTypeDispatched,
-			Status: metav1.ConditionTrue,
-			Reason: "ChildrenInFlight",
-			Message: fmt.Sprintf("%d in-flight, %d on-target, %d incomplete, %d failed, %d already-resolved",
-				c.inFlight, c.succeeded, c.incomplete, c.failed, c.alreadyResolved),
+			Type:               conditionTypeDispatched,
+			Status:             metav1.ConditionTrue,
+			Reason:             reason,
+			Message:            message,
 			LastTransitionTime: now,
 		})
 	}

--- a/internal/foreman/controller/workload_controller.go
+++ b/internal/foreman/controller/workload_controller.go
@@ -200,8 +200,10 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		// Downstream consumers judge each issue by its LATEST fix
 		// iteration: a superseded round's terminal NO-GO must neither
 		// re-fire escalation nor pin the rollup at Failed after a later
-		// round converged.
-		children = activeChildren(&workload, children)
+		// round converged. observeChildren also reports the planned refs
+		// that are genuinely gone, computed before that filtering (#1743).
+		var missingPlanned []string
+		children, missingPlanned = observeChildren(&workload, children)
 
 		// Second-pass emission (#546): escalation reviewers fire here,
 		// after base reviewer verdicts land, before status rollup.
@@ -210,7 +212,7 @@ func (r *WorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, fmt.Errorf("emit escalations: %w", err)
 		}
 		// Roll up child phases into the Workload's status.
-		return r.rollup(ctx, &workload, children)
+		return r.rollup(ctx, &workload, children, missingPlanned)
 	}
 
 	// No children yet -> first reconcile. Decide which mode and render.
@@ -582,14 +584,19 @@ func (r *WorkloadReconciler) listChildren(ctx context.Context, w *foremanv1alpha
 // computeTerminalState, emitAlreadyResolvedCondition) to keep each
 // piece under the gocyclo threshold; the orchestrator here is just
 // the wiring.
-func (r *WorkloadReconciler) rollup(ctx context.Context, w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask) (ctrl.Result, error) {
+func (r *WorkloadReconciler) rollup(
+	ctx context.Context,
+	w *foremanv1alpha1.Workload,
+	children []foremanv1alpha1.AgenticTask,
+	missingPlanned []string,
+) (ctrl.Result, error) {
 	cls := classifyChildren(children)
-	// Report planned children the Workload can no longer observe. This
-	// must match by NAME, never by count (#1738): escalation and
-	// iteration synthesize EXTRA placeholder children that are not in
-	// w.Status.Tasks, so len(children) can legitimately exceed the
-	// planned count and a length comparison would flap.
-	cls.missingTasks = missingPlannedTasks(w.Status.Tasks, children)
+	// Report planned children the Workload can no longer observe.
+	// missingPlanned is computed by observeChildren from the UNFILTERED
+	// observation, because `children` here has already had superseded
+	// rounds removed and those rounds are still alive in the cluster
+	// (#1743).
+	cls.missingTasks = missingPlanned
 
 	// Capture the patch BEFORE mutating w.Status — the patch's
 	// "original" snapshot must reflect the on-cluster state for the
@@ -661,6 +668,29 @@ func missingPlannedTasks(planned []corev1.ObjectReference, children []foremanv1a
 	}
 	sort.Strings(missing)
 	return missing
+}
+
+// observeChildren turns one observation of a Workload's children into the
+// two things rollup needs: the planned refs that are genuinely gone, and
+// the child set judged by each issue's latest attempt.
+//
+// The order is load-bearing (#1743). activeChildren drops rounds that a
+// later attempt superseded, and those rounds never leave w.Status.Tasks:
+// markPlanned assigns that list wholesale, appendNewTaskRefs only appends
+// to it, and nothing trims it. Computing the missing report from the
+// FILTERED set therefore reports every superseded round as missing for as
+// long as the retry round runs, which is precisely the cry-wolf the report
+// exists to avoid. Computing it first sees the superseded round alive.
+//
+// Emissions that both create children and record their refs (iteration,
+// coder escalation, reviewer escalation) are consistent either side of
+// this call: a ref and its child appear together, so neither a
+// just-planned nor a not-yet-planned task reads as missing here.
+func observeChildren(
+	w *foremanv1alpha1.Workload, children []foremanv1alpha1.AgenticTask,
+) ([]foremanv1alpha1.AgenticTask, []string) {
+	missing := missingPlannedTasks(w.Status.Tasks, children)
+	return activeChildren(w, children), missing
 }
 
 // classifyChildren walks the children slice and returns the bucket

--- a/internal/foreman/controller/workload_rollup_slicer_test.go
+++ b/internal/foreman/controller/workload_rollup_slicer_test.go
@@ -419,3 +419,99 @@ func TestRollup_ContradictedTasksAndCondition(t *testing.T) {
 		t.Errorf("condition message does not name the first contradiction: %q", cond.Message)
 	}
 }
+
+// TestRollup_ChildrenMissing drives rollup over planned-vs-observed
+// children and asserts the Dispatched condition reports planned children
+// the Workload can no longer see (#1738). The check MUST match by NAME,
+// never by count: escalation and iteration synthesize extra placeholder
+// children that are not in w.Status.Tasks, so a length comparison would
+// flap and cry wolf on every escalation.
+func TestRollup_ChildrenMissing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := foremanv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add foreman scheme: %v", err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	taskRef := func(name string) corev1.ObjectReference {
+		return corev1.ObjectReference{Name: name}
+	}
+	child := func(name string) foremanv1alpha1.AgenticTask {
+		return foremanv1alpha1.AgenticTask{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: foremanv1alpha1.GroupVersion.String(),
+					Kind:       "Workload",
+					Name:       "missing-wl",
+				}},
+			},
+			Status: foremanv1alpha1.AgenticTaskStatus{
+				Phase: foremanv1alpha1.AgenticTaskPhasePending,
+			},
+		}
+	}
+
+	dispatched := func(w *foremanv1alpha1.Workload) *metav1.Condition {
+		return apimeta.FindStatusCondition(w.Status.Conditions, "Dispatched")
+	}
+
+	tests := []struct {
+		name        string
+		planned     []corev1.ObjectReference
+		children    []foremanv1alpha1.AgenticTask
+		wantReason  string
+		wantMissing string // substring the message must name; "" = none
+	}{
+		{
+			name:        "every planned ref observed",
+			planned:     []corev1.ObjectReference{taskRef("code-1"), taskRef("verify-1"), taskRef("review-1")},
+			children:    []foremanv1alpha1.AgenticTask{child("code-1"), child("verify-1"), child("review-1")},
+			wantReason:  "ChildrenInFlight",
+			wantMissing: "",
+		},
+		{
+			name:        "planned ref absent",
+			planned:     []corev1.ObjectReference{taskRef("code-1"), taskRef("verify-1"), taskRef("review-1")},
+			children:    []foremanv1alpha1.AgenticTask{child("code-1"), child("review-1")},
+			wantReason:  "ChildrenMissing",
+			wantMissing: "verify-1",
+		},
+		{
+			name:        "extra child not planned",
+			planned:     []corev1.ObjectReference{taskRef("code-1"), taskRef("review-1")},
+			children:    []foremanv1alpha1.AgenticTask{child("code-1"), child("review-1"), child("extra-escalation-1")},
+			wantReason:  "ChildrenInFlight",
+			wantMissing: "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wl := &foremanv1alpha1.Workload{
+				ObjectMeta: metav1.ObjectMeta{Name: "missing-wl", Namespace: "default"},
+				Status:     foremanv1alpha1.WorkloadStatus{Tasks: tc.planned},
+			}
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wl).WithStatusSubresource(wl).Build()
+			r := &WorkloadReconciler{Client: cl, Scheme: scheme}
+			if _, err := r.rollup(context.Background(), wl, tc.children); err != nil {
+				t.Fatalf("rollup: %v", err)
+			}
+			cond := dispatched(wl)
+			if cond == nil {
+				t.Fatal("Dispatched condition not emitted")
+			}
+			if cond.Reason != tc.wantReason {
+				t.Errorf("Reason = %q, want %q", cond.Reason, tc.wantReason)
+			}
+			if tc.wantMissing != "" && !strings.Contains(cond.Message, tc.wantMissing) {
+				t.Errorf("message does not name the missing child %q: %q", tc.wantMissing, cond.Message)
+			}
+			if wl.Status.Phase == foremanv1alpha1.WorkloadPhaseFailed {
+				t.Errorf("phase = %q, want not Failed", wl.Status.Phase)
+			}
+		})
+	}
+}

--- a/internal/foreman/controller/workload_rollup_slicer_test.go
+++ b/internal/foreman/controller/workload_rollup_slicer_test.go
@@ -391,7 +391,7 @@ func TestRollup_ContradictedTasksAndCondition(t *testing.T) {
 
 	ctx := context.Background()
 	children := []foremanv1alpha1.AgenticTask{contradicting}
-	if _, err := r.rollup(ctx, wl, children); err != nil {
+	if _, err := r.rollup(ctx, wl, children, nil); err != nil {
 		t.Fatalf("rollup: %v", err)
 	}
 
@@ -455,16 +455,27 @@ func TestRollup_ChildrenMissing(t *testing.T) {
 		}
 	}
 
+	// stepChild is child() plus the step label activeChildren reads and an
+	// explicit phase, so a case can build a superseded round.
+	stepChild := func(name string, phase foremanv1alpha1.AgenticTaskPhase) foremanv1alpha1.AgenticTask {
+		c := child(name)
+		c.Labels = map[string]string{labelWorkload: "missing-wl", labelStep: name}
+		c.Status.Phase = phase
+		return c
+	}
+
 	dispatched := func(w *foremanv1alpha1.Workload) *metav1.Condition {
 		return apimeta.FindStatusCondition(w.Status.Conditions, "Dispatched")
 	}
 
 	tests := []struct {
 		name        string
+		issues      []int32
 		planned     []corev1.ObjectReference
 		children    []foremanv1alpha1.AgenticTask
 		wantReason  string
 		wantMissing string // substring the message must name; "" = none
+		wantAbsent  string // substring the message must NOT name; "" = skip
 	}{
 		{
 			name:        "every planned ref observed",
@@ -487,16 +498,78 @@ func TestRollup_ChildrenMissing(t *testing.T) {
 			wantReason:  "ChildrenInFlight",
 			wantMissing: "",
 		},
+		{
+			// #1743: activeChildren removes a round a fix iteration
+			// superseded, but its refs stay in Status.Tasks forever. The
+			// base round is alive in the cluster and must not be reported
+			// missing for the whole duration of the retry round.
+			name:   "superseded fix-iteration round is not missing",
+			issues: []int32{1},
+			planned: []corev1.ObjectReference{
+				taskRef("code-1"), taskRef("verify-1"), taskRef("review-1-0"),
+				taskRef("code-1-r1"), taskRef("verify-1-r1"), taskRef("review-1-0-r1"),
+			},
+			children: []foremanv1alpha1.AgenticTask{
+				stepChild("code-1", foremanv1alpha1.AgenticTaskPhaseSucceeded),
+				stepChild("verify-1", foremanv1alpha1.AgenticTaskPhaseSucceeded),
+				stepChild("review-1-0", foremanv1alpha1.AgenticTaskPhaseSucceeded),
+				stepChild("code-1-r1", foremanv1alpha1.AgenticTaskPhaseRunning),
+				stepChild("verify-1-r1", foremanv1alpha1.AgenticTaskPhasePending),
+				stepChild("review-1-0-r1", foremanv1alpha1.AgenticTaskPhasePending),
+			},
+			wantReason: "ChildrenInFlight",
+			wantAbsent: "code-1",
+		},
+		{
+			// The other supersession rule (#963): once a coder escalation
+			// exists the WHOLE base attempt is filtered out, and all three
+			// of its refs remain planned.
+			name:   "escalated base attempt is not missing",
+			issues: []int32{1},
+			planned: []corev1.ObjectReference{
+				taskRef("code-1"), taskRef("verify-1"), taskRef("review-1-0"), taskRef("code-1-esc"),
+			},
+			children: []foremanv1alpha1.AgenticTask{
+				stepChild("code-1", foremanv1alpha1.AgenticTaskPhaseFailed),
+				stepChild("verify-1", foremanv1alpha1.AgenticTaskPhaseFailed),
+				stepChild("review-1-0", foremanv1alpha1.AgenticTaskPhaseFailed),
+				stepChild("code-1-esc", foremanv1alpha1.AgenticTaskPhaseRunning),
+			},
+			wantReason: "ChildrenInFlight",
+			wantAbsent: "code-1",
+		},
+		{
+			// The fix must not blunt the feature: a genuinely deleted child
+			// of the LIVE round is still reported, and the superseded round
+			// beside it is still not.
+			name:   "deleted child of the live round is still reported",
+			issues: []int32{1},
+			planned: []corev1.ObjectReference{
+				taskRef("code-1"), taskRef("code-1-r1"), taskRef("verify-1-r1"),
+			},
+			children: []foremanv1alpha1.AgenticTask{
+				stepChild("code-1", foremanv1alpha1.AgenticTaskPhaseSucceeded),
+				stepChild("code-1-r1", foremanv1alpha1.AgenticTaskPhaseRunning),
+			},
+			wantReason:  "ChildrenMissing",
+			wantMissing: "verify-1-r1",
+			wantAbsent:  "code-1,",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			wl := &foremanv1alpha1.Workload{
 				ObjectMeta: metav1.ObjectMeta{Name: "missing-wl", Namespace: "default"},
+				Spec:       foremanv1alpha1.WorkloadSpec{Issues: tc.issues},
 				Status:     foremanv1alpha1.WorkloadStatus{Tasks: tc.planned},
 			}
 			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wl).WithStatusSubresource(wl).Build()
 			r := &WorkloadReconciler{Client: cl, Scheme: scheme}
-			if _, err := r.rollup(context.Background(), wl, tc.children); err != nil {
+			// Reconcile's real order: observe (report + filter), then roll
+			// up the filtered set. Calling observeChildren here rather than
+			// re-deriving it keeps the test from drifting off the caller.
+			active, missing := observeChildren(wl, tc.children)
+			if _, err := r.rollup(context.Background(), wl, active, missing); err != nil {
 				t.Fatalf("rollup: %v", err)
 			}
 			cond := dispatched(wl)
@@ -508,6 +581,9 @@ func TestRollup_ChildrenMissing(t *testing.T) {
 			}
 			if tc.wantMissing != "" && !strings.Contains(cond.Message, tc.wantMissing) {
 				t.Errorf("message does not name the missing child %q: %q", tc.wantMissing, cond.Message)
+			}
+			if tc.wantAbsent != "" && strings.Contains(cond.Message, tc.wantAbsent) {
+				t.Errorf("message names %q, which is alive in the cluster: %q", tc.wantAbsent, cond.Message)
 			}
 			if wl.Status.Phase == foremanv1alpha1.WorkloadPhaseFailed {
 				t.Errorf("phase = %q, want not Failed", wl.Status.Phase)


### PR DESCRIPTION
## What

Report planned child tasks the Workload can no longer observe, in the
`Dispatched` condition, instead of silently reporting only the survivors as
ordinary in-flight work.

## Why

Refs #1738

`rollup` classified only the children it could observe. A child that was deleted
was in no bucket at all, so the counts silently shrank and a Workload that
planned three tasks and lost one reported on two and read as healthy work in
progress. Nothing compared the observed set against what the planner actually
emitted, even though that list is already recorded in `w.Status.Tasks`.

Stale objects are not cosmetic on a MicroK8s/dqlite control plane: accumulated
dead objects have previously bloated dqlite and frozen kubelet's pod watch, so a
Workload that can never terminate carries real operational cost.

This is the second half of the original #1729. The first half shipped in #1736.

## How

`missingPlannedTasks` matches `w.Status.Tasks` against the observed children
**by name, never by count.** That distinction is the whole design:
`workload_escalation.go`, `workload_iteration.go` and
`workload_coder_escalation.go` deliberately synthesize **extra** placeholder
children that are not in `w.Status.Tasks`, so `len(children)` can legitimately
exceed the planned count and a length comparison would flap on every escalation.
Name matching ignores extras and notices only a planned ref that is gone.

Name matching alone was not enough, and the second commit fixes what it missed.
The same iteration and escalation paths that synthesize extra children also
**remove** planned ones: `activeChildren` drops a round that a later attempt
superseded, before `rollup` sees the slice. Since `w.Status.Tasks` is only ever
assigned wholesale by `markPlanned` or appended to by `appendNewTaskRefs`, and
never trimmed, comparing the filtered slice against it reported the base round
of every iterated Workload, and the entire base attempt of every
coder-escalated one, as missing while the retry round ran. `observeChildren`
now computes the report from the unfiltered observation and then filters, so a
superseded round is seen alive. A ref and its child are created together by
every emission, so nothing reads as missing across that call.

Tests cover the superseded fix-iteration round, the escalated base attempt, and
a genuinely deleted child of the live round beside a superseded round that is
not reported. Each fails when the computation is moved back after the filter.

When at least one planned ref is missing, the `Dispatched` condition's `Reason`
becomes `ChildrenMissing` and the `Message` names the count and the missing task
names. The Workload's phase is deliberately **unchanged** and it is not failed:
deleting a task by hand is a legitimate operator action, and this is
diagnosability, not enforcement.

Scoped to the `default:` branch. `classifyChildren` is untouched, and the
`Completed` condition's message is unchanged.

## Known limitation, tracked as #1744

Name matching protects against extra children but not against children that are
**absent because the cache has not caught up.** `markPlanned` writes
`w.Status.Tasks` synchronously while `listChildren` reads through the
cache-backed client, and unlike the escalation paths the planner path does not
synthesize placeholders. So on the first rollup after planning, a planned child
whose create has not yet reached the informer will transiently read as missing.

This is being merged with that gap open, deliberately. The report is
diagnostic-only, never changes the phase, and self-corrects on the next
reconcile within seconds. The clean fix is an uncached confirmation read before
reporting, which introduces `APIReader` to a codebase that does not currently use
it anywhere, and that is a larger change than this reporting fix should carry.
#1744 covers it, including the timing-heuristic alternatives and why they were
rejected.

## Tests

`TestRollup_ChildrenMissing` drives the real `rollup` against a fake client:

- every planned ref observed: `Reason` stays `ChildrenInFlight`, nothing reported
- a planned ref absent: `Reason` is `ChildrenMissing`, the message names it, and
  the phase is asserted not to be `Failed`
- an **extra** observed child not in `w.Status.Tasks`, all planned refs present:
  nothing reported

The third case is the anti-flap boundary that proves name matching beats
counting, and it is the one that would fail if this were reimplemented as a
length comparison.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally. The clean-room gate Job ran it in full for the
      first commit (GATE-PASS); the second was verified locally, whole package
      with envtest plus a sweep of `./internal/...` and `./pkg/foreman/...`
- [x] `make lint` passes locally. The gate Job runs fmt, vet, lint and
      lint-deadcode; the second commit also passed `GOOS=linux golangci-lint`
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance disclosed: authored by the Foreman coder agent
      (DeepSeek V4 Flash, self-hosted) under band 3 of CONTRIBUTING.md, reviewed
      by the automated reviewer and by the maintainer, who owns this review
      conversation. The second commit was written by hand with Claude Code from
      an adversarial review of the first, and verified locally with a mutation
      check on each new test case.
- [ ] Documentation updated. No user-facing change

Note for merging: #1739 has since merged and this branch is now rebased on top
of it. The conflict in the `default:` branch of that switch is resolved by
keeping `conditionTypeDispatched` and `setDispatchedTerminal` from #1739 and
layering the `ChildrenMissing` reason on top of them inside the same case.



