### PR TITLE
docs(labs): link the build page absolutely so the site prerender resolves it

### DIFF
--- a/docs/site/labs/index.md
+++ b/docs/site/labs/index.md
@@ -23,7 +23,7 @@ written down anywhere you can copy.
 
 | Build | Hardware | Model | Shape |
 | --- | --- | --- | --- |
-| [DeepSeek V4 Flash Vision on two DGX Sparks](deepseek-v4-flash-two-sparks) | 2x GB10, 200 Gb RoCE | DeepSeek-V4-Flash-Vision-Exp | vLLM, TP2 + expert parallel, speculative decoding |
+| [DeepSeek V4 Flash Vision on two DGX Sparks](/docs/labs/deepseek-v4-flash-two-sparks) | 2x GB10, 200 Gb RoCE | DeepSeek-V4-Flash-Vision-Exp | vLLM, TP2 + expert parallel, speculative decoding |
 
 ## What a build page contains
 


### PR DESCRIPTION
## What

One-line fix to the labs index link so the docs site prerenders again.

## Why

Refs #1755

The Netlify deploy of the site fails on the page added in #1755:

```
Error: 404 /docs/deepseek-v4-flash-two-sparks (linked from /docs/labs)
```

The labs index is served at `/docs/labs`, so the bare relative target in the builds table resolved against `/docs/` rather than `/docs/labs/`. SvelteKit treats a broken internal link as fatal during prerender, so the whole build exits non-zero and nothing deploys.

## How

Uses the absolute `/docs/...` form the rest of the docs already prefer over a bare relative one.

The links on the build page itself were never broken. That page sits a directory deeper, so its `../guides/` targets already resolve correctly, which is why the prerender reported only this one.

Verified by running the actual site build against this branch, with `LLMKUBE_DOCS_LOCAL_PATH` pointed at the checkout so the web repo reads these files instead of `main`. Prerender completes and writes the site; the only remaining output is two pre-existing anchor warnings on unrelated pages that the site config explicitly tolerates.

## Checklist

- [ ] Tests added/updated. A one-line documentation link; the build itself is the test and it was run.
- [x] `make test` passes locally. Unaffected, no Go changes.
- [x] `make lint` passes locally. Unaffected, no Go changes.
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated

Assisted-by: Claude Code diagnosed the failure from the Netlify log and made the change, then ran the site build locally to confirm it prerenders. The broken link was introduced in #1755, which was also assisted; the review and the merge are mine.
