### PR TITLE
feat(inferenceservice): add resources.memoryLimit to decouple ceiling from reservation

### DIFF
--- a/api/v1alpha1/inferenceservice_types.go
+++ b/api/v1alpha1/inferenceservice_types.go
@@ -1020,14 +1020,39 @@ type InferenceResourceRequirements struct {
 	// +optional
 	CPU string `json:"cpu,omitempty"`
 
-	// Memory requests (e.g., "4Gi")
+	// Memory is the pod's memory RESERVATION (e.g., "4Gi"), translated to
+	// requests.memory. It also sets limits.memory unless MemoryLimit is given,
+	// so by default request and limit are the same quantity and the container
+	// is Guaranteed for memory.
 	// +kubebuilder:validation:Pattern=`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`
 	// +optional
 	Memory string `json:"memory,omitempty"`
 
+	// MemoryLimit is the pod's memory CEILING (e.g., "64Gi"), translated to
+	// limits.memory. Set it to let a workload burst above its reservation.
+	//
+	// Without it, limits.memory equals the request, so a workload has to
+	// RESERVE its peak in order to be allowed to reach it. A server whose
+	// resident set idles low and grows into a large cache would have to reserve
+	// the peak permanently, taking that memory from the scheduler for the whole
+	// life of the pod even though it is free almost all the time (#1763).
+	//
+	// Leaving this unset preserves the equal request-and-limit behaviour, so
+	// the protection added in #1724 -- an unbounded container crossing
+	// MemoryPressure and taking the node NotReady instead of being OOM-killed
+	// -- still holds by default. This only widens the ceiling when a value is
+	// given, and a limit below the effective request is ignored rather than
+	// applied, since the kubelet rejects such a pod outright.
+	//
+	// Applies to whichever of Memory/HostMemory drives the request.
+	// +kubebuilder:validation:Pattern=`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`
+	// +optional
+	MemoryLimit string `json:"memoryLimit,omitempty"`
+
 	// HostMemory specifies the system RAM required for hybrid GPU/CPU offloading (e.g., "64Gi").
 	// Used when MoE expert weights or KV cache are offloaded to CPU via moeCPUOffload or noKvOffload.
 	// Translated to pod resources.requests.memory, taking precedence over Memory when set.
+	// Sets limits.memory too unless MemoryLimit is given.
 	// Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
 	// which can lead to OOM kills after model load.
 	// +kubebuilder:validation:Pattern=`^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$`

--- a/charts/llmkube/templates/crds/inferenceservices.yaml
+++ b/charts/llmkube/templates/crds/inferenceservices.yaml
@@ -4635,12 +4635,38 @@ spec:
                       HostMemory specifies the system RAM required for hybrid GPU/CPU offloading (e.g., "64Gi").
                       Used when MoE expert weights or KV cache are offloaded to CPU via moeCPUOffload or noKvOffload.
                       Translated to pod resources.requests.memory, taking precedence over Memory when set.
+                      Sets limits.memory too unless MemoryLimit is given.
                       Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
                       which can lead to OOM kills after model load.
                     pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                   memory:
-                    description: Memory requests (e.g., "4Gi")
+                    description: |-
+                      Memory is the pod's memory RESERVATION (e.g., "4Gi"), translated to
+                      requests.memory. It also sets limits.memory unless MemoryLimit is given,
+                      so by default request and limit are the same quantity and the container
+                      is Guaranteed for memory.
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                    type: string
+                  memoryLimit:
+                    description: |-
+                      MemoryLimit is the pod's memory CEILING (e.g., "64Gi"), translated to
+                      limits.memory. Set it to let a workload burst above its reservation.
+
+                      Without it, limits.memory equals the request, so a workload has to
+                      RESERVE its peak in order to be allowed to reach it. A server whose
+                      resident set idles low and grows into a large cache would have to reserve
+                      the peak permanently, taking that memory from the scheduler for the whole
+                      life of the pod even though it is free almost all the time (#1763).
+
+                      Leaving this unset preserves the equal request-and-limit behaviour, so
+                      the protection added in #1724 -- an unbounded container crossing
+                      MemoryPressure and taking the node NotReady instead of being OOM-killed
+                      -- still holds by default. This only widens the ceiling when a value is
+                      given, and a limit below the effective request is ignored rather than
+                      applied, since the kubelet rejects such a pod outright.
+
+                      Applies to whichever of Memory/HostMemory drives the request.
                     pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                 type: object

--- a/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
+++ b/config/crd/bases/inference.llmkube.dev_inferenceservices.yaml
@@ -4631,12 +4631,38 @@ spec:
                       HostMemory specifies the system RAM required for hybrid GPU/CPU offloading (e.g., "64Gi").
                       Used when MoE expert weights or KV cache are offloaded to CPU via moeCPUOffload or noKvOffload.
                       Translated to pod resources.requests.memory, taking precedence over Memory when set.
+                      Sets limits.memory too unless MemoryLimit is given.
                       Without this, the K8s scheduler has no visibility into the pod's actual RAM consumption,
                       which can lead to OOM kills after model load.
                     pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                   memory:
-                    description: Memory requests (e.g., "4Gi")
+                    description: |-
+                      Memory is the pod's memory RESERVATION (e.g., "4Gi"), translated to
+                      requests.memory. It also sets limits.memory unless MemoryLimit is given,
+                      so by default request and limit are the same quantity and the container
+                      is Guaranteed for memory.
+                    pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
+                    type: string
+                  memoryLimit:
+                    description: |-
+                      MemoryLimit is the pod's memory CEILING (e.g., "64Gi"), translated to
+                      limits.memory. Set it to let a workload burst above its reservation.
+
+                      Without it, limits.memory equals the request, so a workload has to
+                      RESERVE its peak in order to be allowed to reach it. A server whose
+                      resident set idles low and grows into a large cache would have to reserve
+                      the peak permanently, taking that memory from the scheduler for the whole
+                      life of the pod even though it is free almost all the time (#1763).
+
+                      Leaving this unset preserves the equal request-and-limit behaviour, so
+                      the protection added in #1724 -- an unbounded container crossing
+                      MemoryPressure and taking the node NotReady instead of being OOM-killed
+                      -- still holds by default. This only widens the ceiling when a value is
+                      given, and a limit below the effective request is ignored rather than
+                      applied, since the kubelet rejects such a pod outright.
+
+                      Applies to whichever of Memory/HostMemory drives the request.
                     pattern: ^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$
                     type: string
                 type: object

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -736,7 +736,23 @@ func buildContainerResources(isvc *inferencev1alpha1.InferenceService, model *in
 		}
 		if memoryQ != nil {
 			res.Requests[corev1.ResourceMemory] = *memoryQ
-			res.Limits[corev1.ResourceMemory] = *memoryQ
+			// memoryLimit, when given, decouples the ceiling from the
+			// reservation so a workload can burst above what it permanently
+			// reserves (#1763). Unset keeps limit == request, so the #1724
+			// protection above still applies by default.
+			limitQ := memoryQ
+			if isvc.Spec.Resources.MemoryLimit != "" {
+				if q, err := resource.ParseQuantity(isvc.Spec.Resources.MemoryLimit); err == nil {
+					// A limit below the request is not a narrower ceiling, it is
+					// a pod the kubelet refuses to admit. Ignoring it leaves the
+					// workload running with the previous behaviour rather than
+					// failing to schedule on a typo.
+					if q.Cmp(*memoryQ) >= 0 {
+						limitQ = &q
+					}
+				}
+			}
+			res.Limits[corev1.ResourceMemory] = *limitQ
 		}
 		// Request AND limit. The request is what the scheduler reserves, so it
 		// stops placing further pods on a node this download is about to fill.

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -1456,6 +1456,85 @@ func TestBuildContainerResources_MemoryLimit(t *testing.T) {
 		}
 	})
 
+	t.Run("memoryLimit raises the ceiling above the request", func(t *testing.T) {
+		// The point of #1763: reserve steady state, allow a burst. Without
+		// this the workload has to RESERVE its peak to be allowed to reach it.
+		res := build(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					Memory: "8Gi", MemoryLimit: "64Gi",
+				},
+			},
+		})
+		wantReq, wantLim := resource.MustParse("8Gi"), resource.MustParse("64Gi")
+		if got := res.Requests[corev1.ResourceMemory]; !got.Equal(wantReq) {
+			t.Errorf("Requests[memory] = %s, want %s", got.String(), wantReq.String())
+		}
+		if got := res.Limits[corev1.ResourceMemory]; !got.Equal(wantLim) {
+			t.Errorf("Limits[memory] = %s, want %s", got.String(), wantLim.String())
+		}
+	})
+
+	t.Run("memoryLimit applies over hostMemory too", func(t *testing.T) {
+		res := build(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					Memory: "8Gi", HostMemory: "48Gi", MemoryLimit: "64Gi",
+				},
+			},
+		})
+		wantReq, wantLim := resource.MustParse("48Gi"), resource.MustParse("64Gi")
+		if got := res.Requests[corev1.ResourceMemory]; !got.Equal(wantReq) {
+			t.Errorf("Requests[memory] = %s, want %s", got.String(), wantReq.String())
+		}
+		if got := res.Limits[corev1.ResourceMemory]; !got.Equal(wantLim) {
+			t.Errorf("Limits[memory] = %s, want %s", got.String(), wantLim.String())
+		}
+	})
+
+	t.Run("memoryLimit below the request is ignored", func(t *testing.T) {
+		// The kubelet refuses to admit a pod whose limit is under its request,
+		// so honouring it would turn a typo into an unschedulable workload.
+		res := build(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					Memory: "8Gi", MemoryLimit: "4Gi",
+				},
+			},
+		})
+		want := resource.MustParse("8Gi")
+		if got := res.Limits[corev1.ResourceMemory]; !got.Equal(want) {
+			t.Errorf("Limits[memory] = %s, want %s (limit below request ignored)", got.String(), want.String())
+		}
+	})
+
+	t.Run("malformed memoryLimit falls back to the request", func(t *testing.T) {
+		res := build(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{
+					Memory: "8Gi", MemoryLimit: "not-a-quantity",
+				},
+			},
+		})
+		want := resource.MustParse("8Gi")
+		if got := res.Limits[corev1.ResourceMemory]; !got.Equal(want) {
+			t.Errorf("Limits[memory] = %s, want %s", got.String(), want.String())
+		}
+	})
+
+	t.Run("memoryLimit alone sets nothing", func(t *testing.T) {
+		// No request means no memory keys at all; a bare ceiling would make the
+		// pod BestEffort with a limit, which is not what anyone asked for.
+		res := build(&inferencev1alpha1.InferenceService{
+			Spec: inferencev1alpha1.InferenceServiceSpec{
+				Resources: &inferencev1alpha1.InferenceResourceRequirements{MemoryLimit: "64Gi"},
+			},
+		})
+		if v, ok := res.Limits[corev1.ResourceMemory]; ok {
+			t.Errorf("Limits has memory %s, want none", v.String())
+		}
+	})
+
 	t.Run("neither memory nor hostMemory sets no memory key", func(t *testing.T) {
 		res := build(&inferencev1alpha1.InferenceService{
 			Spec: inferencev1alpha1.InferenceServiceSpec{


### PR DESCRIPTION
## What

Adds an optional `resources.memoryLimit` that sets `limits.memory` independently of the request, so a workload can burst above what it permanently reserves.

## Why

Fixes #1763

Since 0.9.25 the builder emits the memory quantity as **both** `requests.memory` and `limits.memory`, so request and limit are always equal and a workload has to *reserve* its peak in order to be allowed to reach it.

Concretely: a llama.cpp server with a large RAM prompt cache idles near 4Gi and grows to roughly 44Gi as the cache fills. Covering that peak means reserving 48Gi permanently on a 123Gi node, taking it from 71% to 97% requested and blocking anything else from scheduling there. The memory was always available; what changed is that it now has to be reserved to be usable.

## How

`memoryLimit` sets `limits.memory` when given, and applies over whichever of `memory`/`hostMemory` drives the request.

**Unset keeps today's behaviour exactly**, so the hardening from #1724 still holds by default — an unbounded container crossing MemoryPressure takes the node NotReady instead of being OOM-killed. This only ever widens the ceiling, and only when asked.

Two deliberate choices worth flagging:

- **A limit below the effective request is ignored, not applied.** The kubelet refuses to admit such a pod, so honouring it would turn a typo into an unschedulable workload rather than a narrower ceiling. A malformed value falls back the same way, matching the existing `ParseQuantity`-not-`MustParse` handling in this function.
- **`memoryLimit` alone sets nothing.** Without a request there are no memory keys at all; a bare ceiling would make the container BestEffort-with-a-limit, which nobody asked for.

Also corrected the `Memory` and `HostMemory` GoDoc: both said "requests" while the builder set request *and* limit, which is the mismatch that made the 0.9.25 behaviour surprising. CRDs and chart CRDs regenerated via `make manifests generate chart-crds`.

This is the shape suggested in the issue. Happy to rework it if you would rather go another way — for example making `hostMemory` request-only now that a limit is always set.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally — 0 issues
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — the field's GoDoc, which is the CRD description

Five new subtests in `TestBuildContainerResources_MemoryLimit`: the ceiling above the request, applying over `hostMemory`, a limit below the request being ignored, a malformed value falling back, and a bare limit setting nothing. Negative control: reverting the builder change fails the first two.

Not manually tested in a cluster yet — the change is confined to the resource block the unit tests cover, but say the word if you want a live run before merge.

Assisted-by: Claude Code (wrote the field, the builder branch, the tests and this description). I reviewed the change, ran `make test` and `make lint`, and verified the tests fail when the builder change is reverted.