### PR TITLE
feat(router): poolActivation IfIdle serves the warm member when the incumbent is busy

### DIFF
--- a/api/v1alpha1/modelrouter_types.go
+++ b/api/v1alpha1/modelrouter_types.go
@@ -388,6 +388,21 @@ type RuleRoute struct {
 	// +kubebuilder:default=primary-fallback
 	// +optional
 	Strategy string `json:"strategy,omitempty"`
+
+	// PoolActivation decides what the proxy does when a backend in
+	// Backends is a ModelPool member that is not resident and the resident
+	// member is busy. "Wait" (default) holds the request open until the
+	// incumbent drains and the target loads, bounded by the pool's
+	// swapBudget. "IfIdle" only starts a swap when the incumbent is idle;
+	// while it is busy the pooled backend is skipped immediately and the
+	// request falls through to the next entry in Backends, so a rule such
+	// as [preferred-model, resident-model] serves on whichever is warm
+	// instead of queueing behind in-flight work. Non-pooled backends and
+	// same-model requests are unaffected.
+	// +kubebuilder:validation:Enum=Wait;IfIdle
+	// +kubebuilder:default=Wait
+	// +optional
+	PoolActivation string `json:"poolActivation,omitempty"`
 }
 
 // RouterPolicy holds cross-cutting controls applied to all rules.

--- a/charts/llmkube/templates/crds/modelrouters.yaml
+++ b/charts/llmkube/templates/crds/modelrouters.yaml
@@ -900,6 +900,23 @@ spec:
                             type: string
                           minItems: 1
                           type: array
+                        poolActivation:
+                          default: Wait
+                          description: |-
+                            PoolActivation decides what the proxy does when a backend in
+                            Backends is a ModelPool member that is not resident and the resident
+                            member is busy. "Wait" (default) holds the request open until the
+                            incumbent drains and the target loads, bounded by the pool's
+                            swapBudget. "IfIdle" only starts a swap when the incumbent is idle;
+                            while it is busy the pooled backend is skipped immediately and the
+                            request falls through to the next entry in Backends, so a rule such
+                            as [preferred-model, resident-model] serves on whichever is warm
+                            instead of queueing behind in-flight work. Non-pooled backends and
+                            same-model requests are unaffected.
+                          enum:
+                          - Wait
+                          - IfIdle
+                          type: string
                         strategy:
                           default: primary-fallback
                           description: Strategy selects how multiple backends are

--- a/config/crd/bases/inference.llmkube.dev_modelrouters.yaml
+++ b/config/crd/bases/inference.llmkube.dev_modelrouters.yaml
@@ -896,6 +896,23 @@ spec:
                             type: string
                           minItems: 1
                           type: array
+                        poolActivation:
+                          default: Wait
+                          description: |-
+                            PoolActivation decides what the proxy does when a backend in
+                            Backends is a ModelPool member that is not resident and the resident
+                            member is busy. "Wait" (default) holds the request open until the
+                            incumbent drains and the target loads, bounded by the pool's
+                            swapBudget. "IfIdle" only starts a swap when the incumbent is idle;
+                            while it is busy the pooled backend is skipped immediately and the
+                            request falls through to the next entry in Backends, so a rule such
+                            as [preferred-model, resident-model] serves on whichever is warm
+                            instead of queueing behind in-flight work. Non-pooled backends and
+                            same-model requests are unaffected.
+                          enum:
+                          - Wait
+                          - IfIdle
+                          type: string
                         strategy:
                           default: primary-fallback
                           description: Strategy selects how multiple backends are

--- a/docs/operations/gpu-sharing.md
+++ b/docs/operations/gpu-sharing.md
@@ -191,6 +191,43 @@ member is resident, sticky keeps it there and the `default` edit is inert until
 the pool next goes cold. Verified on-cluster: after repointing `default` at the
 other member, the incumbent still owned the slot two minutes later.
 
+### Serving on the warm member instead of waiting: `poolActivation: IfIdle`
+
+By default a request for the non-resident member is held until the incumbent
+drains, however long that takes (up to `swapBudget`). That is the right call
+when the caller only accepts that one model. It is the wrong call for a caller
+that *prefers* one member but would rather run on the other than queue behind
+someone else's work: an interactive assistant that likes the small model, on a
+slot a batch coder keeps busy for an hour at a time.
+
+A `ModelRouter` rule can express that preference. List the members in
+preference order and set `route.poolActivation: IfIdle`:
+
+```yaml
+rules:
+  - name: assistant
+    match:
+      models: ["assistant"]
+    route:
+      backends: ["coder-small", "coder-large"]
+      poolActivation: IfIdle
+```
+
+Under `IfIdle` the proxy only starts a swap when the incumbent is idle. If
+`coder-small` is not resident and `coder-large` has requests in flight, the
+proxy skips `coder-small` at once and dispatches to `coder-large`, the member
+that is already warm. Nothing is held and no swap is queued. When the slot is
+idle the rule behaves exactly like the default (`Wait`): the swap runs under
+`swapBudget` and the request is served by `coder-small` afterwards. A swap that
+is already in flight is waited on in both modes, because the incumbent is
+unloading and cannot serve anyway.
+
+"Busy" means requests the proxy itself is tracking. Traffic that reaches a
+member's Service directly, bypassing the router, is invisible to this check
+(the controller's `/slots` drain still protects it at swap time). Route all
+pool traffic through the router if you rely on `IfIdle`. Skips are counted in
+`llmkube_modelpool_busy_skips_total{router,pool,member}`.
+
 ### swapBudget, and why it is separate from the request timeout
 
 `swapBudget` (default `300s`) bounds how long the router holds a cross-model

--- a/internal/controller/router_builders_test.go
+++ b/internal/controller/router_builders_test.go
@@ -630,6 +630,34 @@ func TestCompileRouterConfigCopiesRuleTimeout(t *testing.T) {
 	}
 }
 
+// TestCompileRouterConfigCopiesRulePoolActivation pins that
+// ModelRouter.spec.rules[].route.poolActivation reaches the wire-shape rule;
+// without it every rule silently behaves as Wait.
+func TestCompileRouterConfigCopiesRulePoolActivation(t *testing.T) {
+	mr := canonicalModelRouter()
+	mr.Spec.Rules[0].Route.PoolActivation = "IfIdle"
+
+	isvc := &inferencev1alpha1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: "qwen3-coder", Namespace: testBuilderNs},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "anthropic-key", Namespace: testBuilderNs},
+		Data:       map[string][]byte{"ANTHROPIC_API_KEY": []byte("test")},
+	}
+	r := newRouterReconcilerForTest(t, mr, isvc, secret)
+	compiled, err := r.compileRouterConfig(context.Background(), mr)
+	if err != nil {
+		t.Fatalf("compileRouterConfig: %v", err)
+	}
+	var cfg router.Config
+	if err := json.Unmarshal(compiled.JSON, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Rules[0].Route.PoolActivation != router.PoolActivationIfIdle {
+		t.Errorf("rule poolActivation = %q, want %q", cfg.Rules[0].Route.PoolActivation, router.PoolActivationIfIdle)
+	}
+}
+
 // TestCompileRouterConfigCopiesBackendTimeout pins the equivalent for
 // per-backend timeouts.
 func TestCompileRouterConfigCopiesBackendTimeout(t *testing.T) {

--- a/internal/controller/router_config_builder.go
+++ b/internal/controller/router_config_builder.go
@@ -356,8 +356,9 @@ func translateRule(in *inferencev1alpha1.RouterRule) router.Rule {
 		Name:       in.Name,
 		FailClosed: in.FailClosed,
 		Route: router.RuleRoute{
-			Backends: append([]string(nil), in.Route.Backends...),
-			Strategy: in.Route.Strategy,
+			Backends:       append([]string(nil), in.Route.Backends...),
+			Strategy:       in.Route.Strategy,
+			PoolActivation: in.Route.PoolActivation,
 		},
 	}
 	if in.Match != nil {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -271,6 +271,17 @@ var (
 		[]string{"router", "pool", "member"},
 	)
 
+	// ModelPoolBusySkipsTotal counts cross-model requests that skipped a pooled
+	// backend under poolActivation=IfIdle because the incumbent was busy, and
+	// fell through to the next backend instead of being held.
+	ModelPoolBusySkipsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "llmkube_modelpool_busy_skips_total",
+			Help: "Pooled backends skipped under IfIdle activation because the resident member was busy.",
+		},
+		[]string{"router", "pool", "member"},
+	)
+
 	// ModelPoolHeldRequests reports the number of requests currently held open
 	// per pool member, waiting for activation.
 	ModelPoolHeldRequests = prometheus.NewGaugeVec(
@@ -377,6 +388,7 @@ var AllCollectors = []prometheus.Collector{
 	ModelPoolSwapDuration,
 	ModelPoolHoldDuration,
 	ModelPoolCoalescedTotal,
+	ModelPoolBusySkipsTotal,
 	ModelPoolHeldRequests,
 	ForemanTaskCompletedTotal,
 	ForemanTaskDurationSeconds,

--- a/internal/router/activator.go
+++ b/internal/router/activator.go
@@ -26,6 +26,12 @@ import (
 // unavailable" signal), never a 429.
 var ErrHoldBudgetExceeded = errors.New("model pool activation hold budget exceeded")
 
+// ErrIncumbentBusy is returned by Activator.AcquireWithMode under
+// PoolActivationIfIdle when the target member is not resident and the
+// resident member has in-flight requests. No swap is started and nothing is
+// held; the caller falls through to its next backend.
+var ErrIncumbentBusy = errors.New("model pool incumbent busy; swap not started")
+
 // MemberController is the slice of Kubernetes operations the Activator needs to
 // drive a ModelPool swap. It is an interface so the swap policy is unit-testable
 // without a live cluster: tests inject a fake, production injects the
@@ -168,6 +174,17 @@ func (pr *poolRuntime) notify() {
 // (ErrHoldBudgetExceeded or a context error) means the caller should not
 // dispatch; an in-progress load is never aborted by a caller giving up.
 func (a *Activator) Acquire(ctx context.Context, p *BackendPool) (func(), error) {
+	return a.AcquireWithMode(ctx, p, PoolActivationWait)
+}
+
+// AcquireWithMode is Acquire with an explicit pool activation mode. Under
+// PoolActivationWait it behaves exactly like Acquire. Under
+// PoolActivationIfIdle a cross-model request whose incumbent is busy returns
+// ErrIncumbentBusy at once instead of being held: a swap is only ever started
+// when the incumbent is idle, so the request can be served on whichever member
+// is warm. A swap already in flight is still waited on in both modes, because
+// the incumbent is unloading and cannot serve the request either way.
+func (a *Activator) AcquireWithMode(ctx context.Context, p *BackendPool, mode string) (func(), error) {
 	member := p.Member
 
 	a.mu.Lock()
@@ -250,6 +267,10 @@ func (a *Activator) Acquire(ctx context.Context, p *BackendPool) (func(), error)
 			incumbent := pr.resident
 			if incumbent == "" || pr.inflight[incumbent] == 0 {
 				a.startSwap(pr, incumbent, member, holdStart)
+			} else if mode == PoolActivationIfIdle {
+				prommetrics.ModelPoolBusySkipsTotal.WithLabelValues(a.router, pr.pool, member).Inc()
+				a.mu.Unlock()
+				return nil, ErrIncumbentBusy
 			}
 		}
 

--- a/internal/router/activator_test.go
+++ b/internal/router/activator_test.go
@@ -435,3 +435,119 @@ func TestActivatorInvalidateResidentForcesRecheck(t *testing.T) {
 		t.Errorf("gemma-longctx activate count = %d, want 2 (invalidation forced swap)", got)
 	}
 }
+
+// TestActivatorIfIdleSkipsBusyIncumbent pins the IfIdle contract: a cross-model
+// request against a busy incumbent returns ErrIncumbentBusy at once, starts no
+// swap and leaves the incumbent resident. Once the incumbent drains, the same
+// request swaps exactly as it would under Wait.
+func TestActivatorIfIdleSkipsBusyIncumbent(t *testing.T) {
+	fake := newFakeMemberController()
+	a := NewActivator(context.Background(), fake, "r", nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	judgeRel, err := a.Acquire(ctx, testPool("judge"))
+	if err != nil {
+		t.Fatalf("Acquire judge: %v", err)
+	}
+
+	start := time.Now()
+	rel, err := a.AcquireWithMode(ctx, testPool("coder"), PoolActivationIfIdle)
+	if !errors.Is(err, ErrIncumbentBusy) {
+		t.Fatalf("IfIdle against busy incumbent: err = %v, want ErrIncumbentBusy", err)
+	}
+	if rel != nil {
+		t.Error("IfIdle returned a release func alongside an error")
+	}
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("IfIdle held for %v; must return without waiting on the incumbent", elapsed)
+	}
+	if got := fake.activateCount("coder"); got != 0 {
+		t.Errorf("coder activate count = %d, want 0 (no swap while incumbent busy)", got)
+	}
+	a.mu.Lock()
+	resident := a.pools["lab/heavy-slot"].resident
+	swapping := a.pools["lab/heavy-slot"].swapping
+	a.mu.Unlock()
+	if resident != "judge" || swapping {
+		t.Errorf("resident = %q swapping = %v after IfIdle skip; want judge resident, no swap", resident, swapping)
+	}
+
+	// Drain the incumbent: IfIdle now behaves like Wait and flips the slot.
+	judgeRel()
+	rel, err = a.AcquireWithMode(ctx, testPool("coder"), PoolActivationIfIdle)
+	if err != nil {
+		t.Fatalf("IfIdle against idle incumbent: %v", err)
+	}
+	rel()
+	if got := fake.activateCount("coder"); got != 1 {
+		t.Errorf("coder activate count = %d, want 1 after the incumbent went idle", got)
+	}
+}
+
+// TestActivatorIfIdleWaitsOnInFlightSwap guards the one case IfIdle must NOT
+// short-circuit: a swap towards the target is already running. The incumbent is
+// unloading and cannot serve, so the request waits for the swap like Wait does.
+func TestActivatorIfIdleWaitsOnInFlightSwap(t *testing.T) {
+	fake := newFakeMemberController()
+	gate := make(chan struct{})
+	fake.activateGate = gate
+	a := NewActivator(context.Background(), fake, "r", nil)
+
+	// Cold pool: the first Wait request starts a swap that blocks on the gate.
+	waitDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		rel, e := a.Acquire(ctx, testPool("coder"))
+		if rel != nil {
+			rel()
+		}
+		waitDone <- e
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		a.mu.Lock()
+		pr, ok := a.pools["lab/heavy-slot"]
+		swapping := ok && pr.swapping
+		a.mu.Unlock()
+		if swapping {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("swap never started")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	ifIdleDone := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		rel, e := a.AcquireWithMode(ctx, testPool("coder"), PoolActivationIfIdle)
+		if rel != nil {
+			rel()
+		}
+		ifIdleDone <- e
+	}()
+	select {
+	case e := <-ifIdleDone:
+		t.Fatalf("IfIdle returned %v during an in-flight swap; must wait for it", e)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(gate)
+	for _, ch := range []chan error{waitDone, ifIdleDone} {
+		select {
+		case e := <-ch:
+			if e != nil {
+				t.Fatalf("Acquire after swap completed: %v", e)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("request did not complete after the swap finished")
+		}
+	}
+	if got := fake.activateCount("coder"); got != 1 {
+		t.Errorf("coder activate count = %d, want 1 (one swap shared by both requests)", got)
+	}
+}

--- a/internal/router/config.go
+++ b/internal/router/config.go
@@ -202,7 +202,20 @@ type RuleRoute struct {
 	// Only primary-fallback is implemented in the MVP; the other two land
 	// in #432.
 	Strategy string `json:"strategy,omitempty"`
+
+	// PoolActivation is "Wait" (default) or "IfIdle". Under IfIdle a pooled
+	// backend whose incumbent is busy is skipped rather than held, so the
+	// dispatch loop falls through to the next backend in Backends. Compiled
+	// from ModelRouter.spec.rules[].route.poolActivation.
+	PoolActivation string `json:"poolActivation,omitempty"`
 }
+
+// Pool activation modes for RuleRoute.PoolActivation. See the CRD field
+// documentation for the semantics of each.
+const (
+	PoolActivationWait   = "Wait"
+	PoolActivationIfIdle = "IfIdle"
+)
 
 // Policy holds cross-cutting controls.
 type Policy struct {
@@ -292,6 +305,12 @@ func (c *Config) Validate() error {
 				return fmt.Errorf("rules[%d] %s: route.backends[%d] %q does not name an existing backend",
 					i, r.Name, j, name)
 			}
+		}
+		switch r.Route.PoolActivation {
+		case "", PoolActivationWait, PoolActivationIfIdle:
+		default:
+			return fmt.Errorf("rules[%d] %s: route.poolActivation %q must be %q or %q",
+				i, r.Name, r.Route.PoolActivation, PoolActivationWait, PoolActivationIfIdle)
 		}
 	}
 	return nil

--- a/internal/router/config_test.go
+++ b/internal/router/config_test.go
@@ -254,3 +254,26 @@ const canonicalJSON = `{
     "auditLog": {"sink": "stdout"}
   }
 }`
+
+// TestConfigValidateRejectsUnknownPoolActivation keeps the wire enum closed so a
+// typo in poolActivation fails at compile time instead of silently meaning Wait.
+func TestConfigValidateRejectsUnknownPoolActivation(t *testing.T) {
+	cfg := &Config{
+		Backends:     []Backend{{Name: "a", Tier: "local", Address: "http://a"}},
+		DefaultRoute: "a",
+		Rules: []Rule{{
+			Name:  "r",
+			Route: RuleRoute{Backends: []string{"a"}, PoolActivation: "Sometimes"},
+		}},
+		Policy: Policy{Classification: ClassificationPolicy{Mode: "header-only"}},
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("Validate accepted poolActivation \"Sometimes\"; want an error")
+	}
+	for _, ok := range []string{"", PoolActivationWait, PoolActivationIfIdle} {
+		cfg.Rules[0].Route.PoolActivation = ok
+		if err := cfg.Validate(); err != nil {
+			t.Errorf("Validate rejected poolActivation %q: %v", ok, err)
+		}
+	}
+}

--- a/internal/router/match.go
+++ b/internal/router/match.go
@@ -56,6 +56,11 @@ type MatchResult struct {
 	// FailClosed is true when a matched fail-closed rule rejects the
 	// request rather than falling through if no backend is healthy.
 	FailClosed bool
+
+	// PoolActivation is the matched rule's Route.PoolActivation, or empty
+	// (Wait) when no rule matched. It tells the dispatch loop whether a
+	// pooled backend with a busy incumbent is held or skipped.
+	PoolActivation string
 }
 
 // Matcher pre-computes lookups over a Config so the per-request hot path
@@ -99,10 +104,11 @@ func (m *Matcher) Match(features *RequestFeatures) MatchResult {
 			continue
 		}
 		return MatchResult{
-			Rule:       rule,
-			Backends:   rule.Route.Backends,
-			Strategy:   strategyOrDefault(rule.Route.Strategy),
-			FailClosed: rule.FailClosed,
+			Rule:           rule,
+			Backends:       rule.Route.Backends,
+			Strategy:       strategyOrDefault(rule.Route.Strategy),
+			FailClosed:     rule.FailClosed,
+			PoolActivation: rule.Route.PoolActivation,
 		}
 	}
 

--- a/internal/router/proxy.go
+++ b/internal/router/proxy.go
@@ -361,7 +361,7 @@ func (p *Proxy) dispatchWithFallback(
 		if b.Pool != nil && p.activator != nil {
 			holdCtx, holdCancel := context.WithTimeout(ctx,
 				resolveSwapBudget(b.Pool, p.disp.ResponseHeaderTimeout()))
-			rel, aerr := p.activator.Acquire(holdCtx, b.Pool)
+			rel, aerr := p.activator.AcquireWithMode(holdCtx, b.Pool, dec.PoolActivation)
 			holdCancel()
 			if aerr != nil {
 				lastErr = aerr

--- a/internal/router/proxy_test.go
+++ b/internal/router/proxy_test.go
@@ -552,6 +552,82 @@ func TestProxyPoolSwapBudgetDecoupledFromDispatchTimeout(t *testing.T) {
 	}
 }
 
+// TestProxyPoolIfIdleFallsBackToResident is the end-to-end IfIdle contract: a
+// rule routes [coder, judge] with poolActivation IfIdle while judge is resident
+// and busy. The request must be served by judge immediately, with coder never
+// activated and nothing held. Under the default Wait mode the same request would
+// sit in the hold until judge drained.
+func TestProxyPoolIfIdleFallsBackToResident(t *testing.T) {
+	coderBackend := newFakeBackend(t)
+	judgeBackend := newFakeBackend(t)
+
+	fake := newFakeMemberController()
+	fake.setPhase("judge", modelReadyPhase)
+	pool := func(member string) *BackendPool {
+		return &BackendPool{
+			Name:       "heavy-slot",
+			Namespace:  "lab",
+			Member:     member,
+			Members:    []string{"coder", "judge"},
+			SwapBudget: 5 * time.Second,
+		}
+	}
+	cfg := &Config{
+		Backends: []Backend{
+			{Name: "coder", Tier: "local", Address: coderBackend.URL(), Pool: pool("coder")},
+			{Name: "judge", Tier: "local", Address: judgeBackend.URL(), Pool: pool("judge")},
+		},
+		Rules: []Rule{{
+			Name:  "prefer-coder",
+			Match: RuleMatch{Models: []string{"work"}},
+			Route: RuleRoute{Backends: []string{"coder", "judge"}, PoolActivation: PoolActivationIfIdle},
+		}},
+		DefaultRoute: "judge",
+		Policy:       Policy{Classification: ClassificationPolicy{Mode: "header-only"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("config: %v", err)
+	}
+
+	act := NewActivator(context.Background(), fake, "r", slog.Default())
+	// judge is resident with one request in flight for the whole test.
+	judgeRel, err := act.Acquire(context.Background(), pool("judge"))
+	if err != nil {
+		t.Fatalf("seed busy judge: %v", err)
+	}
+	defer judgeRel()
+
+	proxy := NewProxy(cfg, slog.Default(), WithActivator(act))
+	mux := http.NewServeMux()
+	proxy.Mount(mux)
+
+	body, _ := json.Marshal(map[string]any{
+		"model":    "work",
+		"messages": []map[string]string{{"role": "user", "content": "hi"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (busy incumbent must serve the request)", rec.Code)
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("request took %v; IfIdle must not hold behind the busy incumbent", elapsed)
+	}
+	if judgeBackend.calls.Load() != 1 {
+		t.Errorf("judge calls = %d, want 1", judgeBackend.calls.Load())
+	}
+	if coderBackend.calls.Load() != 0 {
+		t.Errorf("coder calls = %d, want 0", coderBackend.calls.Load())
+	}
+	if got := fake.activateCount("coder"); got != 0 {
+		t.Errorf("coder activate count = %d, want 0 (no swap while judge is busy)", got)
+	}
+}
+
 // TestProxyRejectsOversizedBody enforces the body-size cap; a request
 // larger than maxRequestBodyBytes is rejected with 400.
 func TestProxyRejectsOversizedBody(t *testing.T) {


### PR DESCRIPTION
## What

Adds `spec.rules[].route.poolActivation: Wait | IfIdle` to `ModelRouter`. Under `IfIdle`, a rule whose preferred backend is a non-resident `ModelPool` member skips that backend immediately when the incumbent is busy and falls through to the next backend in the rule, instead of holding the request until the incumbent drains. `Wait` is the default and preserves today's behaviour exactly.

## Why

A pool holds a cross-model request until the incumbent is idle, bounded only by the pool-wide `swapBudget`. That is the right contract for a caller that accepts one model and the wrong one for a caller that merely prefers one: on a single 24 GB card shared by a small assistant model and a large coder, the assistant waits minutes behind a batch job while the warm coder could serve it now. Client-side fallback cannot solve it because a timeout cannot distinguish "incumbent busy" from "swap already in flight", so it abandons real swaps and lands on a member that is mid-unload.

Fixes #1786

## How

- `RuleRoute.PoolActivation` on the CRD (enum `Wait;IfIdle`, default `Wait`), mirrored on the wire `RuleRoute`, validated in `Config.Validate`, threaded through `MatchResult` and copied by `translateRule`.
- `Activator.AcquireWithMode`: in the `!swapping && resident != member` branch, a busy incumbent under `IfIdle` returns a new `ErrIncumbentBusy` instead of blocking; `Acquire` delegates with `Wait`. The existing deferred cleanup handles the waiter count. A swap already in flight is waited on in both modes, since the incumbent is unloading and cannot serve either way.
- `dispatchWithFallback` passes the matched rule's mode; the existing `continue` on activation error does the fallthrough.
- New counter `llmkube_modelpool_busy_skips_total{router,pool,member}`.
- Docs: new subsection in `docs/operations/gpu-sharing.md`, including the caveat that "busy" means proxy-tracked traffic (direct-to-Service traffic is invisible to the check; the controller's `/slots` drain still protects it at swap time).

Tests: activator unit tests for the skip and for the in-flight-swap exception, a proxy end-to-end test (rule `[coder, judge]`, judge resident and busy, request served by judge with coder never activated), the `translateRule` passthrough, and closed-enum validation. Both behavioural tests fail with the `IfIdle` branch disabled and pass with it.

Assisted-by: Claude Code (Fable 5.1) generated the implementation, tests and docs from my design; I reviewed the diff, and ran `make test`, `make lint` and `make lint-all` locally (all green, router coverage 93.7%).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change)
