### PR TITLE
fix(foreman): reject unverified reviewer GO

### DIFF
--- a/internal/foreman/controller/workload_iteration.go
+++ b/internal/foreman/controller/workload_iteration.go
@@ -183,14 +183,17 @@ func taskStepLabel(t *foremanv1alpha1.AgenticTask) string {
 // Three conditions are required, and each one excludes a NO-GO the coder
 // CAN act on:
 //
-//   - verdictDemotedBy is the issueAsk or scope-overlap rail. A rail that
-//     rewrites a GO without findings manufactures a rejection the coder
-//     cannot act on: re-running cannot make an unverifiable issueAsk verify,
-//     and an issue that names the symptom file rather than the fix site is
-//     scope drift the coder already answered by fixing the cause (#1684).
-//     Keying off the bare verdictDemoted flag alone would not distinguish
-//     these two rails from each other, but both are inert when they carry
-//     no findings, so the single condition below accepts either name.
+//   - verdictDemotedBy is the issueAsk, scope-overlap, or unverified-summary
+//     rail. A rail that rewrites a GO without findings manufactures a
+//     rejection the coder cannot act on: re-running cannot make an
+//     unverifiable issueAsk verify, an issue that names the symptom file
+//     rather than the fix site is scope drift the coder already answered by
+//     fixing the cause (#1684), and a GO whose own summary admits
+//     verification could not be performed (#1454) is a statement about the
+//     review environment, which no re-run changes either. Keying off the
+//     bare verdictDemoted flag alone would not distinguish these rails from
+//     each other, but all are inert when they carry no findings, so the
+//     single condition below accepts any of their names.
 //   - verdictClaimed is GO, i.e. the rail really did rewrite the verdict.
 //     enforceReviewerIssueAsk stamps the demotion fields on a path where
 //     it does NOT: an unverified non-GO review is marked untrusted and the
@@ -217,7 +220,8 @@ func inertDemotion(t *foremanv1alpha1.AgenticTask) (reason string, inert bool) {
 		return "", false
 	}
 	modelExtra := envelope.Extra.ModelExtra
-	if by, _ := modelExtra["verdictDemotedBy"].(string); by != reviewer.RailIssueAsk && by != reviewer.RailScopeOverlap {
+	if by, _ := modelExtra["verdictDemotedBy"].(string); by != reviewer.RailIssueAsk &&
+		by != reviewer.RailScopeOverlap && by != reviewer.RailUnverifiedSummary {
 		return "", false
 	}
 	if claimed, _ := modelExtra["verdictClaimed"].(string); claimed != string(foremanv1alpha1.AgenticTaskVerdictGo) {

--- a/internal/foreman/controller/workload_iteration_test.go
+++ b/internal/foreman/controller/workload_iteration_test.go
@@ -55,17 +55,22 @@ func iterationWorkload(issues []int32, reviewers int, maxIter *int32) *foremanv1
 // rather than being threaded through every call site.
 const reviewStep = "review-641-0"
 
-// demotionReasonIssueAsk / demotionReasonScopeDrift are the two rails'
-// demotionReason strings, copied from enforceReviewerIssueAsk
-// (pkg/foreman/agent/executor_native.go) and enforceReviewerScopeOverlap
-// (pkg/foreman/agent/scope_overlap.go). Only the prose is copied; the
-// verdictDemotedBy values that actually drive the predicate come from the
-// shared reviewer constants both sides compile against.
+// demotionReasonIssueAsk / demotionReasonScopeDrift /
+// demotionReasonUnverifiedSummary are the demotion rails' demotionReason
+// strings, copied from enforceReviewerIssueAsk and
+// enforceReviewerUnverifiedSummary (pkg/foreman/agent/executor_native.go)
+// and enforceReviewerScopeOverlap (pkg/foreman/agent/scope_overlap.go).
+// Only the prose is copied; the verdictDemotedBy values that actually drive
+// the predicate come from the shared reviewer constants both sides compile
+// against.
 const (
 	demotionReasonIssueAsk = "issueAsk could not be verified as covering the " +
 		"fetched issue body; review verdict is untrusted"
 	demotionReasonScopeDrift = "scope drift: the issue names 1 file(s) " +
 		"(internal/foreman/controller/workload_iteration.go) and the diff touches none of them"
+	demotionReasonUnverifiedSummary = "reviewer summary states \"cannot verify goal reward or " +
+		"progression logic\"; a GO whose own summary reports verification could " +
+		"not be performed is not a verified approval"
 )
 
 // reviewResultRaw renders the status.result a reviewer task really carries,
@@ -105,9 +110,10 @@ func reviewResultRaw(
 // stamped verdictDemoted plus verdictDemotedBy naming itself, and
 // verdictClaimed archiving the verdict it rewrote (#1636).
 //
-// rail and claimed are parameters because the predicate turns on both: only
-// the issueAsk rail rewriting a GO is inert. findingsJSON decides whether the
-// demotion carries anything the coder could act on.
+// rail, claimed, and findingsJSON are parameters because the predicate turns
+// on all three: any of the demoting rails (issueAsk, scope-overlap,
+// unverified-summary) rewriting a GO is inert, and only while the demotion
+// carries nothing the coder could act on.
 func railDemotedNoGoChild(
 	rail, claimed, reason, summary, findingsJSON string,
 ) foremanv1alpha1.AgenticTask {
@@ -254,6 +260,45 @@ func TestReviewIterationSteps(t *testing.T) {
 				railDemotedNoGoChild(reviewer.RailScopeOverlap, string(goVerdict),
 					demotionReasonScopeDrift, "scope drift plus a real defect",
 					`[{"severity":"major","area":"scope","message":"the fix must also touch the config loader"}]`),
+			},
+			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
+			wantIterated: []int32{641},
+		},
+		{
+			// #1454: the unverified-summary rail rewrites a GO to NO-GO when
+			// the reviewer's own terminal summary admits verification could
+			// not be performed. That is a statement about the review
+			// environment, not the change: with no findings the coder is
+			// handed a rejection it cannot act on, and re-running cannot
+			// make an unverifiable environment verifiable, so the iteration
+			// is suppressed (#1636). Before this rail's name reached the
+			// inertDemotion predicate, this exact envelope drove a futile
+			// fix iteration.
+			name: "unverified-summary demotion of a GO with no findings is inert",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				railDemotedNoGoChild(reviewer.RailUnverifiedSummary, string(goVerdict),
+					demotionReasonUnverifiedSummary,
+					"cannot verify goal reward or progression logic", `[]`),
+			},
+			wantSuppressed: []string{reviewStep},
+		},
+		{
+			// Narrowness guard, mirroring the issueAsk and scope-overlap
+			// pairs: a demotion that carries findings names concrete work
+			// the coder can address, so it must still open an iteration
+			// even though the rail is unverified-summary.
+			name: "unverified-summary demotion carrying findings still iterates",
+			w:    iterationWorkload([]int32{641}, 1, nil),
+			children: []foremanv1alpha1.AgenticTask{
+				child("code-641", succeeded, goVerdict),
+				child("verify-641", succeeded, gatePass),
+				railDemotedNoGoChild(reviewer.RailUnverifiedSummary, string(goVerdict),
+					demotionReasonUnverifiedSummary,
+					"verification could not be performed, but the diff has a real defect",
+					`[{"severity":"major","area":"correctness","message":"the retry loop drops the last batch"}]`),
 			},
 			wantSteps:    []string{"code-641-r1", "verify-641-r1", "review-641-0-r1"},
 			wantIterated: []int32{641},

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -25,6 +25,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -1028,6 +1029,13 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// the model paraphrased the issue ask (#744).
 			verdict = enforceReviewerIssueAsk(log, loopRes.Terminal.Extra, verdict,
 				scopeDriftDetected, scopeMatched)
+			// Unverified-summary rail (#1454): a GO whose own terminal
+			// summary says verification could not be performed demotes to
+			// NO-GO. Runs with the other demote rails and before the
+			// flag-only diff gate, so the diff gate reports on the verdict
+			// the demote rails produced.
+			verdict = enforceReviewerUnverifiedSummary(log, loopRes.Terminal.Extra,
+				loopRes.Terminal.Summary, verdict)
 			// Ungrounded-review rail (#1570): a GO whose transcript carries no
 			// evidence the reviewer ever obtained the branch diff is uncorrelated
 			// with the code it approves. This is a FLAG, not a block: it records
@@ -1036,7 +1044,9 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 			// the demote rails (empty-claim, grounded-finding, verdict-from-
 			// findings, scope-overlap, issueAsk) so it reports on the verdict
 			// those rails produced, and it is the last reviewer rail before the
-			// findings summary so its log line is the last rail signal recorded.
+			// findings summary so its log line is the last rail signal
+			// recorded. (The unverified-summary rail #1454 joins this list as
+			// the last demote rail.)
 			applyReviewerDiffGateForTask(log, loopRes, verdict)
 			// Review-execution rail (#1618): the rubric's Section K mandates
 			// running the diff's own new test (and an adversarial near-miss
@@ -3762,6 +3772,76 @@ func enforceReviewerIssueAsk(
 		"fetched issue body; review verdict is untrusted"
 	log.Info("reviewer integrity: unverified issueAsk on GO verdict; demoting to NO-GO",
 		"verdictClaimed", verdict)
+	return foremanv1alpha1.AgenticTaskVerdictNoGo
+}
+
+// reUnverifiedReviewerSummary matches a reviewer's own plain-language
+// admission of non-verification in its terminal summary (#1454). The three
+// phrases are the model saying, in its own words, that the change was not
+// checked; anything phrased that way is unambiguous enough to act on. The
+// match is case-insensitive and whitespace-tolerant (summaries wrap), and
+// the trailing \b keeps it off nouns like "verifies"/"verifier" — a summary
+// describing what the change DOES verify is not this rail's business.
+var reUnverifiedReviewerSummary = regexp.MustCompile(`(?i)\b(?:cannot|could\s+not|unable\s+to)\s+verify\b`)
+
+// enforceReviewerUnverifiedSummary demotes a GO whose terminal summary says
+// verification could not be performed (#1454). A GO means "this change was
+// verified"; a summary carrying "cannot verify" / "could not verify" /
+// "unable to verify" contradicts the verdict in the field that becomes the
+// PR body, so the resulting PR advertises its own lack of validation and
+// still opens. The live case (misospace/windowstead#321): a reviewer GO
+// whose summary read "cannot verify goal reward or progression logic" — the
+// self-gate had deferred to a verify Job the fleet runs disabled, and GitHub
+// CI failed two checks the reviewer waved off.
+//
+// Policy: fire only on GO; a matching summary demotes to NO-GO so the
+// branch routes to escalation instead of a PR. The demotion is grounded in
+// the model's own sentence — the matched phrase is quoted in the
+// demotionReason and recorded under unverifiedSummaryPhrase, so the audit
+// record shows the exact words that made the call, the way the other rails
+// archive what they acted on. Non-GO verdicts need nothing (the branch is
+// already not landing) and pass through untouched, marked nowhere. A nil
+// extra cannot carry the demotion record, so like the other rails the
+// verdict passes through with only a log line.
+//
+// The rail is deliberately phrase-anchored to these three admissions rather
+// than any mention of tests or verification: reviewers legitimately write
+// "verified via go test" or "tests cover X", and a guard that fired on the
+// general topic would manufacture NO-GOs on honest approvals.
+func enforceReviewerUnverifiedSummary(
+	log logr.Logger,
+	extra map[string]any,
+	summary string,
+	verdict foremanv1alpha1.AgenticTaskVerdict,
+) foremanv1alpha1.AgenticTaskVerdict {
+	if verdict != foremanv1alpha1.AgenticTaskVerdictGo {
+		return verdict
+	}
+	match := reUnverifiedReviewerSummary.FindString(summary)
+	if match == "" {
+		return verdict
+	}
+	if extra == nil {
+		log.Info("reviewer integrity: unverified-summary GO but extra is nil; cannot record the demotion",
+			"phrase", match)
+		return verdict
+	}
+
+	// Established demotion markers (#1636): the flag travels with the rail
+	// name, and verdictClaimed is first-writer-wins so an earlier rail that
+	// merely re-annotated this verdict (the issueAsk scope-vouch path) keeps
+	// its archive of the original.
+	extra["verdictDemoted"] = true
+	extra["verdictDemotedBy"] = railUnverifiedSummary
+	if _, ok := extra["verdictClaimed"]; !ok {
+		extra["verdictClaimed"] = string(verdict)
+	}
+	extra["unverifiedSummaryPhrase"] = match
+	extra["demotionReason"] = fmt.Sprintf(
+		"reviewer summary states %q; a GO whose own summary reports verification "+
+			"could not be performed is not a verified approval", match)
+	log.Info("reviewer integrity: GO with a verification-failure summary; demoting to NO-GO",
+		"phrase", match)
 	return foremanv1alpha1.AgenticTaskVerdictNoGo
 }
 

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -3776,21 +3776,26 @@ func enforceReviewerIssueAsk(
 }
 
 // reUnverifiedReviewerSummary matches a reviewer's own plain-language
-// admission of non-verification in its terminal summary (#1454). The three
+// admission of non-verification in its terminal summary (#1454). The
 // phrases are the model saying, in its own words, that the change was not
 // checked; anything phrased that way is unambiguous enough to act on. The
 // match is case-insensitive and whitespace-tolerant (summaries wrap), and
 // the trailing \b keeps it off nouns like "verifies"/"verifier" — a summary
-// describing what the change DOES verify is not this rail's business.
-var reUnverifiedReviewerSummary = regexp.MustCompile(`(?i)\b(?:cannot|could\s+not|unable\s+to)\s+verify\b`)
+// describing what the change DOES verify is not this rail's business. The
+// set spans the registers the models actually use: "cannot" and "could not"
+// (formal), "can not" (spaced), the contractions "can't" / "couldn't" in
+// both straight and curly apostrophes, "unable to", and "was not able to".
+var reUnverifiedReviewerSummary = regexp.MustCompile(`(?i)\b(?:cannot|can\s+not|can(?:’|')t|` +
+	`could\s+not|couldn(?:’|')t|unable\s+to|was\s+not\s+able\s+to)\s+verify\b`)
 
 // enforceReviewerUnverifiedSummary demotes a GO whose terminal summary says
 // verification could not be performed (#1454). A GO means "this change was
-// verified"; a summary carrying "cannot verify" / "could not verify" /
-// "unable to verify" contradicts the verdict in the field that becomes the
-// PR body, so the resulting PR advertises its own lack of validation and
-// still opens. The live case (misospace/windowstead#321): a reviewer GO
-// whose summary read "cannot verify goal reward or progression logic" — the
+// verified"; a summary admitting as much — "cannot verify", "can't verify",
+// "couldn't verify", "unable to verify", or any of the rail's other
+// phrases — contradicts the verdict in the field that becomes the PR body,
+// so the resulting PR advertises its own lack of validation and still
+// opens. The live case (misospace/windowstead#321): a reviewer GO whose
+// summary read "cannot verify goal reward or progression logic" — the
 // self-gate had deferred to a verify Job the fleet runs disabled, and GitHub
 // CI failed two checks the reviewer waved off.
 //
@@ -3804,10 +3809,21 @@ var reUnverifiedReviewerSummary = regexp.MustCompile(`(?i)\b(?:cannot|could\s+no
 // extra cannot carry the demotion record, so like the other rails the
 // verdict passes through with only a log line.
 //
-// The rail is deliberately phrase-anchored to these three admissions rather
-// than any mention of tests or verification: reviewers legitimately write
+// The rail is deliberately phrase-anchored to these admissions rather than
+// any mention of tests or verification: reviewers legitimately write
 // "verified via go test" or "tests cover X", and a guard that fired on the
 // general topic would manufacture NO-GOs on honest approvals.
+//
+// Known tradeoff, kept on purpose: the phrases match whatever subject they
+// carry. A summary like "a client without the key cannot verify a forged
+// signature" describes the fixed system, not the reviewer's own
+// non-verification, yet it demotes — the honest GO is the false positive.
+// Requiring a first-person subject ("I could not verify") would close that
+// hole, but it would also miss the incident this rail exists for: the
+// windowstead#321 summary "cannot verify goal reward or progression logic"
+// names no subject at all, and subjectless admissions are the common shape
+// of these summaries. Phrase anchoring trades that rare object-subject
+// false positive for catching them.
 func enforceReviewerUnverifiedSummary(
 	log logr.Logger,
 	extra map[string]any,

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1711,6 +1711,134 @@ func TestEnforceReviewerIssueAsk_UnverifiedGoNoRefsNoVouchDemotes(t *testing.T) 
 	}
 }
 
+// TestEnforceReviewerUnverifiedSummary covers #1454: a reviewer GO whose
+// terminal summary states in plain language that verification could not be
+// performed must demote to NO-GO, and a normal GO must stand untouched. The
+// first row is verbatim from the windowstead#321 incident that motivated
+// the rail.
+func TestEnforceReviewerUnverifiedSummary(t *testing.T) {
+	cases := []struct {
+		name    string
+		summary string
+		verdict foremanv1alpha1.AgenticTaskVerdict
+		want    foremanv1alpha1.AgenticTaskVerdict
+	}{
+		{
+			name:    "windowstead reproduction: cannot verify",
+			summary: "Tests fail due to missing godot runtime in environment; cannot verify goal reward or progression logic.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "could not verify",
+			summary: "The change looks correct but I could not verify it without the service running.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "unable to verify",
+			summary: "Reviewed statically; unable to verify runtime behavior in this environment.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "case-insensitive",
+			summary: "APPROVE. Could NOT VERIFY the migration path; no database available.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "whitespace-tolerant across wrapped lines",
+			summary: "The harness is missing, so we cannot\nverify the fix here.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "normal GO stays GO",
+			summary: "APPROVE: ran go test ./... and all specs pass; the change is minimal and well covered.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictGo,
+		},
+		{
+			name:    "affirmative verification language is not a match",
+			summary: "The new guard verifies the token before use; tests confirm it rejects expired tokens.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictGo,
+		},
+		{
+			name:    "non-GO with the phrase passes through unmarked",
+			summary: "REJECT: cannot verify anything in this broken environment and the diff is wrong.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictNoGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			extra := map[string]any{}
+			got := enforceReviewerUnverifiedSummary(logr.Discard(), extra, tc.summary, tc.verdict)
+			if got != tc.want {
+				t.Fatalf("verdict = %v, want %v", got, tc.want)
+			}
+			demoted := tc.verdict == foremanv1alpha1.AgenticTaskVerdictGo &&
+				tc.want == foremanv1alpha1.AgenticTaskVerdictNoGo
+			v, marked := extra["verdictDemoted"].(bool)
+			if !demoted {
+				if marked {
+					t.Errorf("non-demoting path must not annotate extra; got verdictDemoted=%v", v)
+				}
+				return
+			}
+			if !v {
+				t.Errorf("demotion must set verdictDemoted=true; got %v", v)
+			}
+			if extra["verdictDemotedBy"] != railUnverifiedSummary {
+				t.Errorf("verdictDemotedBy = %v, want %q", extra["verdictDemotedBy"], railUnverifiedSummary)
+			}
+			if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+				t.Errorf("verdictClaimed should archive the original GO; got %v", extra["verdictClaimed"])
+			}
+			if reason, _ := extra["demotionReason"].(string); reason == "" {
+				t.Error("demotionReason must explain the demotion")
+			}
+			if phrase, _ := extra["unverifiedSummaryPhrase"].(string); phrase == "" {
+				t.Error("unverifiedSummaryPhrase must record the matched admission")
+			}
+		})
+	}
+}
+
+func TestEnforceReviewerUnverifiedSummary_NilExtraIsNoOp(t *testing.T) {
+	// Without an extra map the demotion cannot be recorded or grounded in
+	// the audit trail, so the rails pass the verdict through with only a
+	// log line — the enforceReviewerIssueAsk convention.
+	got := enforceReviewerUnverifiedSummary(logr.Discard(), nil,
+		"cannot verify anything", foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictGo {
+		t.Errorf("nil extra must pass the verdict through; got %v", got)
+	}
+}
+
+func TestEnforceReviewerUnverifiedSummary_PreservesFirstWriterVerdictClaimed(t *testing.T) {
+	// The issueAsk scope-vouch path marks a still-GO verdict with
+	// verdictClaimed; this rail must not overwrite it (#1678 first-writer-
+	// wins), while its own rail name still records who made the rewrite.
+	extra := map[string]any{
+		"verdictClaimed": string(foremanv1alpha1.AgenticTaskVerdictGo),
+	}
+	got := enforceReviewerUnverifiedSummary(logr.Discard(), extra,
+		"Tests could not verify the fix; no runtime available.",
+		foremanv1alpha1.AgenticTaskVerdictGo)
+	if got != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("matching GO must demote to NO-GO; got %v", got)
+	}
+	if extra["verdictClaimed"] != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		t.Errorf("verdictClaimed must keep the first writer's archive; got %v", extra["verdictClaimed"])
+	}
+	if extra["verdictDemotedBy"] != railUnverifiedSummary {
+		t.Errorf("verdictDemotedBy = %v, want %q", extra["verdictDemotedBy"], railUnverifiedSummary)
+	}
+}
+
 // TestNormalizeModelVerdict_ErrorMapsToIncompleteWithModelReportedError pins
 // the #649 fix: the submit_result tool contract allows verdict="ERROR" (model
 // reports it cannot complete the task: a reviewer's could-not-review, a

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -1715,7 +1715,8 @@ func TestEnforceReviewerIssueAsk_UnverifiedGoNoRefsNoVouchDemotes(t *testing.T) 
 // terminal summary states in plain language that verification could not be
 // performed must demote to NO-GO, and a normal GO must stand untouched. The
 // first row is verbatim from the windowstead#321 incident that motivated
-// the rail.
+// the rail; the variant rows pin the full phrase set the enforcer's
+// docstring promises, including both apostrophe forms of the contractions.
 func TestEnforceReviewerUnverifiedSummary(t *testing.T) {
 	cases := []struct {
 		name    string
@@ -1742,6 +1743,42 @@ func TestEnforceReviewerUnverifiedSummary(t *testing.T) {
 			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
 		},
 		{
+			name:    "contraction can't, straight apostrophe",
+			summary: "Reviewed statically; can't verify the migration path without a database.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "contraction can't, curly apostrophe",
+			summary: "Reviewed statically; can’t verify the migration path without a database.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "contraction couldn't, straight apostrophe",
+			summary: "The harness is missing, so we couldn't verify the fix in this environment.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "contraction couldn't, curly apostrophe",
+			summary: "The harness is missing, so we couldn’t verify the fix in this environment.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "spaced can not",
+			summary: "No runtime is available here, so I can not verify the behavior.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
+			name:    "was not able to",
+			summary: "I was not able to verify the fix before approving; the harness was unavailable.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
+		},
+		{
 			name:    "case-insensitive",
 			summary: "APPROVE. Could NOT VERIFY the migration path; no database available.",
 			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
@@ -1764,6 +1801,18 @@ func TestEnforceReviewerUnverifiedSummary(t *testing.T) {
 			summary: "The new guard verifies the token before use; tests confirm it rejects expired tokens.",
 			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
 			want:    foremanv1alpha1.AgenticTaskVerdictGo,
+		},
+		{
+			// The tradeoff the enforcer's docstring documents: phrase
+			// anchoring matches whatever subject the phrase carries, so an
+			// honest GO describing what a third party cannot do is
+			// demoted. The false positive is accepted, because the
+			// subjectless incident summaries this rail exists for (#1454)
+			// are the common case.
+			name:    "object-subject honest GO is the accepted false positive",
+			summary: "The new signature check is correct: a client without the key cannot verify a forged signature, and the tests prove it.",
+			verdict: foremanv1alpha1.AgenticTaskVerdictGo,
+			want:    foremanv1alpha1.AgenticTaskVerdictNoGo,
 		},
 		{
 			name:    "non-GO with the phrase passes through unmarked",

--- a/pkg/foreman/agent/rail_skip.go
+++ b/pkg/foreman/agent/rail_skip.go
@@ -20,7 +20,7 @@ import "github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
 // this verdict?" and answering it should not require knowing every rail's name.
 const railsSkippedKey = "railsSkipped"
 
-// Rail names. Used in railsSkipped entries and, for the two rails that can
+// Rail names. Used in railsSkipped entries and, for the rails that can
 // rewrite a verdict, in the verdictDemotedBy marker those rails stamp. The
 // demoting rails take their names from pkg/foreman/agent/reviewer so the
 // controller, which reads verdictDemotedBy back out of the result envelope
@@ -36,6 +36,13 @@ const (
 	// could not be fetched at all; it never rewrites the verdict. Demotion is
 	// a later flip once the fleet shows the runs fit the turn budget.
 	railExecution = "review-execution"
+	// railUnverifiedSummary names the unverified-summary rail (#1454). It
+	// rewrites a GO to NO-GO when the reviewer's own terminal summary states
+	// in plain language that verification could not be performed. Like the
+	// issueAsk rail's demotion, this is a statement about verification
+	// confidence, not about the change: re-running the coder cannot make an
+	// unverifiable environment verifiable.
+	railUnverifiedSummary = "unverified-summary"
 )
 
 // Reasons a rail could not run.

--- a/pkg/foreman/agent/rail_skip.go
+++ b/pkg/foreman/agent/rail_skip.go
@@ -26,8 +26,17 @@ const railsSkippedKey = "railsSkipped"
 // controller, which reads verdictDemotedBy back out of the result envelope
 // and cannot import this package, compares against the same strings (#1636).
 const (
-	railIssueAsk            = reviewer.RailIssueAsk
-	railScopeOverlap        = reviewer.RailScopeOverlap
+	railIssueAsk     = reviewer.RailIssueAsk
+	railScopeOverlap = reviewer.RailScopeOverlap
+	// railUnverifiedSummary aliases the shared rail name so the rail's
+	// verdictDemotedBy marker and the controller's inertDemotion predicate
+	// compile against the same string (#1454, #1636). The rail rewrites a
+	// GO to NO-GO when the reviewer's own terminal summary states in plain
+	// language that verification could not be performed. Like the issueAsk
+	// rail's demotion, this is a statement about verification confidence,
+	// not about the change: re-running the coder cannot make an unverifiable
+	// environment verifiable.
+	railUnverifiedSummary   = reviewer.RailUnverifiedSummary
 	railVerdictFromFindings = "verdict-from-findings"
 	railEmptyClaim          = "empty-claim"
 	railGroundedFinding     = "grounded-finding"
@@ -36,13 +45,6 @@ const (
 	// could not be fetched at all; it never rewrites the verdict. Demotion is
 	// a later flip once the fleet shows the runs fit the turn budget.
 	railExecution = "review-execution"
-	// railUnverifiedSummary names the unverified-summary rail (#1454). It
-	// rewrites a GO to NO-GO when the reviewer's own terminal summary states
-	// in plain language that verification could not be performed. Like the
-	// issueAsk rail's demotion, this is a statement about verification
-	// confidence, not about the change: re-running the coder cannot make an
-	// unverifiable environment verifiable.
-	railUnverifiedSummary = "unverified-summary"
 )
 
 // Reasons a rail could not run.

--- a/pkg/foreman/agent/reviewer/demotion.go
+++ b/pkg/foreman/agent/reviewer/demotion.go
@@ -29,13 +29,20 @@ package reviewer
 // that is a statement about verification confidence, and re-running the
 // coder cannot change it. The scope-overlap rail demotes when the diff
 // touches none of the files the issue names: that is a statement about the
-// diff, and the coder CAN act on it. A consumer keying off verdictDemoted
-// alone conflates the two.
+// diff, and the coder CAN act on it. The unverified-summary rail demotes a
+// GO whose own summary admits verification could not be performed (#1454):
+// a statement about the review environment, not the change, and re-running
+// the coder cannot change it either. A consumer keying off verdictDemoted
+// alone conflates the three.
 //
 // The names live here, in the leaf package that already defines the
 // reviewer's submit_result.extra contract, because the producer
 // (pkg/foreman/agent's rails) and the consumer (internal/foreman/controller)
-// both need the same strings and neither imports the other.
+// both need the same strings and neither imports the other. A rail name
+// that exists only inside pkg/foreman/agent is one the controller's
+// inertDemotion predicate can never match, which is how unverified-summary
+// demotions silently drove futile fix iterations before this constant
+// existed.
 const (
 	// RailIssueAsk names enforceReviewerIssueAsk in
 	// pkg/foreman/agent/executor_native.go.
@@ -43,4 +50,7 @@ const (
 	// RailScopeOverlap names enforceReviewerScopeOverlap in
 	// pkg/foreman/agent/scope_overlap.go.
 	RailScopeOverlap = "scope-overlap"
+	// RailUnverifiedSummary names enforceReviewerUnverifiedSummary in
+	// pkg/foreman/agent/executor_native.go.
+	RailUnverifiedSummary = "unverified-summary"
 )

--- a/pkg/foreman/agent/unverified_summary_demotion_wiring_test.go
+++ b/pkg/foreman/agent/unverified_summary_demotion_wiring_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agent_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -52,9 +53,13 @@ import (
 // promote. The unverified-summary rail is the only actor. The summary is the
 // windowstead#321 incident that motivated the rail.
 
+const submitGOUnverifiedSummaryArgs = `{"verdict":"GO","summary":"APPROVE. The verify job is disabled in this fleet, ` +
+	`so I cannot verify goal reward or progression logic.",` +
+	`"issueAsk":"The verify Job is disabled in this fleet"}`
+
 // submitGOUnverifiedSummary mirrors a reviewer approval whose summary admits
 // verification could not be performed.
-const submitGOUnverifiedSummary = `{
+var submitGOUnverifiedSummary = fmt.Sprintf(`{
   "id": "t-submit",
   "choices": [{
     "index": 0,
@@ -65,13 +70,14 @@ const submitGOUnverifiedSummary = `{
         "type": "function",
         "function": {
           "name": "submit_result",
-          "arguments": "{\"verdict\":\"GO\",\"summary\":\"APPROVE. The verify job is disabled in this fleet, so I cannot verify goal reward or progression logic.\",\"issueAsk\":\"The verify Job is disabled in this fleet\"}"
+          "arguments": %q
         }
       }]
     },
     "finish_reason": "tool_calls"
   }]
-}`
+}`,
+	submitGOUnverifiedSummaryArgs)
 
 func TestUnverifiedSummaryRail_WiredIntoRunLLMPath(t *testing.T) {
 	gitOrSkip(t)
@@ -85,7 +91,8 @@ func TestUnverifiedSummaryRail_WiredIntoRunLLMPath(t *testing.T) {
 		"fetch_issue": {
 			// No path refs, so the scope-overlap rail skips instead of
 			// demoting.
-			Output: map[string]any{"body": "## Bug\n\nThe verify Job is disabled in this fleet, so runtime checks cannot run here."},
+			Output: map[string]any{"body": "## Bug\n\nThe verify Job is disabled " +
+				"in this fleet, so runtime checks cannot run here."},
 		},
 		"submit_result": {
 			Terminal: true,

--- a/pkg/foreman/agent/unverified_summary_demotion_wiring_test.go
+++ b/pkg/foreman/agent/unverified_summary_demotion_wiring_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
+	foremanagent "github.com/defilantech/llmkube/pkg/foreman/agent"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/reviewer"
+)
+
+// Production-path test for the #1454 unverified-summary rail. runLLMPath runs
+// enforceReviewerUnverifiedSummary inside the reviewer block: a GO whose
+// terminal summary admits in plain language that verification could not be
+// performed must come out of Execute as a NO-GO carrying the demotion markers
+// inertDemotion (internal/foreman/controller) keys off.
+//
+// This drives the REAL rail through Execute -> runLLMPath -> the reviewer
+// block (not a direct call to the helper), and asserts the markers on
+// modelExtra. Mutation check: remove the enforceReviewerUnverifiedSummary
+// call from runLLMPath and this test fails, because the verdict stays GO and
+// none of the demotion markers ever reach modelExtra. A test that called
+// enforceReviewerUnverifiedSummary directly would still pass with the call
+// site removed -- this one cannot.
+//
+// The other rails are kept out of the picture by construction: the fetched
+// issue body names no files, so the scope-overlap rail skips
+// (no-path-refs-in-issue) instead of demoting; the submit envelope's issueAsk
+// is a verbatim substring of that body, so reconcileReviewerIssueAsk marks it
+// verified and the issueAsk rail returns without touching the verdict; and
+// findings are empty, so the verdict-from-findings rail has nothing to
+// promote. The unverified-summary rail is the only actor. The summary is the
+// windowstead#321 incident that motivated the rail.
+
+// submitGOUnverifiedSummary mirrors a reviewer approval whose summary admits
+// verification could not be performed.
+const submitGOUnverifiedSummary = `{
+  "id": "t-submit",
+  "choices": [{
+    "index": 0,
+    "message": {
+      "role": "assistant",
+      "tool_calls": [{
+        "id": "tc-submit",
+        "type": "function",
+        "function": {
+          "name": "submit_result",
+          "arguments": "{\"verdict\":\"GO\",\"summary\":\"APPROVE. The verify job is disabled in this fleet, so I cannot verify goal reward or progression logic.\",\"issueAsk\":\"The verify Job is disabled in this fleet\"}"
+        }
+      }]
+    },
+    "finish_reason": "tool_calls"
+  }]
+}`
+
+func TestUnverifiedSummaryRail_WiredIntoRunLLMPath(t *testing.T) {
+	gitOrSkip(t)
+	root := t.TempDir()
+	bare := initBareWithSeed(t, root)
+	const branch = "foreman/review-unverified"
+	csPushNonEmptyBranch(t, root, bare, branch)
+	oaiSrv := scriptedOAI(t, []string{fetchIssueBody, submitGOUnverifiedSummary})
+
+	reg := &fakeRegistry{results: map[string]*foremanagent.ToolResult{
+		"fetch_issue": {
+			// No path refs, so the scope-overlap rail skips instead of
+			// demoting.
+			Output: map[string]any{"body": "## Bug\n\nThe verify Job is disabled in this fleet, so runtime checks cannot run here."},
+		},
+		"submit_result": {
+			Terminal: true,
+			Verdict:  "GO",
+			Summary:  "APPROVE. The verify job is disabled in this fleet, so I cannot verify goal reward or progression logic.",
+			Extra: map[string]any{
+				"reviewOutcome": "APPROVE",
+				// Verbatim substring of the fetched body above, so
+				// issueAsk is verified and its rail leaves the verdict alone.
+				"issueAsk": "The verify Job is disabled in this fleet",
+				"findings": []any{},
+			},
+		},
+	}}
+	e := reviewExecutor(t, bare, branch, reg, oaiSrv)
+
+	res, err := execWithAgent(t, e, &foremanv1alpha1.AgenticTask{
+		ObjectMeta: metav1.ObjectMeta{Name: "review-demo", Namespace: "default", UID: types.UID("review-demo-uid")},
+		Spec: foremanv1alpha1.AgenticTaskSpec{
+			Kind: foremanv1alpha1.AgenticTaskKindReview,
+			Payload: foremanv1alpha1.AgenticTaskPayload{
+				Repo:   "defilantech/LLMKube",
+				Issue:  1678,
+				Branch: branch,
+			},
+			AgentRef: &corev1.LocalObjectReference{Name: "reviewer-demo"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if res.Verdict != foremanv1alpha1.AgenticTaskVerdictNoGo {
+		t.Fatalf("final verdict: want NO-GO got %s (the unverified-summary rail must have demoted the GO)",
+			res.Verdict)
+	}
+
+	me, ok := res.Extra["modelExtra"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelExtra missing or wrong type: %T (%v)", res.Extra["modelExtra"], res.Extra)
+	}
+	if got := me["verdictDemoted"]; got != true {
+		t.Fatalf("verdictDemoted: want true, got %v", got)
+	}
+	if got := me["verdictDemotedBy"]; got != reviewer.RailUnverifiedSummary {
+		t.Fatalf("verdictDemotedBy: want %q got %v", reviewer.RailUnverifiedSummary, got)
+	}
+	if got := me["verdictClaimed"]; got != string(foremanv1alpha1.AgenticTaskVerdictGo) {
+		t.Fatalf("verdictClaimed: want the original GO archived, got %v", got)
+	}
+	if phrase, _ := me["unverifiedSummaryPhrase"].(string); !strings.Contains(phrase, "cannot verify") {
+		t.Fatalf("unverifiedSummaryPhrase: want the matched admission quoted, got %q", phrase)
+	}
+	if reason, _ := me["demotionReason"].(string); !strings.Contains(reason, `"cannot verify"`) {
+		t.Fatalf("demotionReason: want the matched phrase quoted in the reason, got %q", reason)
+	}
+}


### PR DESCRIPTION
## What

Demote a reviewer `GO` verdict to `NO-GO` when its terminal summary explicitly says verification could not be performed.

## Why

A `GO` must represent a verified approval. Previously a reviewer could report that it could not verify the change while still opening a PR. Fixes #1454.

## How

- Add a phrase-anchored reviewer integrity rail for `cannot verify`, `could not verify`, and `unable to verify` admissions.
- Preserve verdict-demotion audit metadata and add focused regression coverage, including the reported incident.
- Assisted-by: Codex with Agentic-local (generated the implementation and tests); I reviewed the diff and ran `make fmt`, `make vet`, `make lint`, and `make test`.

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally
- [x] Commit messages follow conventional commits
- [x] All commits are signed off (`git commit -s`) per DCO
- [x] AI assistance (if any) is disclosed above
- [ ] Documentation updated (if user-facing change)