### PR TITLE
fix(foreman): drain tasks before agent exit

### DIFF
--- a/charts/foreman/templates/agent-deployment.yaml
+++ b/charts/foreman/templates/agent-deployment.yaml
@@ -62,7 +62,7 @@ spec:
   {{- if and (ne $st "Recreate") (ne $st "RollingUpdate") }}
   {{- fail (printf "agents.%s.strategy.type: %q is not a valid Deployment strategy; use \"Recreate\" or \"RollingUpdate\" (the API server rejects anything else, including case variants like \"rollingUpdate\")" $name $st) }}
   {{- end }}
-  {{- $tgps := $agent.terminationGracePeriodSeconds | default 30 }}
+  {{- $tgps := $agent.terminationGracePeriodSeconds | default 300 }}
   {{- /* Kind, not a single kind: the same value reaches this line as
          different Go types depending on how it was supplied. Everything
          routed through `include "foreman.agents" | fromYaml` is float64,

--- a/charts/foreman/tests/agent-rollout_test.yaml
+++ b/charts/foreman/tests/agent-rollout_test.yaml
@@ -3,9 +3,9 @@ templates:
   - agent-deployment.yaml
 
 tests:
-  # ---- Defaults reproduce the previous hardcoded output exactly ----
+  # ---- Defaults render the 300s drain window (#1438) ----
 
-  - it: default agent renders Recreate and a 30s grace period (no change on upgrade)
+  - it: default agent renders Recreate and a 300s grace period (the drain window)
     template: agent-deployment.yaml
     set:
       agent.enabled: true
@@ -18,9 +18,9 @@ tests:
           path: spec.strategy.rollingUpdate
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 30
+          value: 300
 
-  - it: default multi-pool install renders Recreate and 30s for the default pool
+  - it: default multi-pool install renders Recreate and 300s for the default pool
     template: agent-deployment.yaml
     values:
       - ./values-multi.yaml
@@ -36,9 +36,9 @@ tests:
           path: spec.strategy.rollingUpdate
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 30
+          value: 300
 
-  - it: default multi-pool install renders Recreate and 30s for the fork pool
+  - it: default multi-pool install renders Recreate and 300s for the fork pool
     template: agent-deployment.yaml
     values:
       - ./values-multi.yaml
@@ -54,7 +54,7 @@ tests:
           path: spec.strategy.rollingUpdate
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 30
+          value: 300
 
   # ---- Opting into RollingUpdate ----
 
@@ -135,7 +135,7 @@ tests:
           path: spec.strategy.rollingUpdate
       - equal:
           path: spec.template.spec.terminationGracePeriodSeconds
-          value: 30
+          value: 300
 
   - it: the opting-in pool still carries its raised grace period when a sibling opts in
     template: agent-deployment.yaml

--- a/charts/foreman/values.yaml
+++ b/charts/foreman/values.yaml
@@ -357,16 +357,18 @@ agent:
   # How long the kubelet waits after sending SIGTERM before force-killing
   # the agent pod.
   #
-  # Raising this does NOT currently lengthen anything. On SIGTERM the
-  # watcher's poll loop returns straight away on ctx.Done()
-  # (pkg/foreman/agent/watcher.go), an in-process task's executor runs in
-  # a goroutine that nothing waits on, and the FleetNode registrar's drain
-  # patch is capped at its own 5s timeout (pkg/foreman/agent/fleetnode.go),
-  # so the process is gone within a few seconds whatever this is set to.
-  # There is no drain hook yet. Treat the knob as forward-wiring for the
-  # drain work tracked in #1438, plus a way to LOWER the value on a pool
-  # that should die fast. It does not buy a slow local-model turn a longer
-  # window to finish or to be interrupted cleanly.
+  # This is the drain window. On SIGTERM the agent DRAINS instead of
+  # dropping its work (#1438): the watcher's poll loop stops claiming new
+  # tasks, but the turns it already launched keep running and write their
+  # terminal status before the process exits, so a rollout no longer kills a
+  # local-model turn mid-patch (pkg/foreman/agent/watcher.go). The FleetNode
+  # registrar keeps its existing Draining heartbeat throughout
+  # (pkg/foreman/agent/fleetnode.go).
+  #
+  # The default of 300s (5 min) is generous for a bounded turn to land its
+  # final patch without a forced kill. A turn that runs past the window is
+  # force-killed by the kubelet, and the work is recovered by the operator,
+  # not the agent.
   #
   # What recovers the killed task is the operator, not the agent. It is
   # NOT recoverOrphanedTasks: that matches only tasks whose
@@ -383,9 +385,9 @@ agent:
   # Must be a non-negative whole number of seconds. The chart fails the
   # render on a negative, non-numeric or fractional value, rather than
   # shipping a manifest the API server rejects or silently truncating a
-  # 30.5 to 30. The default of 30 reproduces the previous hardcoded value
-  # so an existing install is unchanged until it opts in.
-  terminationGracePeriodSeconds: 30
+  # 30.5 to 30. Lower the value on a pool that should die fast; the default
+  # 300 is what buys a slow turn a clean finish.
+  terminationGracePeriodSeconds: 300
 
   # Pod rollout strategy for this agent Deployment.
   #

--- a/pkg/foreman/agent/watcher.go
+++ b/pkg/foreman/agent/watcher.go
@@ -130,6 +130,16 @@ type AgenticTaskWatcher struct {
 	// they run, so they get their own budget instead of the single
 	// in-process slot (#1559).
 	supervised int
+
+	// execs counts every execution goroutine launchExecutor has started that
+	// has not yet finished and released its slot. Run takes one final Wait()
+	// on it when its ctx is cancelled so a SIGTERM DRAINS the node -- stops
+	// claiming new work but lets the turns already in flight finish and write
+	// their terminal status inside the pod's termination grace window --
+	// instead of orphaning them when the process exits (#1438). It is only
+	// Add()ed from the poll loop and Wait()ed once that loop has exited, so
+	// the two never race (a positive-delta Add after Wait has begun panics).
+	execs sync.WaitGroup
 }
 
 // maxSupervised is MaxSupervisedTasks with its default applied. See the
@@ -260,6 +270,15 @@ func (w *AgenticTaskWatcher) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			// Drain, don't kill (#1438): the node is going away (SIGTERM), so
+			// stop claiming new work but let the executions we already
+			// launched finish and terminally patch. Their contexts are
+			// detached from this one (launchExecutor), so ctx.Done does not
+			// cancel them -- we simply stop starting new work and wait for the
+			// ones in flight to complete. The pod's termination grace window
+			// bounds the wait: a turn that runs past it is force-killed by the
+			// kubelet and re-queued by claim expiry, exactly as before.
+			w.execs.Wait()
 			log.Info("stopping")
 			return nil
 		case <-ticker.C:
@@ -417,6 +436,16 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 	resolved := make(map[string]agentResolution, 2)
 
 	for _, t := range candidates {
+		// Stop at the first candidate if the node is draining (#1438): Run
+		// cancels its ctx on SIGTERM to stop claiming new work, but this pass
+		// is already looping over the candidates it listed before the cancel.
+		// A per-candidate check, placed before any resolve/claim/launch for
+		// this task, makes the pass fall out so no candidate beyond the one
+		// already claimed is started; that run finishes under its detached
+		// context while the rest stay Scheduled for the next node to pick up.
+		if ctx.Err() != nil {
+			return nil
+		}
 		// Capacity is checked per candidate because the two execution modes
 		// draw on different slots: with the in-process slot busy, a Job-mode
 		// task can still start (and vice versa). Only this goroutine reserves
@@ -443,6 +472,16 @@ func (w *AgenticTaskWatcher) pollOnce(ctx context.Context, namespace string) err
 		}
 		if !w.hasCapacityFor(res.supervise) {
 			continue
+		}
+		// Re-check the drain immediately before the claim. A SIGTERM can land
+		// after the top-of-loop check above but before the status patch here —
+		// the resolve above is an uncached apiserver GET, so that window is
+		// real. A claim issued on a draining node can still land server-side
+		// even though the client is going away, stranding the task in Running
+		// until claim expiry; checking here closes the gap to a few
+		// instructions.
+		if ctx.Err() != nil {
+			return nil
 		}
 		if err := w.claim(ctx, t); err != nil {
 			// Patch race or transient apiserver error; let the next
@@ -516,7 +555,15 @@ func (w *AgenticTaskWatcher) launchExecutor(
 		WithValues("task", t.Name, "kind", t.Spec.Kind, "supervised", supervise)
 	log.Info("dispatching to executor")
 
+	// Count this execution before its goroutine starts so a drain that
+	// lands in between still blocks on it (Run's execs.Wait). Add must
+	// happen before the goroutine that will Done it.
+	w.execs.Add(1)
 	go func() {
+		// Registered first, so it runs LAST: the slot below is released and
+		// the run's context cancelled before the drain in Run observes this
+		// execution as complete.
+		defer w.execs.Done()
 		defer func() {
 			w.inflightMu.Lock()
 			if supervise {
@@ -527,9 +574,13 @@ func (w *AgenticTaskWatcher) launchExecutor(
 			w.inflightMu.Unlock()
 		}()
 
-		// Use a fresh context so the executor's lifetime is decoupled from
-		// the poll tick. Cancellation still propagates from the parent.
-		execCtx, cancel := context.WithCancel(ctx)
+		// Detach the run from the drain so a SIGTERM lets the turn finish
+		// instead of killing it mid-patch (#1438). WithoutCancel keeps the
+		// parent's log values but stops inheriting its cancellation, so the
+		// run is now cancelled ONLY by its liveness watchdog (the task
+		// deleted out from under us, #1136) or its own completion -- never
+		// by the watcher's ctx.
+		execCtx, cancel := context.WithCancel(context.WithoutCancel(ctx))
 		defer cancel()
 
 		// Abort the run if its AgenticTask is deleted out from under us
@@ -539,7 +590,12 @@ func (w *AgenticTaskWatcher) launchExecutor(
 		go w.watchTaskLiveness(execCtx, cancel, t)
 
 		res, execErr := w.Executor.Execute(execCtx, t, agent)
-		if patchErr := w.patchTerminal(ctx, t, res, execErr); patchErr != nil {
+		// Patch the terminal status on a context that outlives BOTH the
+		// drain (SIGTERM) and the liveness cancellation: WithoutCancel keeps
+		// the run's log values but detaches cancellation, so the patch can
+		// still re-fetch and write the final status while draining (#1438),
+		// and still detect a deleted task gracefully (#1136).
+		if patchErr := w.patchTerminal(context.WithoutCancel(ctx), t, res, execErr); patchErr != nil {
 			log.Error(patchErr, "patching terminal status failed")
 		}
 	}()

--- a/pkg/foreman/agent/watcher_drain_test.go
+++ b/pkg/foreman/agent/watcher_drain_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+)
+
+// drainExecutor blocks in Execute until either release is closed (it then
+// returns a GO result) or ctx is cancelled (it records the cancellation and
+// returns ctx.Err()). The block is what holds a turn in flight across the
+// drain, and the cancelled flag is what distinguishes "drained to completion"
+// from "aborted by liveness".
+type drainExecutor struct {
+	release   chan struct{}
+	cancelled *atomic.Bool
+}
+
+func (e *drainExecutor) Kind() string { return "drain-test" }
+
+func (e *drainExecutor) Execute(
+	ctx context.Context,
+	task *foremanv1alpha1.AgenticTask,
+	_ *foremanv1alpha1.Agent,
+) (*Result, error) {
+	select {
+	case <-e.release:
+		return NewResult(
+			e.Kind(),
+			foremanv1alpha1.AgenticTaskVerdictGo,
+			"finished during drain",
+			time.Millisecond,
+		), nil
+	case <-ctx.Done():
+		e.cancelled.Store(true)
+		return nil, ctx.Err()
+	}
+}
+
+// waitForTask polls the task's status until want(status) is true, or the
+// deadline elapses. The drain tests need it to observe the poll loop's claim
+// (Scheduled -> Running) before they trigger the drain.
+func waitForTask(
+	t *testing.T, c client.Client, name string,
+	want func(foremanv1alpha1.AgenticTaskStatus) bool,
+) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var got foremanv1alpha1.AgenticTask
+		if err := c.Get(
+			context.Background(),
+			types.NamespacedName{Namespace: "default", Name: name}, &got,
+		); err == nil && want(got.Status) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for task %s to reach the wanted phase", name)
+}
+
+// A SIGTERM arriving while an in-process task is already claimed must NOT
+// kill the run mid-patch. The watcher stops claiming, blocks on the in-flight
+// execution, lets it run to a terminal result and patch it inside the
+// termination grace window, then returns. Before the fix the run's context
+// inherited the drain cancellation, so the kubelet's force-kill (or the
+// process exiting) would drop the work and re-queue it on claim expiry.
+//
+// Regression for defilantech/LLMKube#1438.
+func TestRun_DrainsInFlightTaskOnSigterm(t *testing.T) {
+	c := newRecoveryClient(t, scheduledTask(
+		"drain-go", "m5max-coder", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute,
+	))
+	exe := &drainExecutor{release: make(chan struct{}), cancelled: &atomic.Bool{}}
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "m5max-coder",
+		Namespace:            "default",
+		Executor:             exe,
+		Interval:             10 * time.Millisecond,
+		TaskLivenessInterval: time.Hour, // never fires before the run ends; the task is not deleted here
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	// Wait until the poll loop has claimed the task and launched the run.
+	waitForTask(t, c, "drain-go", func(s foremanv1alpha1.AgenticTaskStatus) bool {
+		return s.Phase == foremanv1alpha1.AgenticTaskPhaseRunning
+	})
+
+	// SIGTERM: the watcher stops claiming and begins draining.
+	cancel()
+
+	// Let the in-flight turn finish. Its context is detached from the drained
+	// ctx, so completing it now patches the terminal status DURING the drain.
+	close(exe.release)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after the in-flight turn drained")
+	}
+
+	if exe.cancelled.Load() {
+		t.Fatal("executor was cancelled during the drain; want it to run to completion")
+	}
+	got := getTask(t, c, "drain-go")
+	if got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseSucceeded {
+		t.Fatalf("phase = %q, want Succeeded (terminal patched during the drain)", got.Status.Phase)
+	}
+}
+
+// Deleting the task out from under an in-flight run during a drain must still
+// abort the run: the liveness watchdog runs on the detached run context, so it
+// survives the drain and cancels the executor, and the terminal patch stands
+// down (the task is already gone). The drain still completes and Run returns.
+//
+// Regression for defilantech/LLMKube#1438 (liveness must be preserved by the
+// drain); the abort itself is #1136.
+func TestRun_DrainStandsDownWhenTaskDeleted(t *testing.T) {
+	const taskName = "drain-deleted"
+	c := newRecoveryClient(t, scheduledTask(taskName, "m5max-coder", foremanv1alpha1.AgenticTaskKindIssueFix, time.Minute))
+	exe := &drainExecutor{release: make(chan struct{}), cancelled: &atomic.Bool{}}
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "m5max-coder",
+		Namespace:            "default",
+		Executor:             exe,
+		Interval:             10 * time.Millisecond,
+		TaskLivenessInterval: 10 * time.Millisecond, // detect the deletion fast
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	// Wait until the poll loop has claimed the task and launched the run.
+	waitForTask(t, c, taskName, func(s foremanv1alpha1.AgenticTaskStatus) bool {
+		return s.Phase == foremanv1alpha1.AgenticTaskPhaseRunning
+	})
+
+	// SIGTERM: the watcher stops claiming and begins draining.
+	cancel()
+
+	// Delete the task out from under the in-flight run (kubectl delete
+	// workload GC-ing the child task).
+	var task foremanv1alpha1.AgenticTask
+	if err := c.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: "default", Name: taskName}, &task,
+	); err != nil {
+		t.Fatalf("get task before delete: %v", err)
+	}
+	if err := c.Delete(context.Background(), &task); err != nil {
+		t.Fatalf("delete task: %v", err)
+	}
+
+	// The run is cancelled by liveness, the patch stands down, and the drain
+	// completes. Run must return.
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after the in-flight run was cancelled by liveness")
+	}
+
+	if !exe.cancelled.Load() {
+		t.Fatal("executor was NOT cancelled on task deletion; liveness must still abort the run during a drain")
+	}
+	var after foremanv1alpha1.AgenticTask
+	if err := c.Get(
+		context.Background(),
+		types.NamespacedName{Namespace: "default", Name: taskName}, &after,
+	); !apierrors.IsNotFound(err) {
+		t.Fatalf("deleted task Get = %v, want NotFound (no terminal patch on a deleted task)", err)
+	}
+}
+
+// A SIGTERM that lands while a poll pass is ALREADY looping over its listed
+// candidates must stop the pass from claiming any candidate beyond the one it
+// has started. The pass listed both tasks before the cancel, so without the
+// per-candidate drain check it would claim the second one too and launch a run
+// on a node that is about to be torn down; with it, the pass falls out at the
+// first sign of the drain, the first run goes in-flight (and drains under its
+// detached context), and the second stays Scheduled for the next node.
+//
+// Regression for defilantech/LLMKube#1438.
+func TestPollOnce_StopsClaimingCandidatesAfterCancel(t *testing.T) {
+	first := taskForAgent("first", "coder", time.Hour) // older, so claimed first
+	second := taskForAgent("second", "coder", time.Minute)
+	// Both job-mode, so after the first is launched the supervision budget
+	// (default 4) still has room: the ONLY thing holding the second back is
+	// the drain check, not a capacity skip. A capacity-based skip would pass
+	// this test even without the fix.
+	exec := newModeExecutor(t, map[string]bool{"coder": true})
+
+	base := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(first, second, agentCR("coder", true)).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		Build()
+
+	// Pin the pass at the first candidate's claim: signal when that patch is
+	// reached, then block until the test cancels ctx and releases. This lands
+	// the cancel deterministically mid-pass -- after the first is claimed and
+	// launched, before the second is considered -- with no timing to race.
+	reached := make(chan struct{})
+	release := make(chan struct{})
+	var claims atomic.Int32
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		SubResourcePatch: func(
+			ctx context.Context, cl client.Client, subResourceName string,
+			obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption,
+		) error {
+			if claims.Add(1) == 1 {
+				close(reached)
+				<-release
+			}
+			return cl.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "node-1",
+		Namespace:            "default",
+		Executor:             exec,
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- w.pollOnce(ctx, "default") }()
+
+	// The pass has reached the first candidate's claim.
+	<-reached
+	// SIGTERM mid-pass: the node is draining.
+	cancel()
+	// Let the first candidate's claim land and its run go in-flight.
+	close(release)
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("pollOnce returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("pollOnce did not return after the drain")
+	}
+
+	// The first candidate was claimed and its run is in-flight (draining).
+	if got := getTask(t, w.Client, "first"); got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseRunning {
+		t.Fatalf("first phase = %q, want Running (claimed and in-flight)", got.Status.Phase)
+	}
+	exec.waitStarted(t, 1)
+	// The second, already-scheduled candidate must NOT have been claimed.
+	if got := getTask(t, w.Client, "second"); got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseScheduled {
+		t.Fatalf("second phase = %q, want Scheduled (not claimed after the cancel)", got.Status.Phase)
+	}
+}
+
+// The per-candidate drain check at the top of the loop is not enough on its
+// own: between it and the status patch sit the Agent resolve (an uncached
+// apiserver GET) and the capacity check, so a SIGTERM can land after the
+// check passed and the candidate still gets claimed onto a node that is about
+// to go away. The re-check immediately before claim closes that gap.
+//
+// The cancel is pinned deterministically at the boundary: the two candidates
+// carry different agentRefs, so the second candidate's Agent resolve is not
+// memoized and its Get is the last client call before its claim. Cancelling
+// inside that Get — after the second candidate's top-of-loop check ran —
+// leaves the cancellation landed with only the re-check standing between here
+// and the claim. Without the re-check the second candidate is claimed (the
+// fake client, like a real apiserver mid-flight, does not veto a patch whose
+// client context has just been cancelled) and the claim-patch interceptor
+// observes it arriving on a cancelled context.
+//
+// Regression for defilantech/LLMKube#1438.
+func TestPollOnce_RechecksCancellationBeforeClaim(t *testing.T) {
+	first := taskForAgent("first", "coder-a", time.Hour) // older, so claimed first
+	second := taskForAgent("second", "coder-b", time.Minute)
+	// Both job-mode, so the supervision budget (default 4) still has room for
+	// the second after the first launches: only the drain check can stop it.
+	exec := newModeExecutor(t, map[string]bool{"coder-a": true, "coder-b": true})
+
+	base := fake.NewClientBuilder().
+		WithScheme(newTestScheme(t)).
+		WithObjects(first, second, agentCR("coder-a", true), agentCR("coder-b", true)).
+		WithStatusSubresource(&foremanv1alpha1.AgenticTask{}).
+		Build()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	var cancelledClaims atomic.Int32
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Get: func(
+			ctx context.Context, cl client.WithWatch, key client.ObjectKey,
+			obj client.Object, opts ...client.GetOption,
+		) error {
+			err := cl.Get(ctx, key, obj, opts...)
+			// The pass has moved to the second candidate: its Agent Get is
+			// the last thing before its claim, so SIGTERM lands exactly at
+			// the check-then-claim boundary.
+			if a, ok := obj.(*foremanv1alpha1.Agent); ok && a.Name == "coder-b" {
+				cancel()
+			}
+			return err
+		},
+		SubResourcePatch: func(
+			ctx context.Context, cl client.Client, subResourceName string,
+			obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption,
+		) error {
+			// A claim attempted on the cancelled drain: the very thing the
+			// re-check must prevent.
+			if ctx.Err() != nil {
+				cancelledClaims.Add(1)
+			}
+			return cl.SubResource(subResourceName).Patch(ctx, obj, patch, opts...)
+		},
+	})
+
+	w := &AgenticTaskWatcher{
+		Client:               c,
+		NodeName:             "node-1",
+		Namespace:            "default",
+		Executor:             exec,
+		TaskLivenessInterval: time.Hour, // no watchdog interference
+	}
+
+	if err := w.pollOnce(ctx, "default"); err != nil {
+		t.Fatalf("pollOnce returned error: %v", err)
+	}
+
+	// The first candidate was claimed before the drain and is in-flight.
+	if got := getTask(t, w.Client, "first"); got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseRunning {
+		t.Fatalf("first phase = %q, want Running (claimed before the drain)", got.Status.Phase)
+	}
+	exec.waitStarted(t, 1)
+	// The cancellation landed after the second candidate's top-of-loop check:
+	// it must still stay Scheduled for the next node.
+	if got := getTask(t, w.Client, "second"); got.Status.Phase != foremanv1alpha1.AgenticTaskPhaseScheduled {
+		t.Fatalf(
+			"second phase = %q, want Scheduled (claim must not start after a cancel at the claim boundary)",
+			got.Status.Phase,
+		)
+	}
+	if n := cancelledClaims.Load(); n != 0 {
+		t.Fatalf("%d claim patch attempt(s) on a cancelled context, want 0 (the pre-claim re-check must stop the pass)", n)
+	}
+}


### PR DESCRIPTION
## What

Drain in-flight foreman-agent tasks on SIGTERM before the agent process exits, and raise the chart default termination grace period to five minutes.

## Why

`foreman-agent` previously returned as soon as Kubernetes delivered SIGTERM, cancelling in-process turns and leaving their tasks for claim-expiry recovery. This makes ordinary agent pod-template rollouts lose active work.

Fixes #1438

## How

The watcher stops accepting new claims as soon as its context is cancelled, including candidates already enumerated by the current poll pass. It waits for previously launched executors, whose execution and terminal-status contexts are detached from the shutdown signal while the task-deletion watchdog remains active. The Helm default now gives that drain a 300-second window. Focused regression tests cover completion during drain, task deletion during drain, and both claim-cancellation boundaries.

AI assistance: Codex (GPT-5) generated and revised the implementation and regression tests; I reviewed the diff and verified `make fmt`, `make vet`, `make lint`, `make test`, `make lint-all`, targeted race tests, and chart tests locally.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (user-facing chart value documentation)