### PR TITLE
fix(foreman): report gate Job DeadlineExceeded as GATE-ERROR and make the gate deadline settable (#1748)

### DIFF
--- a/cmd/foreman-agent/main.go
+++ b/cmd/foreman-agent/main.go
@@ -801,6 +801,21 @@ func clampInt32(n int) int32 {
 	return int32(n) //nolint:gosec // bounded above
 }
 
+// gateActiveDeadlineSeconds converts the Agent's
+// spec.execution.activeDeadlineSeconds (*int64) into the int32 the gate
+// Job's RunGateJobToolConfig.ActiveDeadlineSeconds field carries. Zero or
+// unset keeps the 1800 s default via applyConfigDefaults; a value above
+// math.MaxInt32 saturates so the int32 field never wraps negative (#1748).
+func gateActiveDeadlineSeconds(n *int64) int32 {
+	if n == nil || *n <= 0 {
+		return 0
+	}
+	if *n > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(*n) //nolint:gosec // bounded above
+}
+
 // assembleAgentRegistry builds an agent's tool registry: native tools
 // filtered by the agent's spec.tools whitelist, then MCP tools appended.
 // MCP tools bypass the whitelist by design (they are already gated by their
@@ -869,14 +884,23 @@ func makeRegistryFactory(
 		// Constructed in pkg/foreman/agent/tools so there is exactly one list.
 		// Keeping it here made a third copy that drifted from the webhook
 		// allow-list, shipping three tools registered but unusable (#1482).
+		// GateActiveDeadlineSeconds threads the verifying Agent's
+		// spec.execution.activeDeadlineSeconds into the gate Job, so a
+		// heavy per-hunk mutation pass can raise the fixed 1800 s default
+		// (#1748). Unset keeps the default via applyConfigDefaults.
+		gateDeadline := gateActiveDeadlineSeconds(nil)
+		if ag.Spec.Execution != nil {
+			gateDeadline = gateActiveDeadlineSeconds(ag.Spec.Execution.ActiveDeadlineSeconds)
+		}
 		native := foremantools.BuildAll(foremantools.ToolDeps{
-			Workspace:        workspace,
-			BashTimeout:      bashTimeout,
-			Client:           kc,
-			ForemanNamespace: foremanNamespace,
-			GateCachePVC:     gateCachePVC,
-			LogTailFn:        logTail,
-			Token:            repo.TokenFromEnvOrFile,
+			Workspace:                 workspace,
+			BashTimeout:               bashTimeout,
+			Client:                    kc,
+			ForemanNamespace:          foremanNamespace,
+			GateCachePVC:              gateCachePVC,
+			LogTailFn:                 logTail,
+			Token:                     repo.TokenFromEnvOrFile,
+			GateActiveDeadlineSeconds: gateDeadline,
 		})
 
 		var mcpTools []foremantools.Tool

--- a/cmd/foreman-agent/main_test.go
+++ b/cmd/foreman-agent/main_test.go
@@ -172,6 +172,31 @@ func TestClampInt32(t *testing.T) {
 	}
 }
 
+func TestGateActiveDeadlineSeconds(t *testing.T) {
+	ptr := func(n int64) *int64 { return &n }
+	max := int64(math.MaxInt32)
+	cases := []struct {
+		name string
+		in   *int64
+		want int32
+	}{
+		{"nil keeps zero (default 1800 later)", nil, 0},
+		{"zero keeps zero", ptr(0), 0},
+		{"negative keeps zero", ptr(-1), 0},
+		{"configured value passes through", ptr(7200), 7200},
+		{"exactly max int32 passes through", ptr(max), math.MaxInt32},
+		{"over max int32 saturates", ptr(max + 1), math.MaxInt32},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gateActiveDeadlineSeconds(tc.in)
+			if got != tc.want {
+				t.Errorf("gateActiveDeadlineSeconds(%v) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSanitizeName(t *testing.T) {
 	cases := []struct {
 		name string

--- a/pkg/foreman/agent/tools/buildall.go
+++ b/pkg/foreman/agent/tools/buildall.go
@@ -57,10 +57,11 @@ func BuildAll(deps ToolDeps) []Tool {
 		&RunGateJobTool{
 			Client: deps.Client,
 			Cfg: RunGateJobToolConfig{
-				Namespace: deps.ForemanNamespace,
-				PVCName:   deps.GateCachePVC,
-				LogTailFn: deps.LogTailFn,
-				CodeHost:  deps.CodeHost,
+				Namespace:             deps.ForemanNamespace,
+				PVCName:               deps.GateCachePVC,
+				LogTailFn:             deps.LogTailFn,
+				CodeHost:              deps.CodeHost,
+				ActiveDeadlineSeconds: deps.GateActiveDeadlineSeconds,
 			},
 		},
 		// fetch_issue: read-only GitHub issue surface for the reviewer. The
@@ -118,6 +119,13 @@ type ToolDeps struct {
 	// chart creates (foreman.gateCache.pvcName). Empty keeps the historical
 	// "no volume mount" behavior (#1538).
 	GateCachePVC string
+
+	// GateActiveDeadlineSeconds bounds the gate Job's wall-clock runtime,
+	// threaded from the verifying Agent's
+	// spec.execution.activeDeadlineSeconds so a heavy per-hunk mutation
+	// pass can be given more than the 1800 s default (#1748). Zero keeps
+	// the default via applyConfigDefaults.
+	GateActiveDeadlineSeconds int32
 
 	// LogTailFn reads a finished gate Job's pod logs back for the model.
 	LogTailFn func(ctx context.Context, namespace, jobName string) string

--- a/pkg/foreman/agent/tools/buildall_test.go
+++ b/pkg/foreman/agent/tools/buildall_test.go
@@ -28,6 +28,40 @@ import (
 	"github.com/defilantech/llmkube/pkg/foreman/agent/tools/catalog"
 )
 
+// TestBuildAll_ThreadsGateActiveDeadlineSeconds is the regression test for
+// #1748: a configured GateActiveDeadlineSeconds on ToolDeps must reach the
+// RunGateJobTool's own config so the gate Job's activeDeadlineSeconds is
+// settable from the verifier Agent. Zero keeps the 1800 s default via
+// applyConfigDefaults (covered by TestApplyConfigDefaults_FillsEveryField).
+func TestBuildAll_ThreadsGateActiveDeadlineSeconds(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		deps ToolDeps
+		want int32
+	}{
+		{"configured deadline reaches the tool", ToolDeps{GateActiveDeadlineSeconds: 7200}, 7200},
+		{"zero stays zero before defaults", ToolDeps{GateActiveDeadlineSeconds: 0}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tools := BuildAll(tc.deps)
+			var got *RunGateJobTool
+			for _, tool := range tools {
+				if gt, ok := tool.(*RunGateJobTool); ok {
+					got = gt
+					break
+				}
+			}
+			if got == nil {
+				t.Fatal("BuildAll did not construct a *RunGateJobTool")
+			}
+			if got.Cfg.ActiveDeadlineSeconds != tc.want {
+				t.Errorf("RunGateJobTool.Cfg.ActiveDeadlineSeconds: want %d got %d",
+					tc.want, got.Cfg.ActiveDeadlineSeconds)
+			}
+		})
+	}
+}
+
 // The webhook allow-list must match the tools that actually exist.
 //
 // A tool registered at runtime but missing from catalog is unusable in both

--- a/pkg/foreman/agent/tools/run_gate_job.go
+++ b/pkg/foreman/agent/tools/run_gate_job.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -375,7 +376,7 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 	// Poll. Job.Status.Succeeded == 1 means GATE-PASS; .Failed >= 1
 	// means GATE-FAIL; neither set after PollTimeout means
 	// GATE-ERROR (apiserver lag or stuck Job).
-	verdict, summary, pollErr := t.pollForTerminal(ctx, cfg, jobName)
+	verdict, summary, pollErr, deadlineHit := t.pollForTerminal(ctx, cfg, jobName)
 
 	// Always try the log tail, even on poll error, so the operator
 	// has *something* to look at.
@@ -384,6 +385,16 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 		logTail = cfg.LogTailFn(ctx, cfg.Namespace, jobName)
 		if len(logTail) > MaxLogTailBytes {
 			logTail = logTail[len(logTail)-MaxLogTailBytes:]
+		}
+	}
+
+	// A DeadlineExceeded kill is a gate infrastructure problem, not a
+	// failing test. Name the phase the Job was in when it died so the
+	// operator can see whether it survived the standard checks and
+	// stalled in a long pass (e.g. per-hunk mutation coverage) (#1748).
+	if deadlineHit {
+		if phase := lastGatePhase(logTail); phase != "" {
+			summary += " during " + phase
 		}
 	}
 
@@ -410,11 +421,14 @@ func (t *RunGateJobTool) Execute(ctx context.Context, args json.RawMessage) (*ag
 }
 
 // pollForTerminal blocks until Job.Status reports a terminal phase or
-// PollTimeout elapses. Returns (verdict, summary, pollError string).
-// pollError is the empty string on a clean Succeeded/Failed.
+// PollTimeout elapses. Returns (verdict, summary, pollError string,
+// deadlineHit bool).
+// pollError is the empty string on a clean Succeeded/Failed;
+// deadlineHit reports whether the terminal state was a DeadlineExceeded
+// kill (so Execute can annotate the summary with the active phase).
 func (t *RunGateJobTool) pollForTerminal(
 	ctx context.Context, cfg RunGateJobToolConfig, jobName string,
-) (string, string, string) {
+) (string, string, string, bool) {
 	deadline := time.Now().Add(cfg.PollTimeout)
 	key := types.NamespacedName{Namespace: cfg.Namespace, Name: jobName}
 
@@ -425,31 +439,74 @@ func (t *RunGateJobTool) pollForTerminal(
 				// Job vanished between Create and Get -- TTL fired or
 				// someone deleted it. Treat as GATE-ERROR.
 				return VerdictGateError, "Job disappeared before reaching a terminal phase",
-					"job not found during poll: " + err.Error()
+					"job not found during poll: " + err.Error(), false
 			}
-			return VerdictGateError, "apiserver poll failed", err.Error()
+			return VerdictGateError, "apiserver poll failed", err.Error(), false
 		}
 
 		switch {
 		case job.Status.Succeeded >= 1:
-			return VerdictGatePass, "all gate checks passed", ""
+			return VerdictGatePass, "all gate checks passed", "", false
 		case job.Status.Failed >= 1:
-			return VerdictGateFail, "one or more gate checks failed", ""
+			if gateJobDeadlineExceeded(&job) {
+				// A DeadlineExceeded kill is a gate infrastructure
+				// problem (the Job ran out of wall-clock), not a failing
+				// test. It maps to GATE-ERROR so the executor retries /
+				// escalates rather than marking the branch bad (#1748).
+				return VerdictGateError,
+					fmt.Sprintf("gate Job exceeded its %ds deadline", cfg.ActiveDeadlineSeconds), "", true
+			}
+			return VerdictGateFail, "one or more gate checks failed", "", false
 		}
 
 		if time.Now().After(deadline) {
 			return VerdictGateError,
 				fmt.Sprintf("Job did not reach a terminal phase within %s", cfg.PollTimeout),
-				"poll timeout"
+				"poll timeout", false
 		}
 
 		select {
 		case <-ctx.Done():
 			return VerdictGateError, "context cancelled while polling Job",
-				ctx.Err().Error()
+				ctx.Err().Error(), false
 		case <-time.After(cfg.PollInterval):
 		}
 	}
+}
+
+// gateJobDeadlineExceeded reports whether a terminated Job's failure
+// condition is the fixed ActiveDeadlineSeconds kill, rather than a
+// check that actually failed. The Kubernetes controller sets a
+// Failed condition with Reason DeadlineExceeded when a Job outlives
+// its activeDeadlineSeconds; every other failure reason means a gate
+// check ran to completion and failed (#1748).
+func gateJobDeadlineExceeded(job *batchv1.Job) bool {
+	for _, cond := range job.Status.Conditions {
+		if cond.Type == batchv1.JobFailed &&
+			cond.Status == corev1.ConditionTrue &&
+			cond.Reason == batchv1.JobReasonDeadlineExceeded {
+			return true
+		}
+	}
+	return false
+}
+
+// gatePhaseHeaderPattern matches the "=== <phase> ===" banner the gate
+// script prints once per phase (clone, standard checks, bite check,
+// per-hunk mutation coverage). We keep the whole header text so the
+// operator sees the base ref carried inside it (e.g. "per-hunk mutation
+// coverage (base=abc123)").
+var gatePhaseHeaderPattern = regexp.MustCompile(`(?m)^=== (.+) ===$`)
+
+// lastGatePhase returns the LAST phase header in a log tail, or "" when
+// none matches. A DeadlineExceeded kill lands mid-phase, so the last
+// complete header tells the operator which pass the Job was in (#1748).
+func lastGatePhase(logTail string) string {
+	matches := gatePhaseHeaderPattern.FindAllStringSubmatch(logTail, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[len(matches)-1][1]
 }
 
 // errorResult is the Terminal=true result returned when something

--- a/pkg/foreman/agent/tools/run_gate_job_test.go
+++ b/pkg/foreman/agent/tools/run_gate_job_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,6 +78,29 @@ func flipStatusOnce(ctx context.Context, c client.Client, key types.NamespacedNa
 		if err := c.Get(ctx, key, &job); err == nil {
 			job.Status.Succeeded = succeeded
 			job.Status.Failed = failed
+			_ = c.Status().Update(ctx, &job)
+			return
+		}
+		time.Sleep(1 * time.Millisecond)
+	}
+}
+
+// flipDeadlineOnce watches for the Job to appear, then marks it Failed
+// with a Failed condition whose Reason is DeadlineExceeded -- the shape
+// the Kubernetes controller sets when a Job outlives its
+// activeDeadlineSeconds (#1748). Mirrors flipStatusOnce's polling so a
+// test can drive the fake apiserver through the same terminal transition.
+func flipDeadlineOnce(ctx context.Context, c client.Client, key types.NamespacedName) {
+	for ctx.Err() == nil {
+		var job batchv1.Job
+		if err := c.Get(ctx, key, &job); err == nil {
+			job.Status.Failed = 1
+			job.Status.Conditions = []batchv1.JobCondition{{
+				Type:    batchv1.JobFailed,
+				Status:  corev1.ConditionTrue,
+				Reason:  batchv1.JobReasonDeadlineExceeded,
+				Message: "Job was active longer than specified deadline",
+			}}
 			_ = c.Status().Update(ctx, &job)
 			return
 		}
@@ -224,6 +248,51 @@ func TestRunGateJob_FailedProducesGATEFAIL(t *testing.T) {
 	}
 	if got, _ := res.Extra["logTail"].(string); !strings.Contains(got, "GATE FAIL") {
 		t.Errorf("logTail should carry failure marker; got %q", got)
+	}
+}
+
+// TestRunGateJob_DeadlineExceededProducesGATEERROR is the regression test
+// for #1748: a gate Job killed by its activeDeadlineSeconds must map to
+// GATE-ERROR (retryable gate infrastructure problem), not GATE-FAIL
+// (branch is bad). The summary names the deadline and, when the log tail
+// carries a phase header, the phase the Job was in when it died.
+func TestRunGateJob_DeadlineExceededProducesGATEERROR(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	c := fake.NewClientBuilder().WithScheme(gateScheme(t)).WithStatusSubresource(&batchv1.Job{}).Build()
+	jobName := "foreman-gate-fake-deadline"
+	key := types.NamespacedName{Namespace: "foreman-system", Name: jobName}
+
+	go flipDeadlineOnce(ctx, c, key)
+
+	tool := &RunGateJobTool{
+		Client: c,
+		Cfg: RunGateJobToolConfig{
+			NameFn:       pinName(jobName),
+			PollInterval: 5 * time.Millisecond,
+			PollTimeout:  2 * time.Second,
+			LogTailFn: func(_ context.Context, _, _ string) string {
+				return "=== bite check (base=main) ===\nok\n" +
+					"=== per-hunk mutation coverage (base=abc) ===\n"
+			},
+		},
+	}
+
+	res, err := tool.Execute(ctx, argsJSON(t, "x/y", "b"))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != VerdictGateError {
+		t.Errorf("Verdict: want %s got %s", VerdictGateError, res.Verdict)
+	}
+	if !strings.Contains(res.Summary, "deadline") {
+		t.Errorf("Summary should name the deadline; got %q", res.Summary)
+	}
+	// The phase annotated onto the summary is the LAST "=== <phase> ==="
+	// header in the tail, which is where the Job stalled.
+	if !strings.Contains(res.Summary, "during per-hunk mutation coverage (base=abc)") {
+		t.Errorf("Summary should carry the active phase; got %q", res.Summary)
 	}
 }
 


### PR DESCRIPTION
## What

Two changes to the verify gate's `run_gate_job` tool. A gate Job killed by its `activeDeadlineSeconds` now maps to GATE-ERROR instead of GATE-FAIL, with a summary that names the deadline and the phase the Job was in (`gate Job exceeded its 1800s deadline during per-hunk mutation coverage (base=...)`). And the deadline is settable: the verifying Agent's `spec.execution.activeDeadlineSeconds` is threaded through `ToolDeps.GateActiveDeadlineSeconds` into `RunGateJobToolConfig.ActiveDeadlineSeconds`, with unset keeping the 1800 s default.

## Why

Refs #1748

`wl-1725-agw-pool-refs` passed its bite check, entered the per-hunk mutation pass on `internal/controller` (39 hunks at about five minutes of envtest each), and was killed at 1800 s. `pollForTerminal` read `Job.Status.Failed >= 1` and reported GATE-FAIL, so a branch whose checks were passing was recorded as a failing gate and its review cascade-failed. Nothing could raise the deadline without a code change. A timeout is a gate infrastructure problem, not a failing test, and the verdict decides whether the Workload treats the branch as bad.

## How

`gateJobDeadlineExceeded` walks the Job's conditions for `JobFailed` with reason `DeadlineExceeded`, the shape the Kubernetes Job controller sets on a deadline kill; every other failure reason keeps GATE-FAIL. `pollForTerminal` returns a `deadlineHit` flag, and `Execute` appends the last `=== <phase> ===` banner found in the log tail (`lastGatePhase`) so the operator can see whether the standard checks survived and where the Job stalled. Defaults are applied before polling, so the summary always names the effective deadline.

The deadline wiring mirrors what `run_coder_job` already does for the coder Job: `cmd/foreman-agent/main.go` reads `agent.Spec.Execution.ActiveDeadlineSeconds` (`*int64`), clamps it to `int32` via `gateActiveDeadlineSeconds` (nil, zero and negative keep the default; values above `MaxInt32` saturate), and passes it through `ToolDeps`. `PollTimeout` keeps deriving as twice the deadline.

Tests: `TestRunGateJob_DeadlineExceededProducesGATEERROR` drives the fake apiserver through a `DeadlineExceeded` terminal state and asserts GATE-ERROR plus the phase suffix; `TestRunGateJob_FailedProducesGATEFAIL` still holds for a plain failure; `TestBuildAll_ThreadsGateActiveDeadlineSeconds` and `TestGateActiveDeadlineSeconds` cover the wiring and the clamp.

Not in this PR: bounding the mutation pass itself, which is #1749. To use the new knob on a fleet, roll the agent image and set `spec.execution.activeDeadlineSeconds` on the verifier Agent.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (verify gate GATE-PASS on the branch; CI green)
- [x] `make lint` passes locally (CI)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/) (Foreman-bot sign-off under my address; squash-merge attributes the commit to me, as with #1741)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change): not user-facing; the Agent field already exists and is documented

Assisted-by: Foreman (coder `dsv4-flash-coder`, DeepSeek-V4-Flash-Vision-Exp on vLLM) generated the code and tests from the decided design in #1748; the verify gate ran the full check suite. I reviewed the diff by hand, ran the two packages' tests, vet and gofmt on the branch, and own the sign-off.
