### PR TITLE
fix(rollout): do not defer a scale-from-zero rollout as PodsBusy

### DIFF
--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -981,6 +981,89 @@ var _ = Describe("RolloutPolicy drain-before-rollout", func() {
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
 			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server"))
 		})
+
+		It("should proceed when there is no EndpointSlice at all and no pods", func() {
+			modelName := "model-no-slice"
+			isvcName := "isvc-no-slice"
+			model, isvc, reconciler := setupChangedTemplate(modelName, isvcName)
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+			// No EndpointSlice is created at all: the sibling of the empty-slice
+			// case, reached when upstream's endpointslice reconciler deletes the
+			// slice after its last endpoint is removed. Point the Service-URL
+			// fallback at a closed port so the probe fails exactly as it does
+			// against a zero-replica Service with nothing behind it.
+			dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+			deadURL := dead.URL
+			dead.Close()
+			reconciler.RolloutIdleBaseURL = deadURL
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server-v2"),
+				"a service with no EndpointSlice and no pods must roll out immediately, not defer via the URL fallback")
+
+			final := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, final)).To(Succeed())
+			Expect(findRolloutDeferredCondition(final.Status.Conditions)).To(BeNil())
+		})
+
+		It("should still defer when there is no EndpointSlice at all but a pod exists", func() {
+			modelName := "model-no-slice-pod"
+			isvcName := "isvc-no-slice-pod"
+			model, isvc, reconciler := setupChangedTemplate(modelName, isvcName)
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+
+			dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+			deadURL := dead.URL
+			dead.Close()
+			reconciler.RolloutIdleBaseURL = deadURL
+
+			// A Ready old-generation pod the (now absent) endpoint list has not
+			// caught up with may still hold in-flight work, so the gate must
+			// stay closed even though the Service-URL probe cannot answer.
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      isvcName + "-old",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                           isvcName,
+						"inference.llmkube.dev/service": isvcName,
+					},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "llama-server", Image: "ghcr.io/ggml-org/llama.cpp:server"}}},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, pod) }()
+			pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+			Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			deferred := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferred)).To(Succeed())
+			cond := findRolloutDeferredCondition(deferred.Status.Conditions)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(ReasonPodsBusy))
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server"))
+		})
+
 	})
 
 	Context("rolloutPolicyEnabled helper", func() {
@@ -1151,7 +1234,7 @@ var _ = Describe("LlamaCppBackend.IdleProbe", func() {
 var _ = Describe("RolloutPolicy envtest integration", func() {
 	ctx := context.Background()
 
-	It("should defer rollout (fail-closed) when the idle check fails", func() {
+	It("should proceed when the idle probe cannot answer and there are no pods (#1793 via the Service-URL fallback)", func() {
 		modelName := "model-fail-closed"
 		isvcName := "isvc-fail-closed"
 
@@ -1217,22 +1300,28 @@ var _ = Describe("RolloutPolicy envtest integration", func() {
 		updated.Spec.Image = "ghcr.io/ggml-org/llama.cpp:server-v2"
 		Expect(k8sClient.Update(ctx, updated)).To(Succeed())
 
-		// Second reconcile: template changed, idle check runs against unreachable
-		// cluster-DNS URL (no /slots endpoint in envtest) -> error -> fail-closed.
-		// A failing /slots probe must NOT roll; it must defer until idle or timeout.
+		// Second reconcile: template changed, the idle check runs against the
+		// unreachable cluster-DNS Service URL (no EndpointSlice, no /slots
+		// endpoint in envtest), so the probe cannot answer. With no endpoints
+		// AND no pods there is nothing to drain, so the rollout must proceed
+		// rather than deadlock on IdleCheckFailed until the timeout (#1793 via
+		// the Service-URL fallback). Fail-closed with a pod present is covered by
+		// the scale-from-zero "pod exists" specs, and IdleCheckFailed from an
+		// unreachable published replica by the vLLM replica spec.
 		result2, err := reconciler.Reconcile(ctx, reconcile.Request{
 			NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
 		})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(result2.RequeueAfter).To(BeNumerically(">", 0))
+		Expect(result2.RequeueAfter).To(BeZero())
 
-		// Verify RolloutDeferred condition with IdleCheckFailed reason.
-		deferredISVC := &inferencev1alpha1.InferenceService{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferredISVC)).To(Succeed())
-		cond := findRolloutDeferredCondition(deferredISVC.Status.Conditions)
-		Expect(cond).NotTo(BeNil())
-		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
-		Expect(cond.Reason).To(Equal(ReasonIdleCheckFailed))
+		rolled := &appsv1.Deployment{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, rolled)).To(Succeed())
+		Expect(rolled.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server-v2"),
+			"no endpoints and no pods means nothing to drain; the rollout must not defer on the URL fallback")
+
+		proceeded := &inferencev1alpha1.InferenceService{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, proceeded)).To(Succeed())
+		Expect(findRolloutDeferredCondition(proceeded.Status.Conditions)).To(BeNil())
 	})
 })
 
@@ -2526,7 +2615,8 @@ var _ = Describe("countOldPods", func() {
 			Scheme:             k8sClient.Scheme(),
 			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
 		}
-		total, ready := reconciler.countOldPods(ctx, isvc)
+		total, ready, err := reconciler.countOldPods(ctx, isvc)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(total).To(Equal(int32(0)))
 		Expect(ready).To(Equal(int32(0)))
 	})
@@ -2572,7 +2662,8 @@ var _ = Describe("countOldPods", func() {
 			Scheme:             k8sClient.Scheme(),
 			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
 		}
-		total, ready := reconciler.countOldPods(ctx, isvc)
+		total, ready, err := reconciler.countOldPods(ctx, isvc)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(total).To(Equal(int32(3)))
 		Expect(ready).To(Equal(int32(3)))
 	})
@@ -2618,7 +2709,8 @@ var _ = Describe("countOldPods", func() {
 			Scheme:             k8sClient.Scheme(),
 			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
 		}
-		total, ready := reconciler.countOldPods(ctx, isvc)
+		total, ready, err := reconciler.countOldPods(ctx, isvc)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(total).To(Equal(int32(3)))
 		Expect(ready).To(Equal(int32(0)))
 	})
@@ -2688,7 +2780,8 @@ var _ = Describe("countOldPods", func() {
 			Scheme:             k8sClient.Scheme(),
 			InitContainerImage: "docker.io/curlimages/curl:8.18.0",
 		}
-		total, ready := reconciler.countOldPods(ctx, isvc)
+		total, ready, err := reconciler.countOldPods(ctx, isvc)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(total).To(Equal(int32(3)))
 		Expect(ready).To(Equal(int32(1)))
 	})

--- a/internal/controller/drain_before_roll_test.go
+++ b/internal/controller/drain_before_roll_test.go
@@ -825,6 +825,164 @@ var _ = Describe("RolloutPolicy drain-before-rollout", func() {
 		})
 	})
 
+	Context("scale-from-zero", func() {
+		// The Service exists and so does its EndpointSlice, but the slice
+		// carries no addresses: what a stopped ModelPool member looks like when
+		// the pool scales it back up after its template changed. The idle
+		// server is wired busy so a fallback to the Service URL would defer;
+		// only the empty-endpoints path satisfies the first test.
+		var busyServer *httptest.Server
+
+		BeforeEach(func() {
+			busyServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/slots" {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`[{"id":0,"is_processing":true}]`))
+					return
+				}
+				w.WriteHeader(http.StatusNotFound)
+			}))
+		})
+
+		AfterEach(func() {
+			busyServer.Close()
+		})
+
+		createEmptySlice := func(isvcName string) *discoveryv1.EndpointSlice {
+			slice := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      isvcName + "-empty",
+					Namespace: "default",
+					Labels:    map[string]string{"kubernetes.io/service-name": sanitizeDNSName(isvcName)},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints:   []discoveryv1.Endpoint{},
+			}
+			Expect(k8sClient.Create(ctx, slice)).To(Succeed())
+			return slice
+		}
+
+		setupChangedTemplate := func(modelName, isvcName string) (*inferencev1alpha1.Model, *inferencev1alpha1.InferenceService, *InferenceServiceReconciler) {
+			model := &inferencev1alpha1.Model{
+				ObjectMeta: metav1.ObjectMeta{Name: modelName, Namespace: "default"},
+				Spec: inferencev1alpha1.ModelSpec{
+					Source:   "https://example.com/model.gguf",
+					Hardware: &inferencev1alpha1.HardwareSpec{Accelerator: "cpu"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, model)).To(Succeed())
+			model.Status.Phase = PhaseReady
+			Expect(k8sClient.Status().Update(ctx, model)).To(Succeed())
+
+			replicas := int32(1)
+			isvc := &inferencev1alpha1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: isvcName, Namespace: "default"},
+				Spec: inferencev1alpha1.InferenceServiceSpec{
+					ModelRef: modelName,
+					Replicas: &replicas,
+					Image:    "ghcr.io/ggml-org/llama.cpp:server",
+					RolloutPolicy: &inferencev1alpha1.RolloutPolicySpec{
+						WaitForIdle:        true,
+						IdleTimeoutSeconds: 86400,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).To(Succeed())
+
+			reconciler := &InferenceServiceReconciler{
+				Client:             k8sClient,
+				Scheme:             k8sClient.Scheme(),
+				InitContainerImage: "docker.io/curlimages/curl:8.18.0",
+				RolloutIdleBaseURL: busyServer.URL,
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Change the template so the drain gate engages on the next reconcile.
+			updated := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, updated)).To(Succeed())
+			updated.Spec.Image = "ghcr.io/ggml-org/llama.cpp:server-v2"
+			Expect(k8sClient.Update(ctx, updated)).To(Succeed())
+			return model, isvc, reconciler
+		}
+
+		It("should proceed when the service has no endpoints and no pods", func() {
+			modelName := "model-zero-endpoints"
+			isvcName := "isvc-zero-endpoints"
+			model, isvc, reconciler := setupChangedTemplate(modelName, isvcName)
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+			slice := createEmptySlice(isvcName)
+			defer func() { _ = k8sClient.Delete(ctx, slice) }()
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server-v2"),
+				"a service with nothing to drain must roll out immediately")
+
+			final := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, final)).To(Succeed())
+			Expect(findRolloutDeferredCondition(final.Status.Conditions)).To(BeNil())
+		})
+
+		It("should still defer when the service has no endpoints but a pod exists", func() {
+			modelName := "model-zero-endpoints-pod"
+			isvcName := "isvc-zero-endpoints-pod"
+			model, isvc, reconciler := setupChangedTemplate(modelName, isvcName)
+			defer func() { _ = k8sClient.Delete(ctx, model) }()
+			defer func() { _ = k8sClient.Delete(ctx, isvc) }()
+			slice := createEmptySlice(isvcName)
+			defer func() { _ = k8sClient.Delete(ctx, slice) }()
+
+			// An old-generation pod that is not (yet) published as an endpoint
+			// may still hold in-flight work, so the gate must stay closed.
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      isvcName + "-old",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app":                           isvcName,
+						"inference.llmkube.dev/service": isvcName,
+					},
+				},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "llama-server", Image: "ghcr.io/ggml-org/llama.cpp:server"}}},
+			}
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, pod) }()
+			// Mark it Ready so this exercises the busy path rather than the
+			// crashloop path: a Ready pod the endpoint list has not caught up
+			// with yet is exactly what must not be rolled over.
+			pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+			Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: isvcName, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
+
+			deferred := &inferencev1alpha1.InferenceService{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, deferred)).To(Succeed())
+			cond := findRolloutDeferredCondition(deferred.Status.Conditions)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(ReasonPodsBusy))
+
+			dep := &appsv1.Deployment{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: "default"}, dep)).To(Succeed())
+			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal("ghcr.io/ggml-org/llama.cpp:server"))
+		})
+	})
+
 	Context("rolloutPolicyEnabled helper", func() {
 		It("should return false when RolloutPolicy is nil", func() {
 			isvc := &inferencev1alpha1.InferenceService{}

--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -49,6 +49,13 @@ const AnnotationDesiredTemplateHash = "llmkube.ai/desired-template-hash"
 
 var errIdleUnsupported = errors.New("runtime does not implement idle detection")
 
+// errNoEndpoints is returned by checkServiceIdle when the Service has
+// EndpointSlices but none of them carries an address: the service is scaled to
+// zero, or every pod is gone. Whether that means "nothing to drain" or "pods
+// exist but are not addressable yet" depends on the pod count, which the
+// caller has, so the caller decides.
+var errNoEndpoints = errors.New("service has no endpoints to probe")
+
 // desiredTemplateHash computes a deterministic hash of the pod template for the
 // purpose of detecting operator-driven changes. It serializes the template to
 // JSON and hashes it. The reconciler stamps this hash on the Deployment and
@@ -202,12 +209,11 @@ func (r *InferenceServiceReconciler) checkServiceIdle(ctx context.Context, isvc 
 	replicaURLs = append(replicaURLs, collectNotReadyReplicaURLs(slices, port)...)
 	if len(replicaURLs) == 0 {
 		// Nothing reachable: no ready and no not-ready addresses at all.
-		// This is the genuine crashloop / scale-to-zero case (#1250), but we
-		// cannot distinguish "unreachable, so nothing to protect" from "unready
-		// but still working" here, so we do NOT silently proceed. Report not
-		// idle (fail-closed) and let the caller defer rather than roll over
-		// in-flight work on an undetermined state.
-		return false, nil
+		// This is the crashloop / scale-to-zero case (#1250). We cannot tell
+		// "scaled to zero, nothing to protect" from "unready but still
+		// working" from the endpoints alone, so hand the decision back to the
+		// caller, which knows the pod count.
+		return false, errNoEndpoints
 	}
 
 	for _, url := range replicaURLs {
@@ -295,6 +301,19 @@ func (r *InferenceServiceReconciler) reconcileRolloutPolicy(
 	totalPods, readyPods := r.countOldPods(ctx, isvc)
 
 	idle, checkErr := r.checkServiceIdle(ctx, isvc, svc)
+	if errors.Is(checkErr, errNoEndpoints) {
+		// A service scaled to zero (a stopped ModelPool member being started,
+		// or a template change that landed while replicas was 0) has no
+		// in-flight work to protect. Treating the empty endpoint list as
+		// "busy" deadlocked the scale-up until idleTimeoutSeconds. When pods
+		// do exist but none is addressable yet, keep the fail-closed path.
+		if totalPods == 0 {
+			idle, checkErr = true, nil
+			log.Info("No pods and no endpoints, nothing to drain; proceeding with rollout")
+		} else {
+			idle, checkErr = false, nil
+		}
+	}
 
 	if checkErr == nil && idle {
 		if existingCond != nil {

--- a/internal/controller/drain_before_rollout.go
+++ b/internal/controller/drain_before_rollout.go
@@ -190,8 +190,24 @@ func (r *InferenceServiceReconciler) checkServiceIdle(ctx context.Context, isvc 
 	if len(slices.Items) == 0 {
 		idle, err := probe(ctx, svcURL)
 		if err != nil {
-			log.Info("Failed to check server idle status via Service URL", "error", err)
-			return false, err
+			if errors.Is(err, errIdleUnsupported) {
+				// The runtime cannot be idle-checked at all (e.g. a generic
+				// runtime with no idle annotation). Preserve that signal so the
+				// caller defers with IdleCheckUnsupported rather than treating it
+				// as an empty endpoint list and rolling over live work.
+				return false, err
+			}
+			// No EndpointSlice exists and the Service URL probe could not reach a
+			// backend. Upstream's endpointslice reconciler deletes a slice once
+			// its last endpoint is removed, so a scaled-to-zero Service has none
+			// and its URL has nothing behind it. Returning the raw error defers
+			// with IdleCheckFailed until idleTimeoutSeconds — the #1793 deadlock,
+			// reached through the fallback rather than the empty-slice path. Hand
+			// the decision to the caller's pod-count resolution, symmetric with
+			// the empty-endpoints path below: it proceeds only when no pods
+			// exist either, and stays deferred (fail-closed) when one does.
+			log.Info("No EndpointSlices and the Service URL probe could not reach a backend; deferring to pod-count resolution", "error", err)
+			return false, errNoEndpoints
 		}
 		if !idle {
 			log.Info("Backend is busy (Service URL fallback), deferring rollout")
@@ -236,14 +252,19 @@ func (r *InferenceServiceReconciler) checkServiceIdle(ctx context.Context, isvc 
 // total count and the number of Ready pods. A pod is considered Ready when its
 // PodReady condition is True. This is used by reconcileRolloutPolicy to decide
 // whether there is in-flight work to protect before deferring a rollout.
-func (r *InferenceServiceReconciler) countOldPods(ctx context.Context, isvc *inferencev1alpha1.InferenceService) (total, ready int32) {
+//
+// A List error is returned rather than swallowed as a zero count. The caller
+// promotes a zero count to a rollout gate (proceed when nothing is left to
+// drain), so a transient List failure reported as zero would roll a pod that
+// may still hold work. The caller must fail closed on the error.
+func (r *InferenceServiceReconciler) countOldPods(ctx context.Context, isvc *inferencev1alpha1.InferenceService) (total, ready int32, err error) {
 	podList := &corev1.PodList{}
 	labels := client.MatchingLabels{
 		"app":                           isvc.Name,
 		"inference.llmkube.dev/service": isvc.Name,
 	}
-	if err := r.List(ctx, podList, client.InNamespace(isvc.Namespace), labels); err != nil {
-		return 0, 0
+	if listErr := r.List(ctx, podList, client.InNamespace(isvc.Namespace), labels); listErr != nil {
+		return 0, 0, listErr
 	}
 	for i := range podList.Items {
 		pod := &podList.Items[i]
@@ -255,7 +276,7 @@ func (r *InferenceServiceReconciler) countOldPods(ctx context.Context, isvc *inf
 			}
 		}
 	}
-	return total, ready
+	return total, ready, nil
 }
 
 // reconcileRolloutPolicy checks whether the rollout should be deferred based on
@@ -298,7 +319,7 @@ func (r *InferenceServiceReconciler) reconcileRolloutPolicy(
 	// generations already accepted keep running. checkServiceIdle probes both
 	// ready and not-ready endpoints, so we always consult it rather than
 	// proceeding on the basis of readiness alone.
-	totalPods, readyPods := r.countOldPods(ctx, isvc)
+	totalPods, readyPods, countErr := r.countOldPods(ctx, isvc)
 
 	idle, checkErr := r.checkServiceIdle(ctx, isvc, svc)
 	if errors.Is(checkErr, errNoEndpoints) {
@@ -307,10 +328,18 @@ func (r *InferenceServiceReconciler) reconcileRolloutPolicy(
 		// in-flight work to protect. Treating the empty endpoint list as
 		// "busy" deadlocked the scale-up until idleTimeoutSeconds. When pods
 		// do exist but none is addressable yet, keep the fail-closed path.
-		if totalPods == 0 {
+		switch {
+		case countErr != nil:
+			// The pod list failed, so we cannot prove nothing is left to
+			// drain. This gate promotes a zero count to "proceed", so a
+			// transient List error must defer rather than roll a pod that may
+			// still hold work.
+			idle, checkErr = false, nil
+			log.Info("No endpoints and the pod list failed; deferring rollout (fail-closed)", "error", countErr)
+		case totalPods == 0:
 			idle, checkErr = true, nil
 			log.Info("No pods and no endpoints, nothing to drain; proceeding with rollout")
-		} else {
+		default:
 			idle, checkErr = false, nil
 		}
 	}


### PR DESCRIPTION
## What

A rollout of an InferenceService that currently has no pods no longer waits behind `rolloutPolicy.waitForIdle`. `checkServiceIdle` returns a sentinel when the Service's EndpointSlices carry no addresses, and `reconcileRolloutPolicy` resolves it with the pod count it already computes: zero pods means nothing to drain and the rollout proceeds; pods present but not yet addressable keep today's fail-closed `PodsBusy` deferral.

## Why

Fixes #1793

A service scaled to zero whose template changed while it was down (the normal ModelPool path: a change lands while a member is `Stopped`, then the pool scales it back up) was held at `RolloutDeferred=True / PodsBusy` until `idleTimeoutSeconds` because an empty endpoint list read as "not idle, no error". The pool sat `Swapping` with nothing resident on the GPU.

## How

- `checkServiceIdle`: `return false, errNoEndpoints` instead of `return false, nil` when the replica URL list is empty. The existing comment about not being able to distinguish scale-to-zero from unready-but-working is kept, with the resolution moved to the caller.
- `reconcileRolloutPolicy`: if the error is `errNoEndpoints`, proceed when `countOldPods` reports zero pods, otherwise fall back to the same `PodsBusy` path as before. No other branch changes.
- Tests, `drain_before_roll_test.go`, new `scale-from-zero` context: an EndpointSlice with no endpoints plus a changed template rolls out immediately with the idle server wired busy (so the Service-URL fallback cannot be what satisfied it); the same setup with a Ready old-generation pod present still defers with `PodsBusy`. Both fail on `main` and pass with the change. Existing busy-defer and template-gate specs unchanged and green.

Assisted-by: Claude Code (Fable 5.1) generated the implementation and tests from my diagnosis on a live cluster; I reviewed the diff and ran `make test` (controller 86.5%) and `make lint-all` locally, all green.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [ ] Documentation updated (if user-facing change) — behaviour fix, no doc surface changed
