### PR TITLE
feat(model): send a Hugging Face token on operator-driven downloads (#1750)

### DIFF
--- a/api/v1alpha1/model_types.go
+++ b/api/v1alpha1/model_types.go
@@ -65,10 +65,21 @@ type ModelSpec struct {
 	SHA256 string `json:"sha256,omitempty"`
 
 	// SourceSecretRef names a Secret (in the Model's namespace) whose keys are
-	// wired as env into the model-downloader init container. Used by s3://
-	// sources for S3-compatible credentials/endpoint: AWS_ACCESS_KEY_ID,
-	// AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_ENDPOINT_URL (path-style, e.g.
-	// https://minio.internal:9000 or https://s3.us-east-1.amazonaws.com).
+	// wired as env into the model-downloader init container.
+	//
+	// s3:// sources read S3-compatible credentials and endpoint from
+	// AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION and AWS_ENDPOINT_URL
+	// (path-style, e.g. https://minio.internal:9000 or
+	// https://s3.us-east-1.amazonaws.com).
+	//
+	// hf:// and huggingface.co sources read HF_TOKEN, which is sent as a bearer
+	// credential so gated and private repositories can be downloaded. The token
+	// is attached only for huggingface.co and is dropped if a redirect leaves
+	// that host, so it never reaches a CDN or any other origin. Omit the key,
+	// or the whole Secret, for public repositories.
+	//
+	// One Secret may carry both sets of keys; each is used only by the source
+	// scheme it belongs to.
 	// +optional
 	SourceSecretRef *corev1.LocalObjectReference `json:"sourceSecretRef,omitempty"`
 

--- a/charts/llmkube/templates/crds/models.yaml
+++ b/charts/llmkube/templates/crds/models.yaml
@@ -465,10 +465,21 @@ spec:
               sourceSecretRef:
                 description: |-
                   SourceSecretRef names a Secret (in the Model's namespace) whose keys are
-                  wired as env into the model-downloader init container. Used by s3://
-                  sources for S3-compatible credentials/endpoint: AWS_ACCESS_KEY_ID,
-                  AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_ENDPOINT_URL (path-style, e.g.
-                  https://minio.internal:9000 or https://s3.us-east-1.amazonaws.com).
+                  wired as env into the model-downloader init container.
+
+                  s3:// sources read S3-compatible credentials and endpoint from
+                  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION and AWS_ENDPOINT_URL
+                  (path-style, e.g. https://minio.internal:9000 or
+                  https://s3.us-east-1.amazonaws.com).
+
+                  hf:// and huggingface.co sources read HF_TOKEN, which is sent as a bearer
+                  credential so gated and private repositories can be downloaded. The token
+                  is attached only for huggingface.co and is dropped if a redirect leaves
+                  that host, so it never reaches a CDN or any other origin. Omit the key,
+                  or the whole Secret, for public repositories.
+
+                  One Secret may carry both sets of keys; each is used only by the source
+                  scheme it belongs to.
                 properties:
                   name:
                     default: ""

--- a/config/crd/bases/inference.llmkube.dev_models.yaml
+++ b/config/crd/bases/inference.llmkube.dev_models.yaml
@@ -461,10 +461,21 @@ spec:
               sourceSecretRef:
                 description: |-
                   SourceSecretRef names a Secret (in the Model's namespace) whose keys are
-                  wired as env into the model-downloader init container. Used by s3://
-                  sources for S3-compatible credentials/endpoint: AWS_ACCESS_KEY_ID,
-                  AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_ENDPOINT_URL (path-style, e.g.
-                  https://minio.internal:9000 or https://s3.us-east-1.amazonaws.com).
+                  wired as env into the model-downloader init container.
+
+                  s3:// sources read S3-compatible credentials and endpoint from
+                  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION and AWS_ENDPOINT_URL
+                  (path-style, e.g. https://minio.internal:9000 or
+                  https://s3.us-east-1.amazonaws.com).
+
+                  hf:// and huggingface.co sources read HF_TOKEN, which is sent as a bearer
+                  credential so gated and private repositories can be downloaded. The token
+                  is attached only for huggingface.co and is dropped if a redirect leaves
+                  that host, so it never reaches a CDN or any other origin. Omit the key,
+                  or the whole Secret, for public repositories.
+
+                  One Secret may carry both sets of keys; each is used only by the source
+                  scheme it belongs to.
                 properties:
                   name:
                     default: ""

--- a/docs/contributors/model-hf-source-spec.md
+++ b/docs/contributors/model-hf-source-spec.md
@@ -144,7 +144,13 @@ After code changes:
 ## Out of scope
 
 - Downloading HuggingFace weights into the cache PVC (that's option 2 from the issue; not needed for the vLLM workflow and adds significant complexity)
-- Auth for HF_TOKEN in the Model controller (runtime handles this)
+- ~~Auth for HF_TOKEN in the Model controller (runtime handles this)~~ **Shipped in #1750.**
+  The operator's own downloads now send a bearer token for `hf://` and
+  `huggingface.co` sources, read from `HF_TOKEN` in `spec.sourceSecretRef`. The
+  original reasoning held only for the runtime-resolved flow (a bare repo ID
+  with `skipModelInit: true`), which left every GGUF Model, every `spec.files`
+  staging and the prefetch Job unable to reach a gated repository at all. See
+  the gated-repositories section of the model cache guide.
 - Format validation against HF model type (leave to the runtime)
 - Supporting HF revisions/branches (user can put `owner/repo@revision` syntax in source if HF supports it via vLLM; don't special-case here)
 

--- a/docs/site/guides/model-cache.md
+++ b/docs/site/guides/model-cache.md
@@ -122,6 +122,59 @@ Strict-taint choices:
 Global `perService` mode only avoids cross-node shared-RWO affinity. It cannot
 make an untolerated external helper pod schedule on a tainted node.
 
+## Gated and private Hugging Face repositories
+
+Most vendor repositories (Llama, Gemma, Mistral and others) require an accepted
+licence and an access token. Put the token in a Secret in the Model's namespace
+and name that Secret in `spec.sourceSecretRef`. The downloader reads the
+`HF_TOKEN` key and sends it as a bearer credential.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hf-token
+stringData:
+  HF_TOKEN: hf_xxx
+---
+apiVersion: inference.llmkube.dev/v1alpha1
+kind: Model
+metadata:
+  name: llama-guard
+spec:
+  source: hf://meta-llama/Llama-Guard-4-12B
+  format: safetensors
+  files:
+    - model.safetensors
+    - config.json
+    - tokenizer.json
+  sourceSecretRef:
+    name: hf-token
+```
+
+Public repositories need none of this. Omit the key, or the Secret entirely,
+and downloads go out unauthenticated as before.
+
+This covers every path the operator downloads on: single-file GGUF, multi-file
+`spec.files` staging, `RefreshPolicy: OnChange` revalidation, the prefetch Job,
+and the macOS Metal agent. It is separate from the runtime token settings
+(`vllmConfig.hfTokenSecretRef` and its equivalents), which hand a token to the
+serving container for the different case where the runtime downloads its own
+weights from a bare repo ID.
+
+Two properties worth knowing:
+
+- **The token is only ever sent to huggingface.co.** A Model pointing at a
+  mirror, a private registry or any other host gets no header, even if the
+  Secret it names carries an `HF_TOKEN` key. One Secret can safely hold both
+  `HF_TOKEN` and the `AWS_*` keys.
+- **It is dropped on a redirect that changes host.** Hugging Face answers a
+  weights request with a redirect to a content host, and the token does not
+  follow it.
+
+Rotating the token is a Secret edit; the new value is picked up the next time a
+pod starts, the same as the S3 credentials.
+
 ## Troubleshooting
 
 ### Pending PVC with `hostpath-provisioner-<node>-*` showing `untolerated taint`

--- a/internal/controller/inferenceservice_storage_test.go
+++ b/internal/controller/inferenceservice_storage_test.go
@@ -395,7 +395,7 @@ var _ = Describe("buildEmptyDirStorageConfig multi-file staging", func() {
 
 var _ = Describe("buildMultiFileInitCommand", func() {
 	It("generates download loop for IfNotPresent policy", func() {
-		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring("printf '%s\\n' \"$MODEL_FILES\""))
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$(dirname "$dest")"`))
@@ -405,13 +405,13 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 	})
 
 	It("fails init container if any curl fails in IfNotPresent policy", func() {
-		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`exit 1`))
 		Expect(cmd).To(ContainSubstring("failed to download"))
 	})
 
 	It("generates HEAD revalidation for OnChange policy", func() {
-		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyOnChange)
+		cmd := buildMultiFileInitCommand(true, false, false, RefreshPolicyOnChange)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring("remote_size"))
 		Expect(cmd).To(ContainSubstring("skipped download"))
@@ -419,18 +419,18 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 	})
 
 	It("uses emptyDir prefix without cache dir for non-cached storage", func() {
-		cmd := buildMultiFileInitCommand(false, false, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(false, false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p /models`))
 		Expect(cmd).NotTo(ContainSubstring(`"$CACHE_DIR"`))
 	})
 
 	It("normalizes hf:// URLs via MODEL_SOURCE in the generated command", func() {
-		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring("normalize_hf_source"))
 	})
 
 	It("uses POSIX-compatible shell (no bashisms)", func() {
-		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).NotTo(ContainSubstring("[["))
 		Expect(cmd).To(ContainSubstring("case"))
 		Expect(cmd).To(ContainSubstring("esac"))
@@ -440,12 +440,12 @@ var _ = Describe("buildMultiFileInitCommand", func() {
 		// The bug: url="${SOURCE%/}$rel" strips trailing slash from SOURCE (which ends in /)
 		// and glues filename directly, producing ".../resolve/main" + "a.gguf" = ".../resolve/maina.gguf"
 		// The fix: url="${SOURCE%/}/$rel" adds the slash back, producing ".../resolve/main/a.gguf"
-		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyIfNotPresent)
+		cmd := buildMultiFileInitCommand(true, false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`url="${SOURCE%/}/$rel"`))
 	})
 
 	It("preserves slash between resolve base and filename in OnChange policy (regression test for #1110)", func() {
-		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyOnChange)
+		cmd := buildMultiFileInitCommand(true, false, false, RefreshPolicyOnChange)
 		Expect(cmd).To(ContainSubstring(`url="${SOURCE%/}/$rel"`))
 	})
 })
@@ -1241,7 +1241,7 @@ var _ = Describe("resolveCacheMode", func() {
 
 var _ = Describe("buildModelInitCommand", func() {
 	It("should generate cached remote download command with env var references", func() {
-		cmd := buildModelInitCommand(false, false, true, RefreshPolicyIfNotPresent)
+		cmd := buildModelInitCommand(false, false, true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
 		Expect(cmd).To(ContainSubstring("curl -f -L"))
@@ -1249,19 +1249,19 @@ var _ = Describe("buildModelInitCommand", func() {
 	})
 
 	It("should generate cached local copy command", func() {
-		cmd := buildModelInitCommand(true, false, true, RefreshPolicyIfNotPresent)
+		cmd := buildModelInitCommand(true, false, true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 		Expect(cmd).To(ContainSubstring(`cp /host-model/model.gguf "$MODEL_PATH.tmp" && mv "$MODEL_PATH.tmp" "$MODEL_PATH"`))
 	})
 
 	It("should generate error exit for uncached local source", func() {
-		cmd := buildModelInitCommand(true, false, false, RefreshPolicyIfNotPresent)
+		cmd := buildModelInitCommand(true, false, false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring("ERROR: Local model source requires model cache"))
 		Expect(cmd).To(ContainSubstring("exit 1"))
 	})
 
 	It("should generate uncached remote download command with env var references", func() {
-		cmd := buildModelInitCommand(false, false, false, RefreshPolicyIfNotPresent)
+		cmd := buildModelInitCommand(false, false, false, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring("curl -f -L"))
 		Expect(cmd).To(ContainSubstring(`"$MODEL_SOURCE"`))
 		Expect(cmd).To(ContainSubstring(`"$MODEL_PATH"`))
@@ -1272,7 +1272,7 @@ var _ = Describe("buildModelInitCommand", func() {
 		// Verify that a malicious source cannot appear in the shell script.
 		// The command is a static template with env var references only.
 		maliciousSource := `https://evil.com/$(touch /pwned).gguf`
-		cmd := buildModelInitCommand(false, false, true, RefreshPolicyIfNotPresent)
+		cmd := buildModelInitCommand(false, false, true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).NotTo(ContainSubstring(maliciousSource))
 		Expect(cmd).NotTo(ContainSubstring("touch"))
 		Expect(cmd).NotTo(ContainSubstring("evil.com"))
@@ -1285,7 +1285,7 @@ var _ = Describe("buildModelInitCommand", func() {
 
 	Context("RefreshPolicy=OnChange (http/https revalidation, issue #619)", func() {
 		It("cached: emits HEAD-based revalidation comparing Content-Length to local file size", func() {
-			cmd := buildModelInitCommand(false, false, true, RefreshPolicyOnChange)
+			cmd := buildModelInitCommand(false, false, true, false, RefreshPolicyOnChange)
 			// Still provisions the cache dir like IfNotPresent.
 			Expect(cmd).To(ContainSubstring(`mkdir -p "$CACHE_DIR"`))
 			// HEAD-based revalidation: compare Content-Length against local file size.
@@ -1298,7 +1298,7 @@ var _ = Describe("buildModelInitCommand", func() {
 		})
 
 		It("uncached: emits the same HEAD-based revalidation without the cache dir mkdir", func() {
-			cmd := buildModelInitCommand(false, false, false, RefreshPolicyOnChange)
+			cmd := buildModelInitCommand(false, false, false, false, RefreshPolicyOnChange)
 			Expect(cmd).To(ContainSubstring("remote_size"))
 			Expect(cmd).To(ContainSubstring(`"$MODEL_SOURCE"`))
 			Expect(cmd).NotTo(ContainSubstring("mkdir -p"))
@@ -1306,7 +1306,7 @@ var _ = Describe("buildModelInitCommand", func() {
 		})
 
 		It("keeps the cached file and exits 0 when revalidation is unreachable", func() {
-			cmd := buildModelInitCommand(false, false, true, RefreshPolicyOnChange)
+			cmd := buildModelInitCommand(false, false, true, false, RefreshPolicyOnChange)
 			// Robustness guard: a network blip must not take down a running
 			// InferenceService on pod restart.
 			Expect(cmd).To(ContainSubstring(`[ -f "$MODEL_PATH" ]`))
@@ -1319,14 +1319,14 @@ var _ = Describe("buildModelInitCommand", func() {
 		It("does not change the local (file://) init path", func() {
 			// file:// sources are owned by the controller (#635); the init
 			// container path must be identical regardless of RefreshPolicy.
-			ifNotPresent := buildModelInitCommand(true, false, true, RefreshPolicyIfNotPresent)
-			onChange := buildModelInitCommand(true, false, true, RefreshPolicyOnChange)
+			ifNotPresent := buildModelInitCommand(true, false, true, false, RefreshPolicyIfNotPresent)
+			onChange := buildModelInitCommand(true, false, true, false, RefreshPolicyOnChange)
 			Expect(onChange).To(Equal(ifNotPresent))
 			Expect(onChange).NotTo(ContainSubstring("remote_size"))
 		})
 
 		It("does not contain user-controlled values in the OnChange command string", func() {
-			cmd := buildModelInitCommand(false, false, true, RefreshPolicyOnChange)
+			cmd := buildModelInitCommand(false, false, true, false, RefreshPolicyOnChange)
 			Expect(cmd).NotTo(ContainSubstring("evil.com"))
 			Expect(cmd).NotTo(ContainSubstring("touch"))
 		})

--- a/internal/controller/model_prefetch_hfauth_test.go
+++ b/internal/controller/model_prefetch_hfauth_test.go
@@ -1,0 +1,87 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+)
+
+// The prefetch Job reuses the serving path's downloader through
+// buildModelStorageConfig, so it inherits Hugging Face auth rather than
+// implementing its own. That inheritance is the thing worth pinning: a future
+// refactor that gives prefetch a bespoke container would silently reintroduce
+// the 401 on gated repositories that #1750 fixed for the serving path.
+func TestPrefetchJob_CarriesHFAuth(t *testing.T) {
+	r := &ModelReconciler{InitContainerImage: defaultPrefetchImage}
+	model := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "llama-guard", Namespace: "default"},
+		Spec: inferencev1alpha1.ModelSpec{
+			Source:          "hf://meta-llama/Llama-Guard-4-12B",
+			Format:          "safetensors",
+			Files:           []string{"model.safetensors", "config.json"},
+			SourceSecretRef: &corev1.LocalObjectReference{Name: "hf-token"},
+		},
+		Status: inferencev1alpha1.ModelStatus{CacheKey: "testcachekey"},
+	}
+
+	job, err := r.buildPrefetchJob(model, nil)
+	if err != nil {
+		t.Fatalf("buildPrefetchJob: %v", err)
+	}
+
+	var downloader *corev1.Container
+	for i := range job.Spec.Template.Spec.InitContainers {
+		c := &job.Spec.Template.Spec.InitContainers[i]
+		if c.Name == "model-downloader" {
+			downloader = c
+		}
+	}
+	if downloader == nil {
+		t.Fatal("prefetch Job has no downloader init container")
+	}
+
+	var sawSecret bool
+	for _, ef := range downloader.EnvFrom {
+		if ef.SecretRef != nil && ef.SecretRef.Name == "hf-token" {
+			sawSecret = true
+		}
+	}
+	if !sawSecret {
+		t.Errorf("downloader does not mount sourceSecretRef, so HF_TOKEN never reaches it; envFrom=%+v", downloader.EnvFrom)
+	}
+
+	script := strings.Join(downloader.Command, " ")
+	if !strings.Contains(script, `-H "Authorization: Bearer ${HF_TOKEN}"`) {
+		t.Errorf("prefetch downloader sends no bearer header:\n%s", script)
+	}
+}
+
+// The same Job for a non-Hugging-Face source must not carry the header, so a
+// secret shared between an S3 Model and an HF Model cannot leak the token to
+// the object store.
+func TestPrefetchJob_NoHFAuthForOtherHosts(t *testing.T) {
+	r := &ModelReconciler{InitContainerImage: defaultPrefetchImage}
+	model := &inferencev1alpha1.Model{
+		ObjectMeta: metav1.ObjectMeta{Name: "mirrored", Namespace: "default"},
+		Spec: inferencev1alpha1.ModelSpec{
+			Source:          "https://mirror.internal/models/model.gguf",
+			Format:          "gguf",
+			SourceSecretRef: &corev1.LocalObjectReference{Name: "hf-token"},
+		},
+		Status: inferencev1alpha1.ModelStatus{CacheKey: "testcachekey"},
+	}
+
+	job, err := r.buildPrefetchJob(model, nil)
+	if err != nil {
+		t.Fatalf("buildPrefetchJob: %v", err)
+	}
+	for _, c := range job.Spec.Template.Spec.InitContainers {
+		if strings.Contains(strings.Join(c.Command, " "), "HF_TOKEN") {
+			t.Errorf("non-HF source leaks the token into %s:\n%s", c.Name, strings.Join(c.Command, " "))
+		}
+	}
+}

--- a/internal/controller/model_storage.go
+++ b/internal/controller/model_storage.go
@@ -287,12 +287,31 @@ func addCACertVolume(volumes *[]corev1.Volume, mounts *[]corev1.VolumeMount, cmd
 	*cmd = caPrelude + *cmd
 }
 
+// hfAuthFn defines the shell helper every Hugging Face transfer goes through
+// when the Model's source is on huggingface.co (#1750). It adds a bearer token
+// from $HF_TOKEN, which reaches the container through the same
+// spec.sourceSecretRef envFrom that already carries the AWS_* keys, and falls
+// back to a plain curl when the key is absent so ungated repos keep working
+// with no Secret at all.
+//
+// A function rather than an interpolated flag because the header value contains
+// a space: `${HF_TOKEN:+-H "Authorization: Bearer $HF_TOKEN"}` word-splits into
+// four arguments and sends a malformed header, and quoting it sends one empty
+// argument when the token is unset.
+//
+// The caller decides whether this is used at all, gating on isHFAuthSource, so
+// the token cannot leak to another host. Redirects are safe to follow with -L:
+// curl drops a caller-supplied Authorization header when a redirect crosses to
+// a different host, which is exactly what the LFS handoff to the CDN needs, so
+// --location-trusted must NOT be added here.
+const hfAuthFn = `hf_curl() { if [ -n "${HF_TOKEN:-}" ]; then curl -H "Authorization: Bearer ${HF_TOKEN}" "$@"; else curl "$@"; fi; }` + " && "
+
 // All transfers write to "$MODEL_PATH.tmp" and mv onto "$MODEL_PATH" on
 // success: the guard is a bare existence check, so publishing the file
 // non-atomically would let an interrupted transfer (OOM-kill, eviction,
 // node reboot) leave a truncated artifact that every subsequent restart
 // treats as cached. See remoteRevalidateScript for the same pattern.
-func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) string {
+func buildModelInitCommand(isLocal, isS3, useCache, isHFAuth bool, refreshPolicy string) string {
 	if useCache {
 		if isLocal {
 			return `mkdir -p "$CACHE_DIR" && rm -f "$MODEL_PATH.tmp" && if [ ! -f "$MODEL_PATH" ]; then echo 'Copying model from local source...'; cp /host-model/model.gguf "$MODEL_PATH.tmp" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model copied successfully'; else echo 'Model already cached, skipping copy'; fi`
@@ -301,9 +320,10 @@ func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) s
 			return `mkdir -p "$CACHE_DIR" && rm -f "$MODEL_PATH.tmp" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model from S3...'; curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$MODEL_PATH.tmp" "${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
 		}
 		if refreshPolicy == RefreshPolicyOnChange {
-			return "mkdir -p \"$CACHE_DIR\" && rm -f \"$MODEL_PATH.tmp\" && " + remoteRevalidateScript
+			return "mkdir -p \"$CACHE_DIR\" && rm -f \"$MODEL_PATH.tmp\" && " + hfAuthPrefix(isHFAuth) + remoteRevalidateScript(isHFAuth)
 		}
-		return `mkdir -p "$CACHE_DIR" && rm -f "$MODEL_PATH.tmp" && if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
+		return `mkdir -p "$CACHE_DIR" && rm -f "$MODEL_PATH.tmp" && ` + hfAuthPrefix(isHFAuth) +
+			`if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; ` + curlCmd(isHFAuth) + ` -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already cached, skipping download'; fi`
 	}
 
 	if isLocal {
@@ -313,9 +333,10 @@ func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) s
 		return `if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model from S3...'; curl --aws-sigv4 "aws:amz:${AWS_REGION}:s3" -u "${AWS_ACCESS_KEY_ID}:${AWS_SECRET_ACCESS_KEY}" -f -L -o "$MODEL_PATH.tmp" "${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already exists, skipping download'; fi`
 	}
 	if refreshPolicy == RefreshPolicyOnChange {
-		return remoteRevalidateScript
+		return hfAuthPrefix(isHFAuth) + remoteRevalidateScript(isHFAuth)
 	}
-	return `if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; curl -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already exists, skipping download'; fi`
+	return hfAuthPrefix(isHFAuth) +
+		`if [ ! -f "$MODEL_PATH" ]; then echo 'Downloading model...'; ` + curlCmd(isHFAuth) + ` -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH" && echo 'Model downloaded successfully'; else echo 'Model already exists, skipping download'; fi`
 }
 
 // remoteRevalidateScript implements RefreshPolicy=OnChange for http/https
@@ -352,16 +373,36 @@ func buildModelInitCommand(isLocal, isS3, useCache bool, refreshPolicy string) s
 // already exists, the script logs and exits 0, keeping the cached file. Only a
 // genuinely-missing file (nothing cached and the fetch failed) fails the init
 // container.
-const remoteRevalidateScript = `echo 'Revalidating model against upstream (RefreshPolicy=OnChange)...'; ` +
-	`remote_size=$(curl -fsSL -I "$MODEL_SOURCE" -o /dev/null -w '%header{content-length}' 2>/dev/null || echo 0); ` +
-	`if [ -f "$MODEL_PATH" ] && [ "$(stat -c %s "$MODEL_PATH" 2>/dev/null || echo 0)" = "$remote_size" ] && [ "$remote_size" != "0" ]; then ` +
-	`echo 'Model revalidated (unchanged, skipped download)'; ` +
-	`else ` +
-	`if curl -fsSL -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH"; then ` +
-	`echo 'Model revalidated (downloaded)'; ` +
-	`elif [ -f "$MODEL_PATH" ]; then echo 'Revalidation unreachable; kept cached copy'; exit 0; ` +
-	`else echo 'ERROR: model missing and revalidation failed'; exit 1; fi; ` +
-	`fi`
+func remoteRevalidateScript(isHFAuth bool) string {
+	c := curlCmd(isHFAuth)
+	return `echo 'Revalidating model against upstream (RefreshPolicy=OnChange)...'; ` +
+		`remote_size=$(` + c + ` -fsSL -I "$MODEL_SOURCE" -o /dev/null -w '%header{content-length}' 2>/dev/null || echo 0); ` +
+		`if [ -f "$MODEL_PATH" ] && [ "$(stat -c %s "$MODEL_PATH" 2>/dev/null || echo 0)" = "$remote_size" ] && [ "$remote_size" != "0" ]; then ` +
+		`echo 'Model revalidated (unchanged, skipped download)'; ` +
+		`else ` +
+		`if ` + c + ` -fsSL -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH"; then ` +
+		`echo 'Model revalidated (downloaded)'; ` +
+		`elif [ -f "$MODEL_PATH" ]; then echo 'Revalidation unreachable; kept cached copy'; exit 0; ` +
+		`else echo 'ERROR: model missing and revalidation failed'; exit 1; fi; ` +
+		`fi`
+}
+
+// curlCmd names the transfer command for a source: the authenticating wrapper
+// for huggingface.co, plain curl everywhere else. hfAuthPrefix emits the
+// wrapper's definition, and must be prepended to any script that uses it.
+func curlCmd(isHFAuth bool) string {
+	if isHFAuth {
+		return "hf_curl"
+	}
+	return "curl"
+}
+
+func hfAuthPrefix(isHFAuth bool) string {
+	if isHFAuth {
+		return hfAuthFn
+	}
+	return ""
+}
 
 func modelInitEnvVars(source, cacheDir, modelPath string) []corev1.EnvVar {
 	envs := []corev1.EnvVar{
@@ -536,7 +577,7 @@ func multiFileInitEnvVars(source, cacheDir string, files []string) []corev1.EnvV
 // values directly in the script. When isS3 is true, the curl command is signed
 // with --aws-sigv4 and uses ${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_PREFIX}/$rel
 // as the per-file URL (S3_PREFIX may be empty for bare-bucket sources).
-func buildMultiFileInitCommand(useCache, isS3 bool, refreshPolicy string) string {
+func buildMultiFileInitCommand(useCache, isS3, isHFAuth bool, refreshPolicy string) string {
 	prefix := `mkdir -p "$CACHE_DIR" && find "$CACHE_DIR" -name '*.tmp' -delete && `
 	if !useCache {
 		prefix = `mkdir -p /models && find /models -name '*.tmp' -delete && `
@@ -584,18 +625,18 @@ func buildMultiFileInitCommand(useCache, isS3 bool, refreshPolicy string) string
 	}
 
 	if refreshPolicy == RefreshPolicyOnChange {
-		body := normalizeFn +
+		body := normalizeFn + hfAuthPrefix(isHFAuth) +
 			`SOURCE="$(normalize_hf_source "$MODEL_SOURCE")" && ` +
 			`printf '%s\n' "$MODEL_FILES" | while IFS= read -r rel; do ` +
 			`[ -n "$rel" ] || continue; ` +
 			`dest="$CACHE_DIR/$rel"; ` +
 			`mkdir -p "$(dirname "$dest")"; ` +
 			`url="${SOURCE%/}/$rel"; ` +
-			`remote_size=$(curl -fsSL -I "$url" -o /dev/null -w '%header{content-length}' 2>/dev/null || echo 0); ` +
+			`remote_size=$(` + curlCmd(isHFAuth) + ` -fsSL -I "$url" -o /dev/null -w '%header{content-length}' 2>/dev/null || echo 0); ` +
 			`if [ -f "$dest" ] && [ "$(stat -c %s "$dest" 2>/dev/null || echo 0)" = "$remote_size" ] && [ "$remote_size" != "0" ]; then ` +
 			`echo "Model artifact $rel revalidated (unchanged, skipped download)"; ` +
 			`else ` +
-			`if curl -fsSL -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest"; then ` +
+			`if ` + curlCmd(isHFAuth) + ` -fsSL -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest"; then ` +
 			`echo "Model artifact $rel revalidated (downloaded)"; ` +
 			`elif [ -f "$dest" ]; then echo "Revalidation unreachable for $rel; kept cached copy"; ` +
 			`else echo "ERROR: model artifact $rel missing and revalidation failed"; exit 1; fi; ` +
@@ -604,7 +645,7 @@ func buildMultiFileInitCommand(useCache, isS3 bool, refreshPolicy string) string
 		return prefix + body
 	}
 
-	body := normalizeFn +
+	body := normalizeFn + hfAuthPrefix(isHFAuth) +
 		`SOURCE="$(normalize_hf_source "$MODEL_SOURCE")" && ` +
 		`printf '%s\n' "$MODEL_FILES" | while IFS= read -r rel; do ` +
 		`[ -n "$rel" ] || continue; ` +
@@ -613,7 +654,7 @@ func buildMultiFileInitCommand(useCache, isS3 bool, refreshPolicy string) string
 		`url="${SOURCE%/}/$rel"; ` +
 		`if [ ! -f "$dest" ]; then ` +
 		`echo "Downloading model artifact $rel..."; ` +
-		`curl -f -L -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest" || { echo "ERROR: failed to download $rel"; exit 1; }; ` +
+		curlCmd(isHFAuth) + ` -f -L -o "$dest.tmp" "$url" && mv "$dest.tmp" "$dest" || { echo "ERROR: failed to download $rel"; exit 1; }; ` +
 		`else echo "Model artifact $rel already cached, skipping download"; fi; ` +
 		`done`
 	return prefix + body
@@ -756,7 +797,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 	}
 	if plan != nil {
 		modelPath := stagedCachePath(cacheDir, plan.Primary)
-		cmd := buildMultiFileInitCommand(true, isS3Source(model.Spec.Source), model.Spec.RefreshPolicy)
+		cmd := buildMultiFileInitCommand(true, isS3Source(model.Spec.Source), isHFAuthSource(model.Spec.Source), model.Spec.RefreshPolicy)
 		env := multiFileInitEnvVars(model.Spec.Source, cacheDir, plan.Files)
 
 		initVolumeMounts := []corev1.VolumeMount{
@@ -844,7 +885,7 @@ func buildCachedStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev1a
 		})
 	}
 
-	cmd := buildModelInitCommand(isLocalModelSource(model.Spec.Source), isS3Source(model.Spec.Source), true, model.Spec.RefreshPolicy)
+	cmd := buildModelInitCommand(isLocalModelSource(model.Spec.Source), isS3Source(model.Spec.Source), true, isHFAuthSource(model.Spec.Source), model.Spec.RefreshPolicy)
 	env := modelInitEnvVars(model.Spec.Source, cacheDir, modelPath)
 	addCACertVolume(&volumes, &initVolumeMounts, &cmd, caCertConfigMap)
 
@@ -887,7 +928,7 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 	if plan != nil {
 		stagedDir := fmt.Sprintf("/models/%s-%s", namespace, model.Name)
 		modelPath := fmt.Sprintf("%s/%s", stagedDir, plan.Primary)
-		cmd := buildMultiFileInitCommand(false, isS3Source(model.Spec.Source), model.Spec.RefreshPolicy)
+		cmd := buildMultiFileInitCommand(false, isS3Source(model.Spec.Source), isHFAuthSource(model.Spec.Source), model.Spec.RefreshPolicy)
 		env := multiFileInitEnvVars(model.Spec.Source, stagedDir, plan.Files)
 
 		initVolumeMounts := []corev1.VolumeMount{{Name: "model-storage", MountPath: "/models"}}
@@ -932,7 +973,7 @@ func buildEmptyDirStorageConfig(model *inferencev1alpha1.Model, isvc *inferencev
 		},
 	}
 
-	cmd := buildModelInitCommand(isLocalModelSource(model.Spec.Source), isS3Source(model.Spec.Source), false, model.Spec.RefreshPolicy)
+	cmd := buildModelInitCommand(isLocalModelSource(model.Spec.Source), isS3Source(model.Spec.Source), false, isHFAuthSource(model.Spec.Source), model.Spec.RefreshPolicy)
 	env := modelInitEnvVars(model.Spec.Source, "", modelPath)
 	addCACertVolume(&volumes, &initVolumeMounts, &cmd, caCertConfigMap)
 

--- a/internal/controller/model_storage_hfauth_test.go
+++ b/internal/controller/model_storage_hfauth_test.go
@@ -23,6 +23,9 @@ func TestIsHFAuthSource(t *testing.T) {
 		{"resolved https url", "https://huggingface.co/org/repo/resolve/main/model.gguf", true},
 		{"host case folded", "https://HuggingFace.CO/org/repo/resolve/main/model.gguf", true},
 		{"www prefix", "https://www.huggingface.co/org/repo/resolve/main/model.gguf", true},
+		// The host is case-insensitive per RFC 3986, including the www. label.
+		// Folding after the trim left this false and downloaded unauthenticated.
+		{"www prefix upper", "https://WWW.HuggingFace.co/org/repo/resolve/main/model.gguf", true},
 		// The gate exists to keep the token off other hosts. A lookalike host is
 		// the case that matters: a prefix match on "huggingface.co" without the
 		// trailing slash would leak the token to an attacker-controlled domain.

--- a/internal/controller/model_storage_hfauth_test.go
+++ b/internal/controller/model_storage_hfauth_test.go
@@ -1,0 +1,133 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+)
+
+// The operator's own downloads had no way to authenticate: only s3:// sources
+// got credentials, so every gated or private Hugging Face repository failed
+// with 401 for GGUF models, for spec.files staging, and for prefetch (#1750).
+// These pin the two halves of the fix: the header is emitted for huggingface.co
+// sources, and for nothing else.
+
+func TestIsHFAuthSource(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   bool
+	}{
+		{"hf scheme", "hf://meta-llama/Llama-Guard-4-12B", true},
+		{"hf scheme with revision", "hf://meta-llama/Llama-Guard-4-12B@abc123", true},
+		{"hf scheme upper", "HF://meta-llama/Llama-Guard-4-12B", true},
+		{"resolved https url", "https://huggingface.co/org/repo/resolve/main/model.gguf", true},
+		{"host case folded", "https://HuggingFace.CO/org/repo/resolve/main/model.gguf", true},
+		{"www prefix", "https://www.huggingface.co/org/repo/resolve/main/model.gguf", true},
+		// The gate exists to keep the token off other hosts. A lookalike host is
+		// the case that matters: a prefix match on "huggingface.co" without the
+		// trailing slash would leak the token to an attacker-controlled domain.
+		{"lookalike host", "https://huggingface.co.evil.example/org/repo/model.gguf", false},
+		{"substring host", "https://nothuggingface.co/org/repo/model.gguf", false},
+		{"other host", "https://cdn.example.com/model.gguf", false},
+		{"s3 source", "s3://models/org/repo/model.gguf", false},
+		{"local source", "/host-model/model.gguf", false},
+		{"empty", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHFAuthSource(tc.source); got != tc.want {
+				t.Errorf("isHFAuthSource(%q) = %v, want %v", tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+// authHeader is the exact text a gated fetch must carry. Asserting the whole
+// string rather than a substring keeps a malformed header (a missing space
+// after "Bearer", say) from passing.
+const authHeader = `-H "Authorization: Bearer ${HF_TOKEN}"`
+
+func TestBuildModelInitCommand_HFAuth(t *testing.T) {
+	for _, policy := range []string{RefreshPolicyIfNotPresent, RefreshPolicyOnChange} {
+		for _, useCache := range []bool{true, false} {
+			t.Run(policy+"/cache="+boolStr(useCache), func(t *testing.T) {
+				withAuth := buildModelInitCommand(false, false, useCache, true, policy)
+				if !strings.Contains(withAuth, authHeader) {
+					t.Errorf("HF source: no bearer header in:\n%s", withAuth)
+				}
+				if !strings.Contains(withAuth, "hf_curl()") {
+					t.Error("HF source: the hf_curl definition is missing, so the script would fail with 'not found'")
+				}
+				// Defining the wrapper is not enough: the transfer has to call
+				// it. A script that defines hf_curl and then runs plain curl
+				// downloads unauthenticated and still contains every string a
+				// laxer assertion would look for.
+				if strings.Count(withAuth, "hf_curl ") == 0 {
+					t.Errorf("HF source defines hf_curl but never invokes it:\n%s", withAuth)
+				}
+				for _, plainCall := range []string{"; curl -", "$(curl -", "if curl -"} {
+					if strings.Contains(withAuth, plainCall) {
+						t.Errorf("HF source still has an unauthenticated transfer (%q):\n%s", plainCall, withAuth)
+					}
+				}
+				// --location-trusted would carry the token across the LFS redirect
+				// to the CDN, which is exactly what must not happen.
+				if strings.Contains(withAuth, "--location-trusted") {
+					t.Error("--location-trusted sends the token to the redirect target")
+				}
+
+				plain := buildModelInitCommand(false, false, useCache, false, policy)
+				if strings.Contains(plain, "HF_TOKEN") {
+					t.Errorf("non-HF source leaks the token into:\n%s", plain)
+				}
+				if strings.Contains(plain, "hf_curl") {
+					t.Error("non-HF source should call curl directly")
+				}
+			})
+		}
+	}
+}
+
+func TestBuildMultiFileInitCommand_HFAuth(t *testing.T) {
+	for _, policy := range []string{RefreshPolicyIfNotPresent, RefreshPolicyOnChange} {
+		t.Run(policy, func(t *testing.T) {
+			withAuth := buildMultiFileInitCommand(true, false, true, policy)
+			if !strings.Contains(withAuth, authHeader) {
+				t.Errorf("HF multi-file: no bearer header in:\n%s", withAuth)
+			}
+			if !strings.Contains(withAuth, "hf_curl()") {
+				t.Error("HF multi-file: hf_curl definition missing")
+			}
+			if strings.Count(withAuth, "hf_curl ") == 0 {
+				t.Errorf("HF multi-file defines hf_curl but never invokes it:\n%s", withAuth)
+			}
+			for _, plainCall := range []string{"; curl -", "$(curl -", "if curl -"} {
+				if strings.Contains(withAuth, plainCall) {
+					t.Errorf("HF multi-file still has an unauthenticated transfer (%q):\n%s", plainCall, withAuth)
+				}
+			}
+
+			plain := buildMultiFileInitCommand(true, false, false, policy)
+			if strings.Contains(plain, "HF_TOKEN") {
+				t.Errorf("non-HF multi-file leaks the token into:\n%s", plain)
+			}
+
+			// s3:// keeps signing with sigv4 and must not gain a bearer header
+			// even when the source would otherwise qualify.
+			s3 := buildMultiFileInitCommand(true, true, false, policy)
+			if strings.Contains(s3, "HF_TOKEN") {
+				t.Error("s3 multi-file should authenticate with sigv4 only")
+			}
+			if !strings.Contains(s3, "--aws-sigv4") {
+				t.Error("s3 multi-file lost its sigv4 signing")
+			}
+		})
+	}
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/controller/model_storage_hfauth_test.go
+++ b/internal/controller/model_storage_hfauth_test.go
@@ -45,6 +45,45 @@ func TestIsHFAuthSource(t *testing.T) {
 	}
 }
 
+// The host predicates must agree on every input, because each HF branch gates
+// on isHuggingFaceURL and then calls through to hfURLPathSegments. When they
+// disagreed, an uppercase host was a Hugging Face URL to the first and not a
+// Hugging Face URL to the second, producing a source that is neither an HF repo
+// nor a plain remote HTTP file, a combination the Model controller's classifier
+// has no case for. Nothing failed when they drifted, which is why this exists.
+func TestHFHostPredicatesAgree(t *testing.T) {
+	sources := []string{
+		"https://huggingface.co/Qwen/Qwen3-8B/resolve/main/model.gguf",
+		"https://www.huggingface.co/Qwen/Qwen3-8B/resolve/main/model.gguf",
+		"https://WWW.HuggingFace.co/Qwen/Qwen3-8B/resolve/main/model.gguf",
+		"https://HUGGINGFACE.CO/Qwen/Qwen3-8B/resolve/main/model.gguf",
+		"http://huggingface.co/Qwen/Qwen3-8B/resolve/main/model.gguf",
+		"https://huggingface.co.evil.example/Qwen/Qwen3-8B/model.gguf",
+		"https://cdn.example.com/model.gguf",
+		"s3://models/Qwen/model.gguf",
+		"",
+	}
+	for _, src := range sources {
+		_, segOK := hfURLPathSegments(src)
+		if got := isHuggingFaceURL(src); got != segOK {
+			t.Errorf("%q: isHuggingFaceURL=%v but hfURLPathSegments ok=%v; the two must agree",
+				src, got, segOK)
+		}
+	}
+}
+
+// The repo path is case-sensitive even though the host is not, so folding the
+// host must not reach the path.
+func TestHFPathSegmentsPreserveCase(t *testing.T) {
+	segs, ok := hfURLPathSegments("https://WWW.HuggingFace.co/Qwen/Qwen3-8B/resolve/main/model.gguf")
+	if !ok {
+		t.Fatal("uppercase host rejected")
+	}
+	if len(segs) < 2 || segs[0] != "Qwen" || segs[1] != "Qwen3-8B" {
+		t.Errorf("repo case not preserved: %v", segs)
+	}
+}
+
 // authHeader is the exact text a gated fetch must carry. Asserting the whole
 // string rather than a substring keeps a malformed header (a missing space
 // after "Bearer", say) from passing.

--- a/internal/controller/model_storage_revalidate_test.go
+++ b/internal/controller/model_storage_revalidate_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 // TestRemoteRevalidateScript_Behavioral drives the actual OnChange revalidation
-// shell (remoteRevalidateScript) against a stub HTTP server. It is the
+// shell (remoteRevalidateScript(false)) against a stub HTTP server. It is the
 // regression guard for #1309: the remote-size probe must read Content-Length
 // from the HEAD response. A HEAD has no body, so the earlier
 // -w '%{size_download}' always reported 0, the size comparison never matched,
@@ -81,7 +81,7 @@ func TestRemoteRevalidateScript_Behavioral(t *testing.T) {
 				t.Fatalf("seed cache: %v", err)
 			}
 		}
-		cmd := exec.Command("sh", "-c", remoteRevalidateScript)
+		cmd := exec.Command("sh", "-c", remoteRevalidateScript(false))
 		cmd.Env = append(os.Environ(),
 			"MODEL_SOURCE="+srv.URL+"/model.gguf",
 			"MODEL_PATH="+modelPath,

--- a/internal/controller/model_storage_test.go
+++ b/internal/controller/model_storage_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("buildModelInitCommand (s3)", func() {
 	It("should emit the --aws-sigv4 curl line for s3 source with cache", func() {
-		cmd := buildModelInitCommand(false, true, true, "")
+		cmd := buildModelInitCommand(false, true, true, false, "")
 		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
 		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}"))
 		Expect(cmd).To(ContainSubstring("Downloading model from S3"))
@@ -39,7 +39,7 @@ var _ = Describe("buildModelInitCommand (s3)", func() {
 	})
 
 	It("should emit the --aws-sigv4 curl line for s3 source without cache", func() {
-		cmd := buildModelInitCommand(false, true, false, "")
+		cmd := buildModelInitCommand(false, true, false, false, "")
 		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
 		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}"))
 		Expect(cmd).To(ContainSubstring("Downloading model from S3"))
@@ -50,7 +50,7 @@ var _ = Describe("buildModelInitCommand (s3)", func() {
 	})
 
 	It("should NOT emit --aws-sigv4 for non-s3 source", func() {
-		cmd := buildModelInitCommand(false, false, true, "")
+		cmd := buildModelInitCommand(false, false, true, false, "")
 		Expect(cmd).ToNot(ContainSubstring("aws-sigv4"))
 		Expect(cmd).To(ContainSubstring(`curl -f -L -o "$MODEL_PATH.tmp" "$MODEL_SOURCE" && mv "$MODEL_PATH.tmp" "$MODEL_PATH"`))
 	})
@@ -66,14 +66,14 @@ var _ = Describe("buildModelInitCommand (s3)", func() {
 			{false, true, false},  // s3, uncached
 			{true, false, true},   // local, cached
 		} {
-			cmd := buildModelInitCommand(tc[0], tc[1], tc[2], "")
+			cmd := buildModelInitCommand(tc[0], tc[1], tc[2], false, "")
 			Expect(cmd).ToNot(ContainSubstring(`-o "$MODEL_PATH" `), cmd)
 			Expect(cmd).ToNot(ContainSubstring(`cp /host-model/model.gguf "$MODEL_PATH" `), cmd)
 		}
 	})
 
 	It("should emit the --aws-sigv4 curl line for s3 source with OnChange refresh", func() {
-		cmd := buildModelInitCommand(false, true, true, RefreshPolicyOnChange)
+		cmd := buildModelInitCommand(false, true, true, false, RefreshPolicyOnChange)
 		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
 		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/${S3_KEY}"))
 	})
@@ -84,22 +84,22 @@ var _ = Describe("buildModelInitCommand (s3)", func() {
 // new download so they do not accumulate on the shared cache PVC.
 var _ = Describe("buildModelInitCommand (orphan .tmp cleanup, #1435)", func() {
 	It("should remove stale .tmp before downloading in cached remote path", func() {
-		cmd := buildModelInitCommand(false, false, true, RefreshPolicyIfNotPresent)
+		cmd := buildModelInitCommand(false, false, true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`rm -f "$MODEL_PATH.tmp"`))
 	})
 
 	It("should remove stale .tmp before downloading in cached S3 path", func() {
-		cmd := buildModelInitCommand(false, true, true, RefreshPolicyIfNotPresent)
+		cmd := buildModelInitCommand(false, true, true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`rm -f "$MODEL_PATH.tmp"`))
 	})
 
 	It("should remove stale .tmp before downloading in cached local path", func() {
-		cmd := buildModelInitCommand(true, false, true, RefreshPolicyIfNotPresent)
+		cmd := buildModelInitCommand(true, false, true, false, RefreshPolicyIfNotPresent)
 		Expect(cmd).To(ContainSubstring(`rm -f "$MODEL_PATH.tmp"`))
 	})
 
 	It("should remove stale .tmp before downloading in cached OnChange path", func() {
-		cmd := buildModelInitCommand(false, false, true, RefreshPolicyOnChange)
+		cmd := buildModelInitCommand(false, false, true, false, RefreshPolicyOnChange)
 		Expect(cmd).To(ContainSubstring(`rm -f "$MODEL_PATH.tmp"`))
 	})
 })
@@ -125,7 +125,7 @@ var _ = Describe("modelInitEnvVars (s3)", func() {
 
 var _ = Describe("buildMultiFileInitCommand (s3)", func() {
 	It("should emit --aws-sigv4 for s3 source with cache (IfNotPresent)", func() {
-		cmd := buildMultiFileInitCommand(true, true, "")
+		cmd := buildMultiFileInitCommand(true, true, false, "")
 		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
 		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/"))
 		Expect(cmd).To(ContainSubstring("${S3_PREFIX:+${S3_PREFIX}/}"))
@@ -136,14 +136,14 @@ var _ = Describe("buildMultiFileInitCommand (s3)", func() {
 	})
 
 	It("should emit --aws-sigv4 for s3 source without cache (emptyDir)", func() {
-		cmd := buildMultiFileInitCommand(false, true, "")
+		cmd := buildMultiFileInitCommand(false, true, false, "")
 		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
 		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/"))
 		Expect(cmd).To(ContainSubstring("${S3_PREFIX:+${S3_PREFIX}/}"))
 	})
 
 	It("should emit --aws-sigv4 for s3 source with OnChange refresh", func() {
-		cmd := buildMultiFileInitCommand(true, true, RefreshPolicyOnChange)
+		cmd := buildMultiFileInitCommand(true, true, false, RefreshPolicyOnChange)
 		Expect(cmd).To(ContainSubstring("curl --aws-sigv4"))
 		Expect(cmd).To(ContainSubstring("${AWS_ENDPOINT_URL}/${S3_BUCKET}/"))
 		Expect(cmd).To(ContainSubstring("${S3_PREFIX:+${S3_PREFIX}/}"))
@@ -151,14 +151,14 @@ var _ = Describe("buildMultiFileInitCommand (s3)", func() {
 	})
 
 	It("should NOT emit --aws-sigv4 for non-s3 source (HTTP regression)", func() {
-		cmd := buildMultiFileInitCommand(true, false, "")
+		cmd := buildMultiFileInitCommand(true, false, false, "")
 		Expect(cmd).ToNot(ContainSubstring("aws-sigv4"))
 		Expect(cmd).To(ContainSubstring(`curl -f -L -o "$dest.tmp" "$url"`))
 		Expect(cmd).To(ContainSubstring("${SOURCE%/}/$rel"))
 	})
 
 	It("should NOT emit --aws-sigv4 for non-s3 source with OnChange (HTTP regression)", func() {
-		cmd := buildMultiFileInitCommand(true, false, RefreshPolicyOnChange)
+		cmd := buildMultiFileInitCommand(true, false, false, RefreshPolicyOnChange)
 		Expect(cmd).ToNot(ContainSubstring("aws-sigv4"))
 		Expect(cmd).To(ContainSubstring(`curl -fsSL -o "$dest.tmp" "$url"`))
 		Expect(cmd).To(ContainSubstring("${SOURCE%/}/$rel"))

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -284,10 +284,22 @@ func hfURLPathSegments(source string) (segments []string, ok bool) {
 	} else {
 		return nil, false
 	}
+	// Fold ONLY the host, up to the first slash: the host is case-insensitive
+	// per RFC 3986 but the repo path is not, so Qwen/Qwen3-8B must keep its
+	// capital Q. Folding has to happen before the www. trim, or an uppercase
+	// label survives and the match below fails.
+	//
+	// This has to agree with isHuggingFaceURL. When it did not, an uppercase
+	// host classified as a Hugging Face URL there and as nothing here, leaving
+	// a source that was neither an HF repo nor a plain remote HTTP file, which
+	// no branch in the Model controller's classifier handles.
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		rest = strings.ToLower(rest[:i]) + rest[i:]
+	}
 	rest = strings.TrimPrefix(rest, "www.")
-	// "huggingface.co/" is 15 bytes in any case, so slicing by the literal
-	// length is safe after a case-insensitive prefix check.
-	if !strings.HasPrefix(strings.ToLower(rest), "huggingface.co/") {
+	// "huggingface.co/" is 15 bytes in any case, and the host is folded above,
+	// so slicing by the literal length is safe.
+	if !strings.HasPrefix(rest, "huggingface.co/") {
 		return nil, false
 	}
 	rest = rest[len("huggingface.co/"):]

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -246,10 +246,15 @@ func isHuggingFaceURL(source string) bool {
 	} else {
 		rest = rest[len("http://"):]
 	}
-	rest = strings.TrimPrefix(rest, "www.")
 	// Host is case-insensitive per RFC 3986; the repo path is not (Qwen/... must
-	// keep its case), so only lower-case for the host comparison.
-	return strings.HasPrefix(strings.ToLower(rest), "huggingface.co/")
+	// keep its case), so only lower-case for the host comparison. Fold BEFORE
+	// trimming the www. label: trimming first leaves "WWW.huggingface.co"
+	// untouched and the match fails, which for the auth gate means downloading
+	// unauthenticated rather than sending the token. It fails safe, but the code
+	// disagreed with this comment.
+	rest = strings.ToLower(rest)
+	rest = strings.TrimPrefix(rest, "www.")
+	return strings.HasPrefix(rest, "huggingface.co/")
 }
 
 // isHFAuthSource reports whether the operator's own downloads for this source

--- a/internal/controller/source.go
+++ b/internal/controller/source.go
@@ -252,6 +252,19 @@ func isHuggingFaceURL(source string) bool {
 	return strings.HasPrefix(strings.ToLower(rest), "huggingface.co/")
 }
 
+// isHFAuthSource reports whether the operator's own downloads for this source
+// should carry a Hugging Face bearer token. True for both spellings the
+// downloader accepts: an hf:// source, which normalize_hf_source rewrites to
+// huggingface.co at run time, and a literal huggingface.co URL.
+//
+// This is the gate that keeps the token off every other host (#1750). The
+// header is emitted only when this returns true, so a Model pointing at a
+// mirror, a private registry, or an arbitrary https:// URL never sees it, even
+// if the referenced Secret happens to carry an HF_TOKEN key.
+func isHFAuthSource(source string) bool {
+	return hasSchemeFold(source, "hf://") || isHuggingFaceURL(source)
+}
+
 // hfURLPathSegments returns the non-empty path segments after the
 // "huggingface.co/" host for a huggingface.co URL, with any query string or
 // fragment stripped. ok is false when source is not a huggingface.co URL.

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -349,7 +349,7 @@ func (e *MetalExecutor) fetchModel(ctx context.Context, source, filePath string,
 	// Read from the same sourceSecretRef the S3 path uses, and attached only for
 	// huggingface.co so a Model pointing at another host never sees it.
 	var token string
-	if isHFAuthSource(source) && secretRef != nil {
+	if isHFAuthHost(source) && secretRef != nil {
 		token = e.resolveHFToken(ctx, secretRef.Name)
 	}
 	return e.downloadFile(ctx, source, filePath, token)

--- a/pkg/agent/executor.go
+++ b/pkg/agent/executor.go
@@ -18,6 +18,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -344,7 +345,14 @@ func (e *MetalExecutor) fetchModel(ctx context.Context, source, filePath string,
 	if isS3Source(source) {
 		return e.downloadS3(ctx, source, filePath, secretRef)
 	}
-	return e.downloadFile(ctx, source, filePath)
+	// Gated and private Hugging Face repositories need a bearer token (#1750).
+	// Read from the same sourceSecretRef the S3 path uses, and attached only for
+	// huggingface.co so a Model pointing at another host never sees it.
+	var token string
+	if isHFAuthSource(source) && secretRef != nil {
+		token = e.resolveHFToken(ctx, secretRef.Name)
+	}
+	return e.downloadFile(ctx, source, filePath, token)
 }
 
 // downloadS3 fetches an s3:// source into filePath using AWS SigV4 signing and
@@ -392,13 +400,30 @@ func (e *MetalExecutor) downloadS3(ctx context.Context, source, filePath string,
 	return e.copyToFile(filePath, resp.Body, resp.ContentLength)
 }
 
-func (e *MetalExecutor) downloadFile(ctx context.Context, url, filePath string) error {
+// downloadFile fetches url into filePath. token, when non-empty, is sent as a
+// bearer credential on the FIRST hop only.
+//
+// The redirect handling is deliberate and stricter than net/http's default.
+// Go strips Authorization only when a redirect leaves the registrable domain
+// (shouldCopyHeaderOnRedirect uses isDomainOrSubdomain), so it keeps the header
+// for a subdomain, and keeps it for a different port on the same host. Hugging
+// Face answers a weights request with a redirect to its CDN, and whether that
+// lands on another domain or a subdomain is not ours to depend on: a token
+// scoped to huggingface.co has no business reaching a content host either way,
+// which is also why huggingface_hub does not send it there. hfRedirectStripper
+// therefore drops the header on ANY change of host.
+func (e *MetalExecutor) downloadFile(ctx context.Context, url, filePath, token string) error {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return err
 	}
+	httpClient := http.DefaultClient
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+		httpClient = hfRedirectStripper()
+	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
 	}
@@ -409,6 +434,24 @@ func (e *MetalExecutor) downloadFile(ctx context.Context, url, filePath string) 
 	}
 
 	return e.copyToFile(filePath, resp.Body, resp.ContentLength)
+}
+
+// hfRedirectStripper returns a client that removes the Authorization header
+// whenever a redirect changes the host, comparing host and port rather than
+// registrable domain. Everything else matches http.DefaultClient, including
+// the ten-redirect ceiling that CheckRedirect is expected to enforce.
+func hfRedirectStripper() *http.Client {
+	c := *http.DefaultClient
+	c.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if len(via) > 0 && req.URL.Host != via[0].URL.Host {
+			req.Header.Del("Authorization")
+		}
+		return nil
+	}
+	return &c
 }
 
 // copyToFile streams r into filePath atomically: it writes to a ".partial"

--- a/pkg/agent/executor_hfauth_test.go
+++ b/pkg/agent/executor_hfauth_test.go
@@ -1,0 +1,123 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"go.uber.org/zap"
+)
+
+func hfTestExecutor(t *testing.T, store string) *MetalExecutor {
+	t.Helper()
+	lg, _ := zap.NewDevelopment()
+	return &MetalExecutor{modelStorePath: store, logger: lg.Sugar()}
+}
+
+// A gated repository 401s without a bearer token. This asserts the token
+// reaches the first hop.
+func TestDownloadFile_SendsBearerToken(t *testing.T) {
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("weights"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "model.gguf")
+	if err := hfTestExecutor(t, dir).downloadFile(t.Context(), srv.URL+"/model.gguf", dst, "hf_secret"); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if got != "Bearer hf_secret" {
+		t.Errorf("Authorization = %q, want %q", got, "Bearer hf_secret")
+	}
+	if b, _ := os.ReadFile(dst); string(b) != "weights" {
+		t.Errorf("body = %q", string(b))
+	}
+}
+
+// No token means no header at all, rather than an empty one, so an ungated
+// repository behaves exactly as it did before this change.
+func TestDownloadFile_NoTokenSendsNoHeader(t *testing.T) {
+	var present bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, present = r.Header["Authorization"]
+		_, _ = w.Write([]byte("weights"))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "m.gguf")
+	if err := hfTestExecutor(t, dir).downloadFile(t.Context(), srv.URL+"/m.gguf", dst, ""); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if present {
+		t.Error("Authorization header sent with no token")
+	}
+}
+
+// The one that matters. Hugging Face answers a weights request with a redirect
+// to its CDN on a different host; the token must not follow, or a credential
+// for huggingface.co is handed to an unrelated origin. net/http strips it on a
+// cross-host redirect, and this pins that behaviour so a future switch to a
+// custom client or a CheckRedirect override cannot silently remove it.
+func TestDownloadFile_TokenNotForwardedAcrossHosts(t *testing.T) {
+	var cdnAuth string
+	var cdnHit bool
+	cdn := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cdnHit = true
+		cdnAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("weights-from-cdn"))
+	}))
+	defer cdn.Close()
+
+	var originAuth string
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originAuth = r.Header.Get("Authorization")
+		http.Redirect(w, r, cdn.URL+"/blob", http.StatusFound)
+	}))
+	defer origin.Close()
+
+	dir := t.TempDir()
+	dst := filepath.Join(dir, "model.gguf")
+	if err := hfTestExecutor(t, dir).downloadFile(t.Context(), origin.URL+"/model.gguf", dst, "hf_secret"); err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	if originAuth != "Bearer hf_secret" {
+		t.Errorf("origin Authorization = %q, want the token on the first hop", originAuth)
+	}
+	if !cdnHit {
+		t.Fatal("redirect was not followed, so the test proves nothing")
+	}
+	if cdnAuth != "" {
+		t.Errorf("token leaked across hosts: CDN saw %q", cdnAuth)
+	}
+	if b, _ := os.ReadFile(dst); string(b) != "weights-from-cdn" {
+		t.Errorf("body = %q, want the redirected content", string(b))
+	}
+}
+
+func TestIsHFAuthSource_Agent(t *testing.T) {
+	tests := []struct {
+		source string
+		want   bool
+	}{
+		{"hf://meta-llama/Llama-Guard-4-12B", true},
+		{"HF://meta-llama/Llama-Guard-4-12B", true},
+		{"https://huggingface.co/org/repo/resolve/main/m.gguf", true},
+		{"https://HuggingFace.CO/org/repo/resolve/main/m.gguf", true},
+		{"https://www.huggingface.co/org/repo/resolve/main/m.gguf", true},
+		{"https://huggingface.co.evil.example/org/repo/m.gguf", false},
+		{"https://cdn.example.com/m.gguf", false},
+		{"s3://models/org/repo/m.gguf", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		if got := isHFAuthSource(tc.source); got != tc.want {
+			t.Errorf("isHFAuthSource(%q) = %v, want %v", tc.source, got, tc.want)
+		}
+	}
+}

--- a/pkg/agent/executor_hfauth_test.go
+++ b/pkg/agent/executor_hfauth_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"go.uber.org/zap"
@@ -100,24 +101,46 @@ func TestDownloadFile_TokenNotForwardedAcrossHosts(t *testing.T) {
 	}
 }
 
-func TestIsHFAuthSource_Agent(t *testing.T) {
+// hf:// is NOT in this table. The metal downloader cannot fetch that scheme at
+// all, so a predicate that accepted it would be authenticating a request that
+// never gets made; TestDownloadFile_HFSchemeUnsupported pins that instead.
+func TestIsHFAuthHost(t *testing.T) {
 	tests := []struct {
 		source string
 		want   bool
 	}{
-		{"hf://meta-llama/Llama-Guard-4-12B", true},
-		{"HF://meta-llama/Llama-Guard-4-12B", true},
 		{"https://huggingface.co/org/repo/resolve/main/m.gguf", true},
 		{"https://HuggingFace.CO/org/repo/resolve/main/m.gguf", true},
 		{"https://www.huggingface.co/org/repo/resolve/main/m.gguf", true},
+		{"https://WWW.HuggingFace.co/org/repo/resolve/main/m.gguf", true},
+		{"http://huggingface.co/org/repo/resolve/main/m.gguf", true},
 		{"https://huggingface.co.evil.example/org/repo/m.gguf", false},
+		{"https://nothuggingface.co/org/repo/m.gguf", false},
 		{"https://cdn.example.com/m.gguf", false},
+		{"hf://meta-llama/Llama-Guard-4-12B", false},
 		{"s3://models/org/repo/m.gguf", false},
 		{"", false},
 	}
 	for _, tc := range tests {
-		if got := isHFAuthSource(tc.source); got != tc.want {
-			t.Errorf("isHFAuthSource(%q) = %v, want %v", tc.source, got, tc.want)
+		if got := isHFAuthHost(tc.source); got != tc.want {
+			t.Errorf("isHFAuthHost(%q) = %v, want %v", tc.source, got, tc.want)
 		}
+	}
+}
+
+// The metal path cannot fetch hf:// today: nothing here rewrites it to a
+// resolve URL the way the init container's normalize_hf_source does, so the
+// request fails on the scheme long before a token would matter. Pinned so the
+// gap is visible and a future fix has to come through this test.
+func TestDownloadFile_HFSchemeUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	err := hfTestExecutor(t, dir).downloadFile(
+		t.Context(), "hf://meta-llama/Llama-Guard-4-12B", filepath.Join(dir, "m.gguf"), "tok")
+	if err == nil {
+		t.Fatal("hf:// unexpectedly succeeded; if the metal path learned to resolve it, " +
+			"isHFAuthHost should accept hf:// too and this test should change")
+	}
+	if !strings.Contains(err.Error(), "unsupported protocol scheme") {
+		t.Errorf("want an unsupported-scheme error, got: %v", err)
 	}
 }

--- a/pkg/agent/executor_test.go
+++ b/pkg/agent/executor_test.go
@@ -505,7 +505,7 @@ func TestDownloadFile_FailedDownloadLeavesNoFile(t *testing.T) {
 	}
 	localPath := filepath.Join(modelDir, "model.gguf")
 
-	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath)
+	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath, "")
 	if err == nil {
 		t.Fatal("downloadFile should return error for 401 response")
 	}
@@ -580,7 +580,7 @@ func TestDownloadFile_TruncatedDownloadFails(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath)
+	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath, "")
 	if err == nil {
 		t.Fatal("downloadFile should return error for truncated download")
 	}
@@ -609,7 +609,7 @@ func TestDownloadFile_SuccessRenamesTempFile(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath)
+	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath, "")
 	if err != nil {
 		t.Fatalf("downloadFile should succeed: %v", err)
 	}
@@ -648,7 +648,7 @@ func TestDownloadFile_NoContentLength(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath)
+	err := executor.downloadFile(t.Context(), srv.URL+"/model.gguf", localPath, "")
 	if err != nil {
 		t.Fatalf("downloadFile should succeed without Content-Length: %v", err)
 	}
@@ -682,7 +682,7 @@ func TestDownloadFile_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately.
 
-	err := executor.downloadFile(ctx, srv.URL+"/model.gguf", localPath)
+	err := executor.downloadFile(ctx, srv.URL+"/model.gguf", localPath, "")
 	if err == nil {
 		t.Fatal("downloadFile should return error when context is cancelled")
 	}

--- a/pkg/agent/s3.go
+++ b/pkg/agent/s3.go
@@ -100,22 +100,34 @@ func parseS3Source(source string) (bucket, key string, err error) {
 	return bucket, key, nil
 }
 
-// isHFAuthSource reports whether a bearer token should be attached to this
-// source. Mirrors the controller's isHFAuthSource
-// (internal/controller/source.go) so the metal path and the init container
-// agree on which hosts get the token: hf://, which the agent resolves to
-// huggingface.co, and a literal huggingface.co URL. Nothing else, so a Model
-// pointing elsewhere never receives the credential (#1750).
-func isHFAuthSource(source string) bool {
-	if strings.HasPrefix(strings.ToLower(source), "hf://") {
-		return true
-	}
+// isHFAuthHost reports whether a bearer token should be attached to this
+// source on the metal path.
+//
+// Deliberately narrower than the controller's isHFAuthSource
+// (internal/controller/source.go), which also accepts hf://. The metal
+// downloader hands the source straight to http.NewRequestWithContext, and
+// nothing here rewrites hf:// the way the init container's
+// normalize_hf_source does in the shell, so an hf:// Model on a Metal agent
+// fails with `unsupported protocol scheme "hf"` before any credential is
+// consulted. Claiming to authenticate a scheme this path cannot fetch would
+// describe a step that does not exist. That gap predates this change and is
+// tracked as #1759; TestDownloadFile_HFSchemeUnsupported pins the current
+// behaviour so a future fix has to update this comment too.
+//
+// The two predicates are therefore intentionally different rather than a
+// copy that might drift: this one answers "can the metal downloader reach
+// this host", the controller's answers "will the init container".
+func isHFAuthHost(source string) bool {
 	rest := source
 	for _, scheme := range []string{"https://", "http://"} {
 		if len(rest) >= len(scheme) && strings.EqualFold(rest[:len(scheme)], scheme) {
 			rest = rest[len(scheme):]
+			// Host is case-insensitive per RFC 3986, so fold BEFORE trimming
+			// the www. label: trimming first leaves "WWW.huggingface.co"
+			// intact and the match fails, downloading unauthenticated.
+			rest = strings.ToLower(rest)
 			rest = strings.TrimPrefix(rest, "www.")
-			return strings.HasPrefix(strings.ToLower(rest), "huggingface.co/")
+			return strings.HasPrefix(rest, "huggingface.co/")
 		}
 	}
 	return false

--- a/pkg/agent/s3.go
+++ b/pkg/agent/s3.go
@@ -100,6 +100,45 @@ func parseS3Source(source string) (bucket, key string, err error) {
 	return bucket, key, nil
 }
 
+// isHFAuthSource reports whether a bearer token should be attached to this
+// source. Mirrors the controller's isHFAuthSource
+// (internal/controller/source.go) so the metal path and the init container
+// agree on which hosts get the token: hf://, which the agent resolves to
+// huggingface.co, and a literal huggingface.co URL. Nothing else, so a Model
+// pointing elsewhere never receives the credential (#1750).
+func isHFAuthSource(source string) bool {
+	if strings.HasPrefix(strings.ToLower(source), "hf://") {
+		return true
+	}
+	rest := source
+	for _, scheme := range []string{"https://", "http://"} {
+		if len(rest) >= len(scheme) && strings.EqualFold(rest[:len(scheme)], scheme) {
+			rest = rest[len(scheme):]
+			rest = strings.TrimPrefix(rest, "www.")
+			return strings.HasPrefix(strings.ToLower(rest), "huggingface.co/")
+		}
+	}
+	return false
+}
+
+// resolveHFToken reads HF_TOKEN out of the Model's sourceSecretRef, the same
+// secret the AWS_* keys come from. Unlike the S3 credentials this is NOT a hard
+// error when absent: ungated repositories are the common case and must keep
+// working with no secret at all, so a missing secret or a missing key simply
+// yields an empty token and the request goes out unauthenticated.
+func (e *MetalExecutor) resolveHFToken(ctx context.Context, secretName string) string {
+	if e.k8sClient == nil || secretName == "" {
+		return ""
+	}
+	secret := &corev1.Secret{}
+	if err := e.k8sClient.Get(ctx, types.NamespacedName{Name: secretName, Namespace: e.namespace}, secret); err != nil {
+		e.logger.Debugw("sourceSecretRef unreadable; continuing unauthenticated",
+			"secret", secretName, "namespace", e.namespace, "err", err)
+		return ""
+	}
+	return string(secret.Data["HF_TOKEN"])
+}
+
 // resolveS3Credentials reads the AWS_* keys out of the Model's sourceSecretRef.
 // The secret lives in the Model's namespace (the namespace the executor was
 // constructed with). This mirrors the controller's s3Credentials


### PR DESCRIPTION
## What

Lets the operator's own downloads authenticate to Hugging Face, so gated and private repositories work on every path LLMKube downloads on rather than only where the runtime downloads for itself.

## Why

Refs #1750

A token reached only the serving container of four runtimes, which covers one flow: a bare repo ID with `skipModelInit: true`, where vLLM (or TGI, SGLang, PersonaPlex) fetches its own weights. Every path the operator drives sent anonymous requests, so any gated checkpoint returned 401 for:

- single-file GGUF Models,
- multi-file `spec.files` staging,
- `RefreshPolicy: OnChange` revalidation,
- the prefetch Job,
- the macOS Metal agent.

The only workaround was picking a runtime that downloads for itself, which is not available for llama.cpp or for staged safetensors.

## How

**One secret, not two.** `spec.sourceSecretRef` is already `envFrom`'d into every downloader for the `AWS_*` keys, so an `HF_TOKEN` key beside them needs no new plumbing. The field's GoDoc now documents both key sets and the CRD description is regenerated.

**Gated on the host, not on the Secret.** Only `hf://` and `huggingface.co` sources emit the header, decided in Go by `isHFAuthSource`. A Model pointing at a mirror or a private registry gets nothing even when the Secret it names carries the key, so one Secret can serve an S3 Model and an HF Model without leaking either credential to the other's host.

**A shell wrapper rather than an interpolated flag.** The init container calls `hf_curl`, which adds the header when `HF_TOKEN` is non-empty and falls back to plain `curl` when it is not, so public repositories keep working with no Secret at all. `${HF_TOKEN:+-H "Authorization: Bearer $HF_TOKEN"}` cannot be used: the value contains a space, so it word-splits into four arguments and sends a malformed header, and quoting it sends one empty argument when the token is unset.

**One deviation from the issue's plan, and it is the interesting part.** The issue expected the Metal agent to inherit safe redirect behaviour from `net/http`. It does not. Go strips `Authorization` only when a redirect leaves the registrable domain, so it keeps the header across a subdomain, and across a different port on the same host. A test with two servers reproduced the leak. `downloadFile` now uses a client that drops the header on any change of host, which is stricter and matches what `huggingface_hub` does. curl already behaves this way, which is why only the Go path needed the fix, and why `-L` stays and `--location-trusted` is deliberately absent.

## Testing

`internal/controller`: the header is present for an HF source across both refresh policies and both cache modes, absent for another host, absent for `s3://` (which keeps `--aws-sigv4`), and the host gate is checked against lookalike hosts such as `huggingface.co.evil.example`. The prefetch tests assert the Job inherits both the `envFrom` and the header, since it reuses the serving path's builders rather than its own.

`pkg/agent`: the token reaches the first hop, no header at all is sent without a token, and the cross-host redirect test asserts the origin sees the token and the redirect target does not.

Each new test fails under mutation. Worth noting that the first version of the controller tests did **not**: a mutant that made `curlCmd` always return `curl` left a script that defined the wrapper and then called plain curl, downloading unauthenticated while still containing every string the assertions looked for. The assertions now check the wrapper is invoked, not merely defined.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally (`./internal/controller`, `./pkg/agent`, `./api/...`)
- [x] `make lint` passes locally (`GOOS=linux golangci-lint run ./...`, 0 issues)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance disclosed below, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated

Also ran `make manifests generate chart-crds` for the CRD description and `make check-helm-rbac` (no RBAC change, 284 rules across 2 operators).

Assisted-by: Claude Code implemented this from the issue's plan and ran the checks, including the redirect test that found the `net/http` assumption to be wrong. Human review and the merge are mine.
