### PR TITLE
feat(foreman): enforce reviewer execution runs via a no-test-run rail

### DIFF
--- a/config/foreman/agents/claude-sonnet-cloud-reviewer.yaml
+++ b/config/foreman/agents/claude-sonnet-cloud-reviewer.yaml
@@ -186,6 +186,20 @@ spec:
            `read_file` reads of each touched file).
         6. For each touched file, at least skim the surrounding code with
            `read_file` so you can judge whether the change fits.
+        7. When the diff touches `.go` files, run the diff's own new tests,
+           narrowly: `bash("go test ./<package-of-touched-files>/ -run
+           '<NewTestName>' -count=1")` for the most load-bearing new test. The
+           gate already ran the whole suite; your run is for reading the
+           FAILURE OUTPUT SHAPE: a test that cannot fail informatively is a
+           finding under C.
+        8. When the diff touches `.go` files, probe one near-miss the diff
+           does NOT test. Construct the closest input that must NOT satisfy
+           the new behavior (the prefix-overlap name, the wrong import, the
+           boundary value one off) and execute it. Without write tools, use
+           bash: heredoc a small `_probe_test.go` into the package,
+           `go test -run` it, then `rm` it. One probe, chosen adversarially,
+           beats ten read-the-code-again passes. If the near-miss PASSES when
+           it must not, that is a NO-GO finding with the probe quoted.
 
         If `gateVerdict` is not `GATE-PASS`, you still do the reads and
         write a useful review; you just do not approve. The branch already
@@ -380,27 +394,16 @@ spec:
         gate and read-only review; both fell in minutes to a reviewer who
         executed the change instead of reading it.
 
-        Do these two runs. They are cheap and they are mandatory whenever
-        the diff touches `.go` files:
-
-        1. **Run the diff's own new tests, narrowly.**
-           `bash("go test ./<package-of-touched-files>/ -run '<NewTestName>' -count=1")`
-           for the most load-bearing new test. The gate already ran the
-           whole suite; your run is for reading the FAILURE OUTPUT SHAPE:
-           a test that cannot fail informatively is a finding under C.
-
-        2. **Probe one near-miss the diff does NOT test.** Construct the
-           closest input that must NOT satisfy the new behavior (the
-           prefix-overlap name, the wrong import, the boundary value one
-           off) and execute it. Without write tools, use bash: heredoc a
-           small `_probe_test.go` into the package, `go test -run` it,
-           then `rm` it. One probe, chosen adversarially, beats ten read
-           the code again passes. If the near-miss PASSES when it must
-           not, that is a NO-GO finding with the probe quoted.
+        When the diff touches `.go` files, the two runs are Step 1 items 7
+        and 8: run the diff's own new tests narrowly, then probe one
+        near-miss the diff does not test. They are cheap, mandatory, and
+        they come first — before you form a judgment, not after. A review
+        of a Go diff whose transcript carries no `go test` is recorded as
+        skipping the execution rail.
 
         Then two audits that need no execution:
 
-        3. **Claim-scope audit.** List every issue, reproduction, or
+        1. **Claim-scope audit.** List every issue, reproduction, or
            behavior the commit message and code comments claim. Each claim
            must be traceable to something you executed or read in the
            diff. A claim you cannot trace is a finding; a claim the code
@@ -408,7 +411,7 @@ spec:
            because the next person hitting that case will conclude the
            code is broken rather than the claim was loose.
 
-        4. **Rationale audit.** When a comment justifies a restriction or
+        2. **Rationale audit.** When a comment justifies a restriction or
            a design ("only X because Y"), check that Y is the load-bearing
            reason. A guard justified by cost that actually exists for
            soundness will be deleted by the first optimizer who disproves

--- a/config/foreman/agents/devstral-24b-reviewer.yaml
+++ b/config/foreman/agents/devstral-24b-reviewer.yaml
@@ -132,6 +132,20 @@ spec:
            `read_file` reads of each touched file).
         6. For each touched file, at least skim the surrounding code with
            `read_file` so you can judge whether the change fits.
+        7. When the diff touches `.go` files, run the diff's own new tests,
+           narrowly: `bash("go test ./<package-of-touched-files>/ -run
+           '<NewTestName>' -count=1")` for the most load-bearing new test. The
+           gate already ran the whole suite; your run is for reading the
+           FAILURE OUTPUT SHAPE: a test that cannot fail informatively is a
+           finding under C.
+        8. When the diff touches `.go` files, probe one near-miss the diff
+           does NOT test. Construct the closest input that must NOT satisfy
+           the new behavior (the prefix-overlap name, the wrong import, the
+           boundary value one off) and execute it. Without write tools, use
+           bash: heredoc a small `_probe_test.go` into the package,
+           `go test -run` it, then `rm` it. One probe, chosen adversarially,
+           beats ten read-the-code-again passes. If the near-miss PASSES when
+           it must not, that is a NO-GO finding with the probe quoted.
 
         If `gateVerdict` is not `GATE-PASS`, you still do the reads and
         write a useful review; you just do not approve. The branch already
@@ -326,27 +340,16 @@ spec:
         gate and read-only review; both fell in minutes to a reviewer who
         executed the change instead of reading it.
 
-        Do these two runs. They are cheap and they are mandatory whenever
-        the diff touches `.go` files:
-
-        1. **Run the diff's own new tests, narrowly.**
-           `bash("go test ./<package-of-touched-files>/ -run '<NewTestName>' -count=1")`
-           for the most load-bearing new test. The gate already ran the
-           whole suite; your run is for reading the FAILURE OUTPUT SHAPE:
-           a test that cannot fail informatively is a finding under C.
-
-        2. **Probe one near-miss the diff does NOT test.** Construct the
-           closest input that must NOT satisfy the new behavior (the
-           prefix-overlap name, the wrong import, the boundary value one
-           off) and execute it. Without write tools, use bash: heredoc a
-           small `_probe_test.go` into the package, `go test -run` it,
-           then `rm` it. One probe, chosen adversarially, beats ten read
-           the code again passes. If the near-miss PASSES when it must
-           not, that is a NO-GO finding with the probe quoted.
+        When the diff touches `.go` files, the two runs are Step 1 items 7
+        and 8: run the diff's own new tests narrowly, then probe one
+        near-miss the diff does not test. They are cheap, mandatory, and
+        they come first — before you form a judgment, not after. A review
+        of a Go diff whose transcript carries no `go test` is recorded as
+        skipping the execution rail.
 
         Then two audits that need no execution:
 
-        3. **Claim-scope audit.** List every issue, reproduction, or
+        1. **Claim-scope audit.** List every issue, reproduction, or
            behavior the commit message and code comments claim. Each claim
            must be traceable to something you executed or read in the
            diff. A claim you cannot trace is a finding; a claim the code
@@ -354,7 +357,7 @@ spec:
            because the next person hitting that case will conclude the
            code is broken rather than the claim was loose.
 
-        4. **Rationale audit.** When a comment justifies a restriction or
+        2. **Rationale audit.** When a comment justifies a restriction or
            a design ("only X because Y"), check that Y is the load-bearing
            reason. A guard justified by cost that actually exists for
            soundness will be deleted by the first optimizer who disproves

--- a/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
+++ b/config/foreman/agents/qwen36-35b-a3b-reviewer.yaml
@@ -167,6 +167,20 @@ spec:
            `read_file` reads of each touched file).
         6. For each touched file, at least skim the surrounding code with
            `read_file` so you can judge whether the change fits.
+        7. When the diff touches `.go` files, run the diff's own new tests,
+           narrowly: `bash("go test ./<package-of-touched-files>/ -run
+           '<NewTestName>' -count=1")` for the most load-bearing new test. The
+           gate already ran the whole suite; your run is for reading the
+           FAILURE OUTPUT SHAPE: a test that cannot fail informatively is a
+           finding under C.
+        8. When the diff touches `.go` files, probe one near-miss the diff
+           does NOT test. Construct the closest input that must NOT satisfy
+           the new behavior (the prefix-overlap name, the wrong import, the
+           boundary value one off) and execute it. Without write tools, use
+           bash: heredoc a small `_probe_test.go` into the package,
+           `go test -run` it, then `rm` it. One probe, chosen adversarially,
+           beats ten read-the-code-again passes. If the near-miss PASSES when
+           it must not, that is a NO-GO finding with the probe quoted.
 
         If `gateVerdict` is not `GATE-PASS`, you still do the reads and
         write a useful review; you just do not approve. The branch already
@@ -361,27 +375,16 @@ spec:
         gate and read-only review; both fell in minutes to a reviewer who
         executed the change instead of reading it.
 
-        Do these two runs. They are cheap and they are mandatory whenever
-        the diff touches `.go` files:
-
-        1. **Run the diff's own new tests, narrowly.**
-           `bash("go test ./<package-of-touched-files>/ -run '<NewTestName>' -count=1")`
-           for the most load-bearing new test. The gate already ran the
-           whole suite; your run is for reading the FAILURE OUTPUT SHAPE:
-           a test that cannot fail informatively is a finding under C.
-
-        2. **Probe one near-miss the diff does NOT test.** Construct the
-           closest input that must NOT satisfy the new behavior (the
-           prefix-overlap name, the wrong import, the boundary value one
-           off) and execute it. Without write tools, use bash: heredoc a
-           small `_probe_test.go` into the package, `go test -run` it,
-           then `rm` it. One probe, chosen adversarially, beats ten read
-           the code again passes. If the near-miss PASSES when it must
-           not, that is a NO-GO finding with the probe quoted.
+        When the diff touches `.go` files, the two runs are Step 1 items 7
+        and 8: run the diff's own new tests narrowly, then probe one
+        near-miss the diff does not test. They are cheap, mandatory, and
+        they come first — before you form a judgment, not after. A review
+        of a Go diff whose transcript carries no `go test` is recorded as
+        skipping the execution rail.
 
         Then two audits that need no execution:
 
-        3. **Claim-scope audit.** List every issue, reproduction, or
+        1. **Claim-scope audit.** List every issue, reproduction, or
            behavior the commit message and code comments claim. Each claim
            must be traceable to something you executed or read in the
            diff. A claim you cannot trace is a finding; a claim the code
@@ -389,7 +392,7 @@ spec:
            because the next person hitting that case will conclude the
            code is broken rather than the claim was loose.
 
-        4. **Rationale audit.** When a comment justifies a restriction or
+        2. **Rationale audit.** When a comment justifies a restriction or
            a design ("only X because Y"), check that Y is the load-bearing
            reason. A guard justified by cost that actually exists for
            soundness will be deleted by the first optimizer who disproves

--- a/config/foreman/system-prompts/reviewer.md
+++ b/config/foreman/system-prompts/reviewer.md
@@ -89,6 +89,20 @@ wrong.
    `read_file` reads of each touched file).
 6. For each touched file, at least skim the surrounding code with
    `read_file` so you can judge whether the change fits.
+7. When the diff touches `.go` files, run the diff's own new tests,
+   narrowly: `bash("go test ./<package-of-touched-files>/ -run
+   '<NewTestName>' -count=1")` for the most load-bearing new test. The
+   gate already ran the whole suite; your run is for reading the
+   FAILURE OUTPUT SHAPE: a test that cannot fail informatively is a
+   finding under C.
+8. When the diff touches `.go` files, probe one near-miss the diff
+   does NOT test. Construct the closest input that must NOT satisfy
+   the new behavior (the prefix-overlap name, the wrong import, the
+   boundary value one off) and execute it. Without write tools, use
+   bash: heredoc a small `_probe_test.go` into the package,
+   `go test -run` it, then `rm` it. One probe, chosen adversarially,
+   beats ten read-the-code-again passes. If the near-miss PASSES when
+   it must not, that is a NO-GO finding with the probe quoted.
 
 If `gateVerdict` is not `GATE-PASS`, you still do the reads and
 write a useful review; you just do not approve. The branch already
@@ -283,27 +297,16 @@ fixed when its code structurally excluded one of them. Both passed
 gate and read-only review; both fell in minutes to a reviewer who
 executed the change instead of reading it.
 
-Do these two runs. They are cheap and they are mandatory whenever
-the diff touches `.go` files:
-
-1. **Run the diff's own new tests, narrowly.**
-   `bash("go test ./<package-of-touched-files>/ -run '<NewTestName>' -count=1")`
-   for the most load-bearing new test. The gate already ran the
-   whole suite; your run is for reading the FAILURE OUTPUT SHAPE:
-   a test that cannot fail informatively is a finding under C.
-
-2. **Probe one near-miss the diff does NOT test.** Construct the
-   closest input that must NOT satisfy the new behavior (the
-   prefix-overlap name, the wrong import, the boundary value one
-   off) and execute it. Without write tools, use bash: heredoc a
-   small `_probe_test.go` into the package, `go test -run` it,
-   then `rm` it. One probe, chosen adversarially, beats ten read
-   the code again passes. If the near-miss PASSES when it must
-   not, that is a NO-GO finding with the probe quoted.
+When the diff touches `.go` files, the two runs are Step 1 items 7
+and 8: run the diff's own new tests narrowly, then probe one
+near-miss the diff does not test. They are cheap, mandatory, and
+they come first — before you form a judgment, not after. A review
+of a Go diff whose transcript carries no `go test` is recorded as
+skipping the execution rail.
 
 Then two audits that need no execution:
 
-3. **Claim-scope audit.** List every issue, reproduction, or
+1. **Claim-scope audit.** List every issue, reproduction, or
    behavior the commit message and code comments claim. Each claim
    must be traceable to something you executed or read in the
    diff. A claim you cannot trace is a finding; a claim the code
@@ -311,7 +314,7 @@ Then two audits that need no execution:
    because the next person hitting that case will conclude the
    code is broken rather than the claim was loose.
 
-4. **Rationale audit.** When a comment justifies a restriction or
+2. **Rationale audit.** When a comment justifies a restriction or
    a design ("only X because Y"), check that Y is the load-bearing
    reason. A guard justified by cost that actually exists for
    soundness will be deleted by the first optimizer who disproves

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1042,10 +1042,10 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// running the diff's own new test (and an adversarial near-miss
 			// probe) whenever the diff touches `.go` files. A GO whose
 			// transcript never ran `go test` did not execute the change it
-			// approved, so demote it to NO-GO (it routes to escalation
-			// instead of opening a PR) and record the rail skipped. This is a
-			// demote rail like scope-overlap, and it runs after the diff gate
-			// so its verdict rewrite is what the findings summary reports.
+			// approved, so record the rail as skipped and leave the verdict
+			// as the model returned it. This is a mark, not a demote rail: it
+			// runs after the diff gate, and demotion is a later flip once the
+			// fleet shows the runs fit the turn budget.
 			verdict = enforceReviewerExecution(log, loopRes.Terminal.Extra, reviewDiff, verdict, loopRes.Transcript)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 			// Per-clause coverage rail (#1554): require the reviewer to have

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1045,8 +1045,11 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// approved, so record the rail as skipped and leave the verdict
 			// as the model returned it. This is a mark, not a demote rail: it
 			// runs after the diff gate, and demotion is a later flip once the
-			// fleet shows the runs fit the turn budget.
-			verdict = enforceReviewerExecution(log, loopRes.Terminal.Extra, reviewDiff, verdict, loopRes.Transcript)
+			// fleet shows the runs fit the turn budget. It takes reviewDiffErr
+			// so a failed diff fetch is recorded as a skipped rail, like the
+			// scope rail above, instead of passing as a docs-only exemption.
+			verdict = enforceReviewerExecution(log, loopRes.Terminal.Extra, reviewDiff, reviewDiffErr,
+				verdict, loopRes.Transcript)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 			// Per-clause coverage rail (#1554): require the reviewer to have
 			// covered each behaviour clause the issue enumerated, or flag the

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -1038,6 +1038,15 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// those rails produced, and it is the last reviewer rail before the
 			// findings summary so its log line is the last rail signal recorded.
 			applyReviewerDiffGateForTask(log, loopRes, verdict)
+			// Review-execution rail (#1618): the rubric's Section K mandates
+			// running the diff's own new test (and an adversarial near-miss
+			// probe) whenever the diff touches `.go` files. A GO whose
+			// transcript never ran `go test` did not execute the change it
+			// approved, so demote it to NO-GO (it routes to escalation
+			// instead of opening a PR) and record the rail skipped. This is a
+			// demote rail like scope-overlap, and it runs after the diff gate
+			// so its verdict rewrite is what the findings summary reports.
+			verdict = enforceReviewerExecution(log, loopRes.Terminal.Extra, reviewDiff, verdict, loopRes.Transcript)
 			logReviewerFindings(log, loopRes.Terminal.Extra)
 			// Per-clause coverage rail (#1554): require the reviewer to have
 			// covered each behaviour clause the issue enumerated, or flag the

--- a/pkg/foreman/agent/rail_skip.go
+++ b/pkg/foreman/agent/rail_skip.go
@@ -31,8 +31,10 @@ const (
 	railVerdictFromFindings = "verdict-from-findings"
 	railEmptyClaim          = "empty-claim"
 	railGroundedFinding     = "grounded-finding"
-	// railExecution names the review-execution rail (#1618). It can rewrite a
-	// verdict, so it lives here beside the other demoting rails.
+	// railExecution names the review-execution rail (#1618). It records a
+	// GO on a Go diff whose review never ran `go test`, and a GO whose diff
+	// could not be fetched at all; it never rewrites the verdict. Demotion is
+	// a later flip once the fleet shows the runs fit the turn budget.
 	railExecution = "review-execution"
 )
 

--- a/pkg/foreman/agent/rail_skip.go
+++ b/pkg/foreman/agent/rail_skip.go
@@ -31,6 +31,9 @@ const (
 	railVerdictFromFindings = "verdict-from-findings"
 	railEmptyClaim          = "empty-claim"
 	railGroundedFinding     = "grounded-finding"
+	// railExecution names the review-execution rail (#1618). It can rewrite a
+	// verdict, so it lives here beside the other demoting rails.
+	railExecution = "review-execution"
 )
 
 // Reasons a rail could not run.
@@ -42,6 +45,9 @@ const (
 	// for any issue citing no extractable file paths, which hand-written
 	// issues routinely do not.
 	skipReasonNoPathRefs = "no-path-refs-in-issue"
+	// skipReasonNoTestRun marks the review-execution rail (#1618) short-
+	// circuiting: a GO on a .go diff whose transcript never ran `go test`.
+	skipReasonNoTestRun = "no-test-run"
 )
 
 // Reasons the scope rail detected drift and then declined to act on it. These

--- a/pkg/foreman/agent/review_execution_gate.go
+++ b/pkg/foreman/agent/review_execution_gate.go
@@ -31,11 +31,14 @@ import (
 
 // reGoTestCommand matches a shell command that actually invokes `go test`. It
 // is anchored on a command position (start of a line, or right after a `;`,
-// `&`, or `|` command separator) so a mere mention — `grep "go test"
-// Makefile`, or a read_file of a test file whose text carries the literal `go
-// test` — does not satisfy the rail. The space after `test` separates the
+// `&`, or `|` command separator) so a mere mention, such as `grep "go test"
+// Makefile` or a read_file of a test file whose text carries the literal `go
+// test`, does not satisfy the rail. The command position tolerates the
+// prefixes a reviewer naturally types in front of the binary: leading
+// indentation, `time`, `sudo`, and shell environment assignments such as
+// `GOFLAGS=-v` or `CGO_ENABLED=0`. The space after `test` separates the
 // subcommand from the package pattern (`go test ./pkg/...`).
-var reGoTestCommand = regexp.MustCompile(`(?m)(^|[;&|]\s*)go\s+test\b`)
+var reGoTestCommand = regexp.MustCompile(`(?m)(^|[;&|])\s*(?:(?:time|sudo|[A-Za-z_][A-Za-z0-9_]*=\S*)\s+)*go\s+test\b`)
 
 // transcriptRanGoTest reports whether any executed bash invocation in the
 // transcript is a `go test` run. It scans assistant tool_call arguments (via
@@ -75,16 +78,24 @@ func transcriptRanGoTest(transcript []oai.Message) bool {
 // reviewer's verdict. It fires only for a GO on a diff that touches a `.go`
 // file: the Section-K execution runs are mandatory for Go diffs but are
 // exempt for docs/YAML-only changes. A GO whose transcript never ran `go test`
-// is marked — the skipped rail is recorded on extra so the verdict is
-// distinguishable afterwards from one that earned the execution check — and
+// is marked: the skipped rail is recorded on extra so the verdict is
+// distinguishable afterwards from one that earned the execution check, and
 // the verdict stands as the model returned it. A transcript that did run `go
 // test` leaves the verdict untouched. Marking, not demotion: demotion is a
 // later flip once the fleet shows the runs fit the turn budget. A non-GO
 // verdict is not this rail's business and returns untouched.
+//
+// diffErr is the error from the ground-truth diff fetch. When it is non-nil
+// the rail has no input: diffFiles is nil, which hasSourceFile reads as a
+// docs-only diff, so without this branch a GO issued with no diff at all would
+// look identical to a GO on a docs-only change. Like the scope-overlap rail
+// (#1605), the rail records itself as skipped with skipReasonNoDiff and leaves
+// the verdict alone.
 func enforceReviewerExecution(
 	log logr.Logger,
 	extra map[string]any,
 	diffFiles []string,
+	diffErr error,
 	verdict foremanv1alpha1.AgenticTaskVerdict,
 	transcript []oai.Message,
 ) foremanv1alpha1.AgenticTaskVerdict {
@@ -93,6 +104,16 @@ func enforceReviewerExecution(
 		return verdict
 	}
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		return verdict
+	}
+	if diffErr != nil {
+		// A log line is not a record (#1605). The diff never arrived, so the
+		// Go-only guard below cannot tell a docs-only change from no change
+		// at all; mark the skip so this GO is distinguishable afterwards from
+		// one the rail actually checked.
+		recordRailSkipped(extra, railExecution, skipReasonNoDiff)
+		log.Info("reviewer execution: ground-truth diff unavailable; skipping execution check",
+			"err", diffErr.Error())
 		return verdict
 	}
 	// Non-.go diffs are exempt: the mandatory execution runs only apply when

--- a/pkg/foreman/agent/review_execution_gate.go
+++ b/pkg/foreman/agent/review_execution_gate.go
@@ -15,45 +15,55 @@ import (
 // the first live Section-K review the reviewer performed every read and skipped
 // both runs, disclosing the omission in onTrust instead. Numbered step
 // sequences are followed faithfully; checklist prose is treated as advisory.
-// This rail makes the execution mandate self-enforcing: when the diff touches a
-// `.go` file, a GO whose transcript never ran `go test` is demoted to NO-GO so
-// it routes to escalation instead of approving a branch the reviewer did not
-// execute.
+// This rail makes the execution mandate observable: when the diff touches a
+// `.go` file, a GO whose transcript never ran `go test` is marked in its
+// record (the skipped rail is recorded on the result's extra) so a later stage
+// can see the approval did not execute the change it covers. Marking, not
+// demotion: the verdict stands as returned, and flipping a GO to NO-GO is a
+// later decision for when the fleet shows the runs fit the turn budget.
 //
 // These functions are deterministic and model-free: they run over a stored
 // transcript ([]oai.Message) and the ground-truth diff files, making no git
 // calls. They mirror the shape of reviewer_diff_gate.go (walk a transcript,
 // correlate tool results to the assistant tool_call that produced them, return
-// a finding) and the demotion pattern of scope_overlap.go (stamp a GO->NO-GO
-// rewrite with verdictDemoted / verdictDemotedBy / verdictClaimed /
-// demotionReason).
+// a finding) and the mark-but-do-not-demote pattern of rail_skip.go (record the
+// rail as skipped on extra, leave the verdict alone).
 
-// reGoTestCommand matches a shell command that invokes `go test`. It is
-// applied to both the assistant tool_call arguments and the tool result
-// content (the bash tool echoes the command back in its JSON output), so a
-// `go test` run is caught whether the transcript records it as the request or
-// as the result. The leading word boundary keeps it from matching a path or a
-// comment; the space after `test` separates the subcommand from the package
-// pattern (`go test ./pkg/...`).
-var reGoTestCommand = regexp.MustCompile(`\bgo\s+test\b`)
+// reGoTestCommand matches a shell command that actually invokes `go test`. It
+// is anchored on a command position (start of a line, or right after a `;`,
+// `&`, or `|` command separator) so a mere mention — `grep "go test"
+// Makefile`, or a read_file of a test file whose text carries the literal `go
+// test` — does not satisfy the rail. The space after `test` separates the
+// subcommand from the package pattern (`go test ./pkg/...`).
+var reGoTestCommand = regexp.MustCompile(`(?m)(^|[;&|]\s*)go\s+test\b`)
 
-// transcriptRanGoTest reports whether any bash invocation in the transcript is
-// a `go test` run. It scans assistant tool_call arguments (via
+// transcriptRanGoTest reports whether any executed bash invocation in the
+// transcript is a `go test` run. It scans assistant tool_call arguments (via
 // commandFromToolCallArgs, the same correlation the diff gate uses) and
-// tool-role content (via toolContent, so a tool message whose Name is empty
-// still counts). An empty transcript yields false without panic.
+// tool-role content, but a tool-role message counts only when a bash tool call
+// produced it: a read_file of a file that merely contains the string `go test`
+// must not satisfy the rail. The tool-role correlation uses callNameByToolCallID
+// to recover the tool name from the assistant tool_call that produced the
+// message. An empty transcript yields false without panic.
 func transcriptRanGoTest(transcript []oai.Message) bool {
+	names := callNameByToolCallID(transcript)
 	for i := range transcript {
 		m := transcript[i]
 		switch m.Role {
 		case oai.RoleAssistant:
 			for _, tc := range m.ToolCalls {
+				if tc.Function.Name != "bash" {
+					continue
+				}
 				if reGoTestCommand.MatchString(commandFromToolCallArgs(tc.Function.Arguments)) {
 					return true
 				}
 			}
 		case oai.RoleTool:
-			if reGoTestCommand.MatchString(toolContent(m)) {
+			if names[m.ToolCallID] != "bash" {
+				continue
+			}
+			if reGoTestCommand.MatchString(commandFromToolCallArgs(toolContent(m))) {
 				return true
 			}
 		}
@@ -65,14 +75,12 @@ func transcriptRanGoTest(transcript []oai.Message) bool {
 // reviewer's verdict. It fires only for a GO on a diff that touches a `.go`
 // file: the Section-K execution runs are mandatory for Go diffs but are
 // exempt for docs/YAML-only changes. A GO whose transcript never ran `go test`
-// is demoted to NO-GO, and the skipped rail is recorded so the verdict is
-// distinguishable afterwards from one that earned the execution check. A
-// transcript that did run `go test` leaves the verdict untouched.
-//
-// The demotion is stamped exactly like the scope-overlap rail: verdictDemoted,
-// verdictDemotedBy (naming this rail), verdictClaimed (the archived original
-// verdict, first-writer-wins per #1678), and demotionReason. A non-GO verdict
-// is not this rail's business and returns untouched.
+// is marked — the skipped rail is recorded on extra so the verdict is
+// distinguishable afterwards from one that earned the execution check — and
+// the verdict stands as the model returned it. A transcript that did run `go
+// test` leaves the verdict untouched. Marking, not demotion: demotion is a
+// later flip once the fleet shows the runs fit the turn budget. A non-GO
+// verdict is not this rail's business and returns untouched.
 func enforceReviewerExecution(
 	log logr.Logger,
 	extra map[string]any,
@@ -81,6 +89,7 @@ func enforceReviewerExecution(
 	transcript []oai.Message,
 ) foremanv1alpha1.AgenticTaskVerdict {
 	if extra == nil {
+		log.Info("reviewer execution: extra is nil; cannot record the rail as skipped")
 		return verdict
 	}
 	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
@@ -96,19 +105,12 @@ func enforceReviewerExecution(
 		return verdict
 	}
 
-	// The GO on a Go diff never ran `go test`. Record the skipped rail and
-	// demote the verdict so the approval does not stand on an unexecuted
-	// branch.
+	// The GO on a Go diff never ran `go test`. Record the skipped rail so the
+	// approval is distinguishable afterwards from one that earned the execution
+	// check; the verdict stands as returned. Demotion is a later flip once the
+	// fleet shows the runs fit the turn budget.
 	recordRailSkipped(extra, railExecution, skipReasonNoTestRun)
-	extra["verdictDemoted"] = true
-	extra["verdictDemotedBy"] = railExecution
-	// First-writer-wins for the claimed verdict: another demoting rail may have
-	// already archived the reviewer's original GO (#1678).
-	if _, ok := extra["verdictClaimed"]; !ok {
-		extra["verdictClaimed"] = string(verdict)
-	}
-	extra["demotionReason"] = "reviewer returned GO on a .go diff without running `go test` in the transcript"
-	log.Info("reviewer execution: GO on a .go diff with no `go test` run in the transcript; demoting to NO-GO",
-		"verdictClaimed", verdict)
-	return foremanv1alpha1.AgenticTaskVerdictNoGo
+	log.Info("reviewer execution: GO on a .go diff with no `go test` run in the transcript; recorded the rail as skipped",
+		"verdict", verdict)
+	return verdict
 }

--- a/pkg/foreman/agent/review_execution_gate.go
+++ b/pkg/foreman/agent/review_execution_gate.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"regexp"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// review_execution_gate.go is the deterministic rail behind #1618. The
+// reviewer rubric's Section K mandates two execution runs (run the diff's own
+// new test; probe one near-miss) whenever the diff touches `.go` files, but in
+// the first live Section-K review the reviewer performed every read and skipped
+// both runs, disclosing the omission in onTrust instead. Numbered step
+// sequences are followed faithfully; checklist prose is treated as advisory.
+// This rail makes the execution mandate self-enforcing: when the diff touches a
+// `.go` file, a GO whose transcript never ran `go test` is demoted to NO-GO so
+// it routes to escalation instead of approving a branch the reviewer did not
+// execute.
+//
+// These functions are deterministic and model-free: they run over a stored
+// transcript ([]oai.Message) and the ground-truth diff files, making no git
+// calls. They mirror the shape of reviewer_diff_gate.go (walk a transcript,
+// correlate tool results to the assistant tool_call that produced them, return
+// a finding) and the demotion pattern of scope_overlap.go (stamp a GO->NO-GO
+// rewrite with verdictDemoted / verdictDemotedBy / verdictClaimed /
+// demotionReason).
+
+// reGoTestCommand matches a shell command that invokes `go test`. It is
+// applied to both the assistant tool_call arguments and the tool result
+// content (the bash tool echoes the command back in its JSON output), so a
+// `go test` run is caught whether the transcript records it as the request or
+// as the result. The leading word boundary keeps it from matching a path or a
+// comment; the space after `test` separates the subcommand from the package
+// pattern (`go test ./pkg/...`).
+var reGoTestCommand = regexp.MustCompile(`\bgo\s+test\b`)
+
+// transcriptRanGoTest reports whether any bash invocation in the transcript is
+// a `go test` run. It scans assistant tool_call arguments (via
+// commandFromToolCallArgs, the same correlation the diff gate uses) and
+// tool-role content (via toolContent, so a tool message whose Name is empty
+// still counts). An empty transcript yields false without panic.
+func transcriptRanGoTest(transcript []oai.Message) bool {
+	for i := range transcript {
+		m := transcript[i]
+		switch m.Role {
+		case oai.RoleAssistant:
+			for _, tc := range m.ToolCalls {
+				if reGoTestCommand.MatchString(commandFromToolCallArgs(tc.Function.Arguments)) {
+					return true
+				}
+			}
+		case oai.RoleTool:
+			if reGoTestCommand.MatchString(toolContent(m)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// enforceReviewerExecution applies the review-execution rail (#1618) to a
+// reviewer's verdict. It fires only for a GO on a diff that touches a `.go`
+// file: the Section-K execution runs are mandatory for Go diffs but are
+// exempt for docs/YAML-only changes. A GO whose transcript never ran `go test`
+// is demoted to NO-GO, and the skipped rail is recorded so the verdict is
+// distinguishable afterwards from one that earned the execution check. A
+// transcript that did run `go test` leaves the verdict untouched.
+//
+// The demotion is stamped exactly like the scope-overlap rail: verdictDemoted,
+// verdictDemotedBy (naming this rail), verdictClaimed (the archived original
+// verdict, first-writer-wins per #1678), and demotionReason. A non-GO verdict
+// is not this rail's business and returns untouched.
+func enforceReviewerExecution(
+	log logr.Logger,
+	extra map[string]any,
+	diffFiles []string,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+	transcript []oai.Message,
+) foremanv1alpha1.AgenticTaskVerdict {
+	if extra == nil {
+		return verdict
+	}
+	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		return verdict
+	}
+	// Non-.go diffs are exempt: the mandatory execution runs only apply when
+	// the diff touches `.go` files. hasSourceFile defaults to [".go"] when exts
+	// is nil, so this is the Go-only guard.
+	if !hasSourceFile(diffFiles, nil) {
+		return verdict
+	}
+	if transcriptRanGoTest(transcript) {
+		return verdict
+	}
+
+	// The GO on a Go diff never ran `go test`. Record the skipped rail and
+	// demote the verdict so the approval does not stand on an unexecuted
+	// branch.
+	recordRailSkipped(extra, railExecution, skipReasonNoTestRun)
+	extra["verdictDemoted"] = true
+	extra["verdictDemotedBy"] = railExecution
+	// First-writer-wins for the claimed verdict: another demoting rail may have
+	// already archived the reviewer's original GO (#1678).
+	if _, ok := extra["verdictClaimed"]; !ok {
+		extra["verdictClaimed"] = string(verdict)
+	}
+	extra["demotionReason"] = "reviewer returned GO on a .go diff without running `go test` in the transcript"
+	log.Info("reviewer execution: GO on a .go diff with no `go test` run in the transcript; demoting to NO-GO",
+		"verdictClaimed", verdict)
+	return foremanv1alpha1.AgenticTaskVerdictNoGo
+}

--- a/pkg/foreman/agent/review_execution_gate_test.go
+++ b/pkg/foreman/agent/review_execution_gate_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -127,7 +128,7 @@ func TestEnforceReviewerExecution_GoDiffRanGoTest(t *testing.T) {
 		toolResult("bash", "call-1", "ok  \tpkg/foreman/agent\n"),
 	}
 	extra := map[string]any{}
-	got := enforceReviewerExecution(logr.Discard(), extra, []string{"pkg/foreman/agent/x.go"},
+	got := enforceReviewerExecution(logr.Discard(), extra, []string{"pkg/foreman/agent/x.go"}, nil,
 		foremanv1alpha1.AgenticTaskVerdictGo, tr)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("expected GO to stand when `go test` ran, got %v", got)
@@ -151,7 +152,7 @@ func TestEnforceReviewerExecution_GoDiffNoGoTest(t *testing.T) {
 		toolResult("bash", "call-2", "package agent\n"),
 	}
 	extra := map[string]any{}
-	got := enforceReviewerExecution(logr.Discard(), extra, []string{"pkg/foreman/agent/x.go"},
+	got := enforceReviewerExecution(logr.Discard(), extra, []string{"pkg/foreman/agent/x.go"}, nil,
 		foremanv1alpha1.AgenticTaskVerdictGo, tr)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("expected GO to stand (marking, not demotion), got %v", got)
@@ -185,7 +186,7 @@ func TestEnforceReviewerExecution_NonGoDiffExempt(t *testing.T) {
 		toolResult("bash", "call-1", "diff --git a/docs/x.md b/docs/x.md\n@@ -1 +1 @@\n"),
 	}
 	extra := map[string]any{}
-	got := enforceReviewerExecution(logr.Discard(), extra, []string{"docs/x.md"},
+	got := enforceReviewerExecution(logr.Discard(), extra, []string{"docs/x.md"}, nil,
 		foremanv1alpha1.AgenticTaskVerdictGo, tr)
 	if got != foremanv1alpha1.AgenticTaskVerdictGo {
 		t.Fatalf("expected a non-.go diff to be exempt (GO stands), got %v", got)
@@ -204,12 +205,109 @@ func TestEnforceReviewerExecution_NonGoVerdictUntouched(t *testing.T) {
 		toolResult("bash", "call-1", "diff --git a/x.go b/x.go\n@@ -1 +1 @@\n"),
 	}
 	extra := map[string]any{}
-	got := enforceReviewerExecution(logr.Discard(), extra, []string{"x.go"},
+	got := enforceReviewerExecution(logr.Discard(), extra, []string{"x.go"}, nil,
 		foremanv1alpha1.AgenticTaskVerdictNoGo, tr)
 	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
 		t.Fatalf("a non-GO verdict is not this rail's business, got %v", got)
 	}
 	if _, demoted := extra["verdictDemoted"]; demoted {
 		t.Fatalf("expected no demotion marker on a non-GO verdict, extra=%v", extra)
+	}
+}
+
+// TestTranscriptRanGoTest_CommandPrefixes pins the command-position anchor on
+// both sides: the prefixes a reviewer naturally types in front of `go test`
+// count as a run, while mentions inside another command's arguments do not.
+func TestTranscriptRanGoTest_CommandPrefixes(t *testing.T) {
+	// rawArgs carries a multi-line script as the JSON the bash tool would
+	// actually receive; bashCallArgs does not escape newlines, so the table
+	// spells that one case out.
+	cases := []struct {
+		name    string
+		command string
+		rawArgs string
+		want    bool
+	}{
+		{name: "bare", command: "go test ./...", want: true},
+		{name: "time prefix", command: "time go test ./pkg/foreman/agent/ -count=1", want: true},
+		{name: "env assignment prefix", command: "GOFLAGS=-v go test ./...", want: true},
+		{name: "two env assignments", command: "CGO_ENABLED=0 GOFLAGS=-mod=mod go test ./...", want: true},
+		{name: "indented line of a script", rawArgs: `{"command":"cd /tmp\n  go test ./..."}`, want: true},
+		{name: "after separator with prefix", command: "cd /tmp && CGO_ENABLED=0 go test ./...", want: true},
+		{name: "grep mention", command: `grep -rn "go test" Makefile`, want: false},
+		{name: "echo mention with prefix", command: `echo "time go test ./..."`, want: false},
+		{name: "comment line", command: "# go test ./...", want: false},
+		{name: "go testing subcommand", command: "go testing ./...", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			call := assistantBash("call-1", tc.command)
+			if tc.rawArgs != "" {
+				call = assistantFunction("call-1", "bash", tc.rawArgs)
+			}
+			tr := []oai.Message{
+				call,
+				toolResult("bash", "call-1", "ok\n"),
+			}
+			if got := transcriptRanGoTest(tr); got != tc.want {
+				t.Fatalf("transcriptRanGoTest(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEnforceReviewerExecution_DiffUnavailableRecordsSkip covers the input the
+// Go-only guard cannot see: when the ground-truth diff fetch failed, diffFiles
+// is nil and hasSourceFile reads that as a docs-only exemption. A GO in that
+// state must be recorded as skipping the rail with the diff-unavailable
+// reason, not the no-test-run reason, and the verdict must stand. A non-GO
+// verdict is still not the rail's business and records nothing.
+func TestEnforceReviewerExecution_DiffUnavailableRecordsSkip(t *testing.T) {
+	diffErr := errors.New("git diff: exit status 128")
+	tr := []oai.Message{
+		assistantBash("call-1", "git diff main...HEAD"),
+		toolResult("bash", "call-1", "fatal: bad revision\n"),
+	}
+
+	extra := map[string]any{}
+	got := enforceReviewerExecution(logr.Discard(), extra, nil, diffErr,
+		foremanv1alpha1.AgenticTaskVerdictGo, tr)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("expected GO to stand when the diff is unavailable (marking, not demotion), got %v", got)
+	}
+	reason, ok := skippedFor(extra, railExecution)
+	if !ok {
+		t.Fatalf("want %s recorded as skipped when the diff is unavailable, extra=%v", railExecution, extra)
+	}
+	if reason != skipReasonNoDiff {
+		t.Fatalf("want reason %q, got %q", skipReasonNoDiff, reason)
+	}
+	for _, marker := range []string{"verdictDemoted", "verdictDemotedBy", "verdictClaimed", "demotionReason"} {
+		if _, present := extra[marker]; present {
+			t.Fatalf("expected no %s marker, extra=%v", marker, extra)
+		}
+	}
+
+	// A transcript that DID run `go test` still records the skip: the rail
+	// has no diff to say whether the run covered the change.
+	extra = map[string]any{}
+	ran := []oai.Message{
+		assistantBash("call-1", "go test ./..."),
+		toolResult("bash", "call-1", "ok\n"),
+	}
+	enforceReviewerExecution(logr.Discard(), extra, nil, diffErr, foremanv1alpha1.AgenticTaskVerdictGo, ran)
+	if reason, ok := skippedFor(extra, railExecution); !ok || reason != skipReasonNoDiff {
+		t.Fatalf("want %s: %s even when go test ran, extra=%v", railExecution, skipReasonNoDiff, extra)
+	}
+
+	// A non-GO verdict is untouched and records nothing.
+	extra = map[string]any{}
+	got = enforceReviewerExecution(logr.Discard(), extra, nil, diffErr,
+		foremanv1alpha1.AgenticTaskVerdictNoGo, tr)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("a non-GO verdict is not this rail's business, got %v", got)
+	}
+	if _, skipped := skippedFor(extra, railExecution); skipped {
+		t.Fatalf("expected no rail-skip on a non-GO verdict, extra=%v", extra)
 	}
 }

--- a/pkg/foreman/agent/review_execution_gate_test.go
+++ b/pkg/foreman/agent/review_execution_gate_test.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+func TestTranscriptRanGoTest_BashCommand(t *testing.T) {
+	tr := []oai.Message{
+		assistantBash("call-1", "go test ./pkg/foreman/agent/ -run TestReviewerSawDiff -count=1"),
+		toolResult("bash", "call-1", "ok  	pkg/foreman/agent\n"),
+	}
+	if !transcriptRanGoTest(tr) {
+		t.Fatalf("expected transcriptRanGoTest=true for a `go test` bash command, got false")
+	}
+}
+
+func TestTranscriptRanGoTest_ToolResultOnly(t *testing.T) {
+	// The bash tool echoes the command back in its JSON output; a transcript
+	// that records only the tool result (Name left empty) must still count.
+	tr := []oai.Message{
+		toolResult("", "call-1", `{"command":"go test ./pkg/...","exit_code":0,"stdout":"ok"}`),
+	}
+	if !transcriptRanGoTest(tr) {
+		t.Fatalf("expected transcriptRanGoTest=true for a `go test` tool result, got false")
+	}
+}
+
+func TestTranscriptRanGoTest_NoGoTest(t *testing.T) {
+	tr := []oai.Message{
+		assistantBash("call-1", "git diff main...HEAD"),
+		toolResult("bash", "call-1", "diff --git a/x.go b/x.go\n@@ -1 +1 @@\n"),
+		assistantBash("call-2", "ls -l"),
+		toolResult("bash", "call-2", "total 8\n"),
+	}
+	if transcriptRanGoTest(tr) {
+		t.Fatalf("expected transcriptRanGoTest=false for a transcript with no `go test`, got true")
+	}
+}
+
+func TestTranscriptRanGoTest_EmptyTranscript(t *testing.T) {
+	if transcriptRanGoTest(nil) {
+		t.Fatalf("expected transcriptRanGoTest=false for a nil transcript, got true")
+	}
+	if transcriptRanGoTest([]oai.Message{}) {
+		t.Fatalf("expected transcriptRanGoTest=false for an empty transcript, got true")
+	}
+	// A transcript with only non-bash messages must not count either.
+	tr := []oai.Message{
+		{Role: oai.RoleSystem, Content: "go test ./..."},
+		{Role: oai.RoleUser, Content: "review this"},
+	}
+	if transcriptRanGoTest(tr) {
+		t.Fatalf("expected transcriptRanGoTest=false when no bash/tool message runs `go test`, got true")
+	}
+}
+
+// TestEnforceReviewerExecution_GoDiffRanGoTest is case 1: a .go diff whose
+// transcript contains a `go test` call must not be demoted.
+func TestEnforceReviewerExecution_GoDiffRanGoTest(t *testing.T) {
+	tr := []oai.Message{
+		assistantBash("call-1", "go test ./pkg/foreman/agent/ -run TestReviewerSawDiff -count=1"),
+		toolResult("bash", "call-1", "ok  	pkg/foreman/agent\n"),
+	}
+	extra := map[string]any{}
+	got := enforceReviewerExecution(logr.Discard(), extra, []string{"pkg/foreman/agent/x.go"},
+		foremanv1alpha1.AgenticTaskVerdictGo, tr)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("expected GO to stand when `go test` ran, got %v", got)
+	}
+	if _, demoted := extra["verdictDemoted"]; demoted {
+		t.Fatalf("expected no demotion marker when `go test` ran, extra=%v", extra)
+	}
+	if _, skipped := skippedFor(extra, railExecution); skipped {
+		t.Fatalf("expected no rail-skip when `go test` ran, extra=%v", extra)
+	}
+}
+
+// TestEnforceReviewerExecution_GoDiffNoGoTest is case 2: a .go diff whose
+// transcript never ran `go test` must record the rail skipped and demote GO.
+func TestEnforceReviewerExecution_GoDiffNoGoTest(t *testing.T) {
+	tr := []oai.Message{
+		assistantBash("call-1", "git diff main...HEAD"),
+		toolResult("bash", "call-1", "diff --git a/x.go b/x.go\n@@ -1 +1 @@\n"),
+		assistantBash("call-2", "read_file pkg/foreman/agent/x.go"),
+		toolResult("bash", "call-2", "package agent\n"),
+	}
+	extra := map[string]any{}
+	got := enforceReviewerExecution(logr.Discard(), extra, []string{"pkg/foreman/agent/x.go"},
+		foremanv1alpha1.AgenticTaskVerdictGo, tr)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("expected GO demoted to NO-GO when no `go test` ran, got %v", got)
+	}
+	reason, ok := skippedFor(extra, railExecution)
+	if !ok {
+		t.Fatalf("want %s recorded as skipped, extra=%v", railExecution, extra)
+	}
+	if reason != skipReasonNoTestRun {
+		t.Fatalf("want reason %q, got %q", skipReasonNoTestRun, reason)
+	}
+	if extra["verdictDemotedBy"] != railExecution {
+		t.Fatalf("demotion must name this rail in verdictDemotedBy=%q; got %v",
+			railExecution, extra["verdictDemotedBy"])
+	}
+	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		t.Fatalf("verdictClaimed must archive the original GO, got %v", extra["verdictClaimed"])
+	}
+	if reason, _ := extra["demotionReason"].(string); strings.TrimSpace(reason) == "" {
+		t.Fatalf("expected a non-empty demotionReason, got %v", extra["demotionReason"])
+	}
+}
+
+// TestEnforceReviewerExecution_NonGoDiffExempt is case 3: a non-.go diff with
+// no `go test` is exempt -- the mandatory execution runs only apply to Go.
+func TestEnforceReviewerExecution_NonGoDiffExempt(t *testing.T) {
+	tr := []oai.Message{
+		assistantBash("call-1", "git diff main...HEAD"),
+		toolResult("bash", "call-1", "diff --git a/docs/x.md b/docs/x.md\n@@ -1 +1 @@\n"),
+	}
+	extra := map[string]any{}
+	got := enforceReviewerExecution(logr.Discard(), extra, []string{"docs/x.md"},
+		foremanv1alpha1.AgenticTaskVerdictGo, tr)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("expected a non-.go diff to be exempt (GO stands), got %v", got)
+	}
+	if _, demoted := extra["verdictDemoted"]; demoted {
+		t.Fatalf("expected no demotion for a non-.go diff, extra=%v", extra)
+	}
+	if _, skipped := skippedFor(extra, railExecution); skipped {
+		t.Fatalf("expected no rail-skip for a non-.go diff, extra=%v", extra)
+	}
+}
+
+func TestEnforceReviewerExecution_NonGoVerdictUntouched(t *testing.T) {
+	tr := []oai.Message{
+		assistantBash("call-1", "git diff main...HEAD"),
+		toolResult("bash", "call-1", "diff --git a/x.go b/x.go\n@@ -1 +1 @@\n"),
+	}
+	extra := map[string]any{}
+	got := enforceReviewerExecution(logr.Discard(), extra, []string{"x.go"},
+		foremanv1alpha1.AgenticTaskVerdictNoGo, tr)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("a non-GO verdict is not this rail's business, got %v", got)
+	}
+	if _, demoted := extra["verdictDemoted"]; demoted {
+		t.Fatalf("expected no demotion marker on a non-GO verdict, extra=%v", extra)
+	}
+}

--- a/pkg/foreman/agent/review_execution_gate_test.go
+++ b/pkg/foreman/agent/review_execution_gate_test.go
@@ -1,7 +1,6 @@
 package agent
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -10,24 +9,84 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
 )
 
+// assistantFunction returns an assistant message whose sole tool_call runs the
+// given non-bash tool with the given raw JSON arguments. It mirrors
+// assistantBash (in reviewer_diff_gate_test.go) but sets an arbitrary function
+// name so the review-execution rail can distinguish a bash call from a
+// read_file (or any other tool) that merely mentions `go test`.
+func assistantFunction(id, name, args string) oai.Message {
+	return oai.Message{
+		Role:    oai.RoleAssistant,
+		Content: "",
+		ToolCalls: []oai.ToolCall{
+			{
+				ID:   id,
+				Type: "function",
+				Function: oai.ToolCallFunction{
+					Name:      name,
+					Arguments: args,
+				},
+			},
+		},
+	}
+}
+
 func TestTranscriptRanGoTest_BashCommand(t *testing.T) {
 	tr := []oai.Message{
 		assistantBash("call-1", "go test ./pkg/foreman/agent/ -run TestReviewerSawDiff -count=1"),
-		toolResult("bash", "call-1", "ok  	pkg/foreman/agent\n"),
+		toolResult("bash", "call-1", "ok  \tpkg/foreman/agent\n"),
 	}
 	if !transcriptRanGoTest(tr) {
 		t.Fatalf("expected transcriptRanGoTest=true for a `go test` bash command, got false")
 	}
 }
 
-func TestTranscriptRanGoTest_ToolResultOnly(t *testing.T) {
-	// The bash tool echoes the command back in its JSON output; a transcript
-	// that records only the tool result (Name left empty) must still count.
+func TestTranscriptRanGoTest_ToolResultCorrelatedToBashCall(t *testing.T) {
+	// A bash tool result echoes the command back in its JSON output, so the
+	// rail must count it when the result is correlated (via ToolCallID) to a
+	// bash tool_call -- even though the assistant's own arguments mentioned
+	// no `go test`.
 	tr := []oai.Message{
-		toolResult("", "call-1", `{"command":"go test ./pkg/...","exit_code":0,"stdout":"ok"}`),
+		assistantBash("call-1", "make test-focus"),
+		toolResult("bash", "call-1", `{"command":"go test ./pkg/...","exit_code":0,"stdout":"ok"}`),
 	}
 	if !transcriptRanGoTest(tr) {
-		t.Fatalf("expected transcriptRanGoTest=true for a `go test` tool result, got false")
+		t.Fatalf("expected transcriptRanGoTest=true for a `go test` bash tool result, got false")
+	}
+}
+
+func TestTranscriptRanGoTest_ReadFileResultDoesNotCount(t *testing.T) {
+	// Reading a file whose text carries the literal `go test` is not executing
+	// `go test`. The reviewer must read every touched file (the
+	// review_execution_gate_test.go fixtures contain exactly such a literal),
+	// so a read_file result must not satisfy the rail.
+	tr := []oai.Message{
+		assistantFunction("call-1", "read_file", `{"path":"pkg/foreman/agent/review_execution_gate_test.go"}`),
+		toolResult("read_file", "call-1", "package agent\n\ngo test ./pkg/foreman/agent/ -run TestX -count=1\n"),
+	}
+	if transcriptRanGoTest(tr) {
+		t.Fatalf("expected transcriptRanGoTest=false for a read_file result that merely mentions `go test`, got true")
+	}
+}
+
+func TestTranscriptRanGoTest_GrepMentionDoesNotCount(t *testing.T) {
+	// A grep that only searches for the string `go test` is not a `go test`
+	// run; it must not satisfy the rail.
+	tr := []oai.Message{
+		assistantBash("call-1", `grep -rn "go test" Makefile`),
+		toolResult("bash", "call-1", `matches found`),
+	}
+	if transcriptRanGoTest(tr) {
+		t.Fatalf("expected transcriptRanGoTest=false for a grep that mentions `go test`, got true")
+	}
+
+	// But a `go test` run after a command separator IS executed and counts.
+	tr = []oai.Message{
+		assistantBash("call-1", "cd /tmp && go test ./..."),
+		toolResult("bash", "call-1", "ok\n"),
+	}
+	if !transcriptRanGoTest(tr) {
+		t.Fatalf("expected transcriptRanGoTest=true for a `go test` after `&&`, got false")
 	}
 }
 
@@ -61,11 +120,11 @@ func TestTranscriptRanGoTest_EmptyTranscript(t *testing.T) {
 }
 
 // TestEnforceReviewerExecution_GoDiffRanGoTest is case 1: a .go diff whose
-// transcript contains a `go test` call must not be demoted.
+// transcript contains a `go test` call must not be marked as skipped.
 func TestEnforceReviewerExecution_GoDiffRanGoTest(t *testing.T) {
 	tr := []oai.Message{
 		assistantBash("call-1", "go test ./pkg/foreman/agent/ -run TestReviewerSawDiff -count=1"),
-		toolResult("bash", "call-1", "ok  	pkg/foreman/agent\n"),
+		toolResult("bash", "call-1", "ok  \tpkg/foreman/agent\n"),
 	}
 	extra := map[string]any{}
 	got := enforceReviewerExecution(logr.Discard(), extra, []string{"pkg/foreman/agent/x.go"},
@@ -82,7 +141,8 @@ func TestEnforceReviewerExecution_GoDiffRanGoTest(t *testing.T) {
 }
 
 // TestEnforceReviewerExecution_GoDiffNoGoTest is case 2: a .go diff whose
-// transcript never ran `go test` must record the rail skipped and demote GO.
+// transcript never ran `go test` records the rail as skipped and the GO
+// stands (marking, not demotion).
 func TestEnforceReviewerExecution_GoDiffNoGoTest(t *testing.T) {
 	tr := []oai.Message{
 		assistantBash("call-1", "git diff main...HEAD"),
@@ -93,8 +153,8 @@ func TestEnforceReviewerExecution_GoDiffNoGoTest(t *testing.T) {
 	extra := map[string]any{}
 	got := enforceReviewerExecution(logr.Discard(), extra, []string{"pkg/foreman/agent/x.go"},
 		foremanv1alpha1.AgenticTaskVerdictGo, tr)
-	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
-		t.Fatalf("expected GO demoted to NO-GO when no `go test` ran, got %v", got)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Fatalf("expected GO to stand (marking, not demotion), got %v", got)
 	}
 	reason, ok := skippedFor(extra, railExecution)
 	if !ok {
@@ -103,15 +163,17 @@ func TestEnforceReviewerExecution_GoDiffNoGoTest(t *testing.T) {
 	if reason != skipReasonNoTestRun {
 		t.Fatalf("want reason %q, got %q", skipReasonNoTestRun, reason)
 	}
-	if extra["verdictDemotedBy"] != railExecution {
-		t.Fatalf("demotion must name this rail in verdictDemotedBy=%q; got %v",
-			railExecution, extra["verdictDemotedBy"])
+	if _, ok := extra["verdictDemoted"]; ok {
+		t.Fatalf("expected no verdictDemoted marker, extra=%v", extra)
 	}
-	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
-		t.Fatalf("verdictClaimed must archive the original GO, got %v", extra["verdictClaimed"])
+	if _, ok := extra["verdictDemotedBy"]; ok {
+		t.Fatalf("expected no verdictDemotedBy marker, extra=%v", extra)
 	}
-	if reason, _ := extra["demotionReason"].(string); strings.TrimSpace(reason) == "" {
-		t.Fatalf("expected a non-empty demotionReason, got %v", extra["demotionReason"])
+	if _, ok := extra["verdictClaimed"]; ok {
+		t.Fatalf("expected no verdictClaimed marker, extra=%v", extra)
+	}
+	if _, ok := extra["demotionReason"]; ok {
+		t.Fatalf("expected no demotionReason marker, extra=%v", extra)
 	}
 }
 


### PR DESCRIPTION
## What

Make the reviewer rubric's execution steps enforceable. The two runs Section K asked for (run the diff's own new test; probe one adversarial near-miss) move into Step 1 as mandatory numbered items 7 and 8, and a deterministic rail (`pkg/foreman/agent/review_execution_gate.go`) checks the review transcript of any `.go` diff for a `go test` invocation. A GO with no such run is recorded as skipping the `review-execution` rail (`no-test-run`). The three reviewer Agent manifests are the `make sync-reviewer-prompts` output of the rubric change.

## Why

Refs #1618

The first live Section-K review (`wl-1616-added-lines-review-1616-0`) performed every numbered read, skipped both execution runs, and disclosed the omission in `onTrust`. Numbered step sequences are followed faithfully; checklist prose is treated as advisory. So the mandate has to sit in the numbered sequence, and the transcript has to be checked by code rather than trusted.

## How

The rail mirrors `reviewer_diff_gate.go`: walk the stored transcript, correlate tool results to the assistant tool call that produced them, return a finding, and record a skipped rail through the same `recordRailSkipped` mechanism (`rail_skip.go` gains `railExecution` and `skipReasonNoTestRun`). It is wired in `executor_native.go` directly after the diff gate so its verdict rewrite is what the findings summary reports. Non-`.go` diffs are exempt; a non-GO verdict is left alone. Tests cover: a Go diff whose transcript ran `go test` (GO stands), one that did not (rail recorded, verdict untouched, no demotion markers), a docs-only diff (exempt), a NO-GO input (untouched), a bash result correlated to a bash call (counts), a `read_file` result containing the literal (does not count), and a grep mention versus a `cd && go test` (only the latter counts).

The second commit is a Foreman revision pass driven by the human review below: the rail now marks instead of demoting (the verdict stands, the skipped rail is the record), and the transcript scan counts only executed `bash` commands, correlated through the same tool-call map the diff gate uses, with the regex anchored on a command position so a `grep "go test"` or a `read_file` of a test fixture cannot satisfy it.

The third commit is a hand-written second revision from a further review pass. The rail now takes the diff-fetch error and records itself as skipped (`diff-unavailable`) on a GO whose ground-truth diff never arrived, instead of passing as a docs-only exemption (a nil diff satisfied the Go-only guard). The `rail_skip.go` comment that still called it a demoting rail is fixed. The `go test` anchor now accepts `time`, `sudo`, env-assignment prefixes, and indented script lines, while a grep or echo of the string and a comment line stay negative. Two new tests cover those, and each fails with its production hunk reverted.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (verify gate GATE-PASS on the branch; CI green)
- [x] `make lint` passes locally (CI)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) (currently signed by the Foreman bot; finalized with a human sign-off via `scripts/foreman-finalize.sh` before merge)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): the rubric itself

Assisted-by: Foreman (coder `dsv4-flash-coder`, DeepSeek-V4-Flash-Vision-Exp on vLLM) generated the code, tests and rubric edit from a decided design, then applied the human review findings in a second pass through the revise seam (#951); the verify gate ran the full check suite on both commits. The in-cluster reviewer's GO does not count either time: it captured no diff and ran no tests. The third commit was written by hand with Claude Code from the second review's findings and verified locally (package tests, lint, and a mutation check on each new test). Human review and the merge are mine.

