### PR TITLE
feat(observability): pin the llama.cpp metric contract (#1186)

### DIFF
--- a/docs/observability/amd-gpu-metrics.md
+++ b/docs/observability/amd-gpu-metrics.md
@@ -51,7 +51,9 @@ versions of the same readings.
 <!-- metrics-contract:begin -->
 SLO metrics come from llama.cpp `/metrics` (`--metrics`), not this exporter:
 `llamacpp:predicted_tokens_seconds`, `llamacpp:prompt_tokens_seconds`,
-`llamacpp:requests_processing`. Backend-agnostic and already emitted.
+`llamacpp:requests_processing`, `llamacpp:requests_deferred`. Backend-agnostic
+and already emitted. Pinned in `llamacpp-metrics.md`; scraped by the chart's
+`inference-podmonitor.yaml`.
 <!-- metrics-contract:end -->
 
 ## Known gaps (deliberate)

--- a/docs/observability/llamacpp-metrics.md
+++ b/docs/observability/llamacpp-metrics.md
@@ -1,0 +1,90 @@
+# llama.cpp metric contract
+
+The pinned metric names for the inference tier (issue #700, slice #1186).
+Dashboards and alerts key off these names; changing them is a breaking change
+to this contract and must update `charts/llmkube/dashboards/llamacpp-dashboard.json`
+in the same PR, which is where every `llamacpp:` query lives.
+
+Backend-agnostic: these come from llama.cpp itself, so they are identical on
+CUDA, ROCm and Vulkan servers. The AMD-specific device metrics are a separate
+contract — see `amd-gpu-metrics.md`.
+
+## Source: llama.cpp `/metrics`
+
+Requires the server to run with `--metrics`. Scraped by the chart's
+`inference-podmonitor.yaml` (`prometheus.inferencePodMonitor.enabled`, on by
+default), which selects on the operator's `inference.llmkube.dev/service` label
+and relabels every series with `service`, `model`, `runtime` and `namespace`, so
+a panel can break down per model without naming a target.
+
+<!-- metrics-contract:begin -->
+
+### Throughput
+
+| Metric | Type | Unit | Notes |
+| --- | --- | --- | --- |
+| `llamacpp:predicted_tokens_seconds` | gauge | tokens/s | **decode** throughput — generation |
+| `llamacpp:prompt_tokens_seconds` | gauge | tokens/s | **prefill** throughput — prompt processing |
+
+Keep these separate rather than presenting one "tokens per second". Prefill is
+compute-bound and decode is memory-bandwidth-bound, so they degrade
+independently, and a combined figure hides the case where one collapses while
+the other holds. Observed in practice: a server whose decode fell from 56 to
+5 tokens/s while prefill stayed at its usual rate — a single averaged number
+would have read as a mild dip rather than a 10× regression.
+
+### Saturation
+
+| Metric | Type | Unit | Notes |
+| --- | --- | --- | --- |
+| `llamacpp:requests_processing` | gauge | count | requests in flight |
+| `llamacpp:requests_deferred` | gauge | count | requests queued behind a full slot set — **the queueing signal** |
+| `llamacpp:n_busy_slots_per_decode` | gauge | count | average busy slots per `llama_decode()` call |
+
+`llamacpp:requests_deferred` is what distinguishes "the server is busy" from "the server
+is oversubscribed": it goes above zero only once every parallel slot is
+occupied. Alert on it rather than inferring queueing from latency.
+
+### Totals
+
+| Metric | Type | Notes |
+| --- | --- | --- |
+| `llamacpp:n_decode_total` | counter | decode calls |
+| `llamacpp:tokens_predicted_total` / `llamacpp:tokens_predicted_seconds_total` | counter | generated tokens and time |
+| `llamacpp:prompt_tokens_total` / `llamacpp:prompt_seconds_total` | counter | prompt tokens and time |
+| `llamacpp:prompt_tokens_cached_total` | counter | prompt tokens served from cache — prefix-cache effectiveness |
+| `llamacpp:n_tokens_max` | counter | largest observed sequence length (prompt + generation) |
+| `llamacpp:spec_decode_num_drafts_total`, `llamacpp:spec_decode_num_draft_tokens_total`, `llamacpp:spec_decode_num_accepted_tokens_total` | counter | speculative decoding; emitted unconditionally, at zero, on a server with no draft model |
+| `llamacpp:spec_decode_num_accepted_tokens_per_pos_total` | counter | speculative decoding, labelled by position; the one spec_decode counter that appears only when a draft model is configured |
+
+<!-- metrics-contract:end -->
+
+## Minimum llama.cpp build
+
+Five of the names above are newer than many shipping servers. `prompt_tokens_cached_total`
+arrived in `decaf508b` (2026-08-13) and the four `spec_decode_*` counters in
+`a035a8887` (2026-08-05), so a server older than mid-August 2026 emits neither
+group and a panel keyed on them stays blank rather than erroring. Everything
+else in this contract predates that.
+
+## Known gaps (deliberate)
+
+- **KV-cache occupancy is not exposed.** There is no `kv_cache_usage_ratio` or
+  equivalent in llama.cpp's `/metrics`. Slice #1186 originally pinned that name
+  along with `llamacpp:tokens_per_second`; neither exists. `n_busy_slots_per_decode`
+  is a reasonable saturation proxy but measures slot occupancy, not cache
+  residency, and should be labelled as such rather than substituted.
+- **Per-request attribution**: the metrics are per-server aggregates. Attributing
+  throughput to a caller needs the proxy in front of the server, not this endpoint.
+- **Context-window pressure**: `n_tokens_max` is a high-water mark, not a
+  distribution, so it cannot show how often requests approach the limit.
+
+## Verification
+
+Every metric above was read from a live server rather than from documentation.
+Confirmed on a Strix Halo (gfx1151) node and four other InferenceServices, all
+scraped through the chart's PodMonitor; types and descriptions are the ones the
+server reports in its own metric metadata. The `spec_decode_*` split was checked
+against a build `b10795` server started without `--spec-type`, which emits the
+first three counters at zero and omits
+`llamacpp:spec_decode_num_accepted_tokens_per_pos_total` entirely.

--- a/internal/metrics/testdata/llamacpp-metrics.txt
+++ b/internal/metrics/testdata/llamacpp-metrics.txt
@@ -3,9 +3,14 @@ llamacpp:n_decode_total
 llamacpp:n_tokens_max
 llamacpp:predicted_tokens_seconds
 llamacpp:prompt_seconds_total
+llamacpp:prompt_tokens_cached_total
 llamacpp:prompt_tokens_seconds
 llamacpp:prompt_tokens_total
 llamacpp:requests_deferred
 llamacpp:requests_processing
+llamacpp:spec_decode_num_accepted_tokens_per_pos_total
+llamacpp:spec_decode_num_accepted_tokens_total
+llamacpp:spec_decode_num_draft_tokens_total
+llamacpp:spec_decode_num_drafts_total
 llamacpp:tokens_predicted_seconds_total
 llamacpp:tokens_predicted_total


### PR DESCRIPTION
## What

The contract half of the inference tier:

- `docs/observability/llamacpp-metrics.md` — the pinned metric contract, in the same shape as `amd-gpu-metrics.md`, with `metrics-contract` markers so the suite reads it.
- `internal/metrics/testdata/llamacpp-metrics.txt` — the five emitted names the fixture was missing.

The PodMonitor is gone; see below.

## Why

Refs #1186 — deliberately non-closing, since #1187 still has to read the renegotiated contract off that issue.

Slice 2 of #700. Two of the three metric names pinned in #1186 do not exist in llama.cpp's `/metrics`, so #1187 would build panel queries against metrics that never arrive:

| pinned in #1186 | reality |
| --- | --- |
| `llamacpp:requests_processing` | exists |
| `llamacpp:tokens_per_second` | no such metric |
| `llamacpp:kv_cache_usage_ratio` | no such metric — nothing matching `kv_cache` is exposed |

## How

**Contract.** Throughput is pinned as two metrics rather than one — `llamacpp:predicted_tokens_seconds` (decode) and `llamacpp:prompt_tokens_seconds` (prefill). They bottleneck on different resources and degrade independently, so a combined figure hides one collapsing while the other holds. I watched a server fall from 56 to 5 tokens/s of decode with prefill unchanged; an averaged number would have read as a mild dip rather than a 10x regression.

`llamacpp:requests_deferred` is added as the queueing signal. It rises only once every parallel slot is occupied, which is what separates "busy" from "oversubscribed".

KV-cache occupancy is documented as a known gap rather than substituted, in a section deliberately left outside the contract markers so it can keep naming metrics that do not exist.

**The markers were the real defect.** The doc had none, so `TestDocContractMetrics` walked it and skipped it — a fake metric name in the throughput table left the suite green. With the markers added it correctly flagged five names missing from the fixture, so those are added rather than removed: they are real, just newer. `prompt_tokens_cached_total` landed in `decaf508b` (2026-08-13) and the four `spec_decode_*` counters in `a035a8887` (2026-08-05), so the doc gains a minimum-build note — a server older than mid-August 2026 emits neither group and a panel keyed on them stays blank.

**Splitting the spec_decode caveat.** The doc claimed all four `spec_decode_*` counters appear "only when a draft model is configured". That is right for one of them and wrong for three. A build `b10795` server here started without `--spec-type` emits `spec_decode_num_drafts_total`, `spec_decode_num_draft_tokens_total` and `spec_decode_num_accepted_tokens_total` at zero, and omits only `spec_decode_num_accepted_tokens_per_pos_total`. They are now two rows, matching that split.

**No PodMonitor.** The chart already ships an identical one at `charts/llmkube/templates/inference-podmonitor.yaml`, on by default — same `inference.llmkube.dev/service` Exists selector, same `http` port and `/metrics` path, same 30s interval, same four relabelings, `namespaceSelector.any: true`, and `{{ include "llmkube.fullname" . }}-inference` renders to the same object name. My copy's explicit `action: replace` is the implicit default, so it was byte-equivalent. Any Prometheus with an empty `podMonitorSelector` would adopt both and scrape every llama.cpp pod twice into the same series. `TestInferenceDashboardCoversEveryRuntime` already names the chart template as the thing that relabels `runtime`, so it was the canonical one all along.

**Dashboard pointer.** The header said a rename must update `charts/llmkube/dashboards/amd-gpu-observability.json`, which has zero `llamacpp:` queries. It now points at `llamacpp-dashboard.json`, which has fourteen.

## Verification

- `go test ./internal/metrics/` green.
- Negative control: injecting `llamacpp:totally_fake_metric` into the contract region fails `TestDocContractMetrics` on that name, and removing it goes green — the markers bite.
- The 16 identifiers inside the contract region are exactly the 16 names a live b10795 server emits on `/metrics`.
- `kubectl kustomize config/monitoring` still builds.

Assisted-by: Claude Code (drafted the contract doc and this description; I verified every metric name, type and description against my own running servers and ran the metrics suite).

## Checklist

- [x] Tests added/updated — the `metrics-contract` markers put this doc under `TestDocContractMetrics`, which never read it before, plus five fixture entries.
- [x] `make test` passes locally
- [x] `make lint` passes locally — no Go changes