### PR TITLE
fix(router): return 503 + Retry-After when every IfIdle backend skips busy

### DIFF
--- a/docs/operations/gpu-sharing.md
+++ b/docs/operations/gpu-sharing.md
@@ -228,6 +228,14 @@ member's Service directly, bypassing the router, is invisible to this check
 pool traffic through the router if you rely on `IfIdle`. Skips are counted in
 `llmkube_modelpool_busy_skips_total{router,pool,member}`.
 
+If *every* backend in an `IfIdle` rule skips because no preferred member is warm
+(the slot is held busy by a member outside the rule), the request cannot be
+served right now. The proxy returns `503` with a `Retry-After` header and the
+audit reason `pool_incumbent_busy`, the same retryable signal as a swap that
+outruns `swapBudget`, so a client that retries after the incumbent drains is
+served. It is deliberately not a `502`: nothing is broken upstream, the slot is
+just occupied.
+
 ### swapBudget, and why it is separate from the request timeout
 
 `swapBudget` (default `300s`) bounds how long the router holds a cross-model

--- a/internal/router/proxy.go
+++ b/internal/router/proxy.go
@@ -192,6 +192,20 @@ func (p *Proxy) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 				"pool_activation_timeout", elapsed)
 			return
 		}
+		// Every backend in an IfIdle rule skipped because its ModelPool incumbent
+		// was busy: no preferred member is warm right now. This is the same
+		// transient, retryable class as the hold-budget timeout above (the
+		// incumbent will drain and a retry will serve), so give it the same 503 +
+		// Retry-After treatment and its own audit reason rather than a generic
+		// 502 that reads as an upstream outage.
+		if errors.Is(err, ErrIncumbentBusy) {
+			w.Header().Set("Retry-After", modelPoolRetryAfterSeconds)
+			writeError(w, http.StatusServiceUnavailable,
+				"model pool incumbent busy; no preferred member is warm, retry")
+			p.audit(features, decision, nil, http.StatusServiceUnavailable,
+				"pool_incumbent_busy", elapsed)
+			return
+		}
 		// Runtime fail-closed: when every backend in a fail-closed
 		// rule's pool is unreachable, return 503 with a clear reason
 		// rather than 502. This is the runtime counterpart to the
@@ -336,15 +350,24 @@ func (p *Proxy) dispatchWithFallback(
 	path string,
 ) (*Backend, *http.Response, error) {
 	var lastErr error
+	// allIncumbentBusy stays true only if every backend that was tried failed
+	// specifically because its ModelPool incumbent was busy under IfIdle (no
+	// swap started). Any other failure (unconfigured, unhealthy, dispatch error,
+	// 5xx) makes it false. When it holds, the aggregate is a transient,
+	// retryable condition (503 + Retry-After) rather than a generic upstream
+	// outage (502).
+	allIncumbentBusy := true
 	tracer := otel.Tracer("model_router.dispatch")
 	for i, name := range dec.Backends {
 		b := p.matcher.BackendByName(name)
 		if b == nil {
 			lastErr = fmt.Errorf("backend %q not configured", name)
+			allIncumbentBusy = false
 			continue
 		}
 		if !p.disp.IsHealthy(name) {
 			lastErr = fmt.Errorf("backend %q marked unhealthy", name)
+			allIncumbentBusy = false
 			continue
 		}
 
@@ -365,6 +388,9 @@ func (p *Proxy) dispatchWithFallback(
 			holdCancel()
 			if aerr != nil {
 				lastErr = aerr
+				if !errors.Is(aerr, ErrIncumbentBusy) {
+					allIncumbentBusy = false
+				}
 				continue
 			}
 			poolRelease = rel
@@ -396,6 +422,7 @@ func (p *Proxy) dispatchWithFallback(
 			span.End()
 			cancel()
 			lastErr = err
+			allIncumbentBusy = false
 			continue
 		}
 		if resp.StatusCode >= 500 {
@@ -408,6 +435,7 @@ func (p *Proxy) dispatchWithFallback(
 			span.End()
 			cancel()
 			lastErr = fmt.Errorf("%s returned %d", name, resp.StatusCode)
+			allIncumbentBusy = false
 			continue
 		}
 		// Successful response: wrap the body so its Close also
@@ -427,6 +455,11 @@ func (p *Proxy) dispatchWithFallback(
 	}
 	if lastErr == nil {
 		lastErr = errors.New("no backends attempted")
+	} else if allIncumbentBusy {
+		// Every backend skipped under IfIdle because its incumbent was busy.
+		// Return the sentinel unwrapped so the handler maps it to 503 +
+		// Retry-After like the sibling hold-budget timeout, not a 502.
+		return nil, nil, ErrIncumbentBusy
 	}
 	return nil, nil, lastErr
 }

--- a/internal/router/proxy_test.go
+++ b/internal/router/proxy_test.go
@@ -628,6 +628,86 @@ func TestProxyPoolIfIdleFallsBackToResident(t *testing.T) {
 	}
 }
 
+// TestProxyPoolIfIdleAllBusyReturns503 verifies that when every backend in an
+// IfIdle rule skips because the pool incumbent is busy (no preferred member is
+// warm), the proxy returns 503 + Retry-After (the same retryable class as a
+// hold-budget timeout), not a 502 that reads as an upstream outage. A third
+// member, gemma, holds the slot busy; the rule only routes to coder and judge,
+// so both skip.
+func TestProxyPoolIfIdleAllBusyReturns503(t *testing.T) {
+	coderBackend := newFakeBackend(t)
+	judgeBackend := newFakeBackend(t)
+
+	fake := newFakeMemberController()
+	fake.setPhase("gemma", modelReadyPhase)
+	pool := func(member string) *BackendPool {
+		return &BackendPool{
+			Name:       "heavy-slot",
+			Namespace:  "lab",
+			Member:     member,
+			Members:    []string{"coder", "judge", "gemma"},
+			SwapBudget: 5 * time.Second,
+		}
+	}
+	cfg := &Config{
+		Backends: []Backend{
+			{Name: "coder", Tier: "local", Address: coderBackend.URL(), Pool: pool("coder")},
+			{Name: "judge", Tier: "local", Address: judgeBackend.URL(), Pool: pool("judge")},
+		},
+		Rules: []Rule{{
+			Name:  "prefer-coder",
+			Match: RuleMatch{Models: []string{"work"}},
+			Route: RuleRoute{Backends: []string{"coder", "judge"}, PoolActivation: PoolActivationIfIdle},
+		}},
+		DefaultRoute: "coder",
+		Policy:       Policy{Classification: ClassificationPolicy{Mode: "header-only"}},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("config: %v", err)
+	}
+
+	act := NewActivator(context.Background(), fake, "r", slog.Default())
+	// gemma owns the slot with a request in flight for the whole test, so
+	// neither coder nor judge (the rule's backends) can swap in under IfIdle.
+	gemmaRel, err := act.Acquire(context.Background(), pool("gemma"))
+	if err != nil {
+		t.Fatalf("seed busy gemma: %v", err)
+	}
+	defer gemmaRel()
+
+	proxy := NewProxy(cfg, slog.Default(), WithActivator(act))
+	mux := http.NewServeMux()
+	proxy.Mount(mux)
+
+	body, _ := json.Marshal(map[string]any{
+		"model":    "work",
+		"messages": []map[string]string{{"role": "user", "content": "hi"}},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	start := time.Now()
+	mux.ServeHTTP(rec, req)
+
+	resp := rec.Result()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 (all IfIdle backends busy is retryable, not 502)", resp.StatusCode)
+	}
+	if resp.Header.Get("Retry-After") == "" {
+		t.Error("missing Retry-After header on all-incumbent-busy 503")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("request took %v; IfIdle must skip immediately, not hold", elapsed)
+	}
+	if coderBackend.calls.Load() != 0 || judgeBackend.calls.Load() != 0 {
+		t.Errorf("backend calls coder=%d judge=%d, want 0/0 (nothing warm to serve)",
+			coderBackend.calls.Load(), judgeBackend.calls.Load())
+	}
+	if got := fake.activateCount("coder") + fake.activateCount("judge"); got != 0 {
+		t.Errorf("activate count = %d, want 0 (no swap while gemma is busy)", got)
+	}
+}
+
 // TestProxyRejectsOversizedBody enforces the body-size cap; a request
 // larger than maxRequestBodyBytes is rejected with 400.
 func TestProxyRejectsOversizedBody(t *testing.T) {


### PR DESCRIPTION
## What

When every backend in a `poolActivation: IfIdle` rule skips because its `ModelPool` incumbent is busy (no preferred member is warm), return `503` + `Retry-After` with the audit reason `pool_incumbent_busy`, instead of the generic `502 all_backends_failed`.

## Why

Raised in review of #1787: the all-skip IfIdle path returned 502, while the sibling case (a swap that outruns `swapBudget`) returns 503 + Retry-After with a `pool_activation_timeout` audit reason. Both are the same transient, retryable condition — the incumbent drains and a retry serves — so they should look the same to clients. A 502 reads as an upstream outage and does not carry Retry-After, so well-behaved clients do not back off deterministically.

## How

`dispatchWithFallback` tracks `allIncumbentBusy`: it stays true only if every backend that was tried failed specifically with `ErrIncumbentBusy`. Any other failure (unconfigured, unhealthy, dispatch error, 5xx) clears it. When it holds, the function returns the `ErrIncumbentBusy` sentinel unwrapped so the handler `errors.Is` it and maps it to 503 + Retry-After with the `pool_incumbent_busy` audit reason, mirroring the `ErrHoldBudgetExceeded` path. Mixed failures still surface exactly as before (502 / fail-closed).

The reclaim check sits before the fail-closed branch: for a fail-closed rule whose backends are merely busy (not unhealthy), the 503 "incumbent busy" reason is more accurate than "all backends unhealthy" and is still a refusal to spill (no egress).

## Checklist

- [x] Tests added/updated (a third member holds the slot busy, both rule backends skip -> 503 + Retry-After, no dispatch, no swap)
- [x] `make test` passes locally (router suite green)
- [x] `make lint` passes locally (0 issues)
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (DCO)
- [x] AI assistance disclosed (Claude, reviewed by me)
- [x] Documentation updated (docs/operations/gpu-sharing.md)
