### PR TITLE
feat(controller): metric-gated idle probe for the generic runtime

### DIFF
--- a/api/v1alpha1/constants.go
+++ b/api/v1alpha1/constants.go
@@ -38,6 +38,25 @@ const (
 	// in to drain-before-roll. Set on InferenceService metadata.annotations.
 	AnnotationIdleEndpoint = "inference.llmkube.dev/idle-endpoint"
 
+	// AnnotationIdleMetric names a Prometheus gauge exposed on the generic
+	// runtime's metrics endpoint whose sum reports in-flight work (for example
+	// vLLM's vllm:num_requests_running or SGLang's sglang:num_running_reqs).
+	// When set, the generic idle probe scrapes the metrics path and reports the
+	// member idle when the gauge sum is at or below AnnotationIdleMetricThreshold,
+	// giving a custom-image server the same precise drain the native runtimes
+	// get instead of a 2xx health check that is always "idle". Takes precedence
+	// over AnnotationIdleEndpoint. Set on InferenceService metadata.annotations.
+	AnnotationIdleMetric = "inference.llmkube.dev/idle-metric"
+
+	// AnnotationIdleMetricThreshold is the gauge sum at or below which the
+	// member counts as idle for AnnotationIdleMetric. Parsed as a float;
+	// defaults to 0 when unset or unparseable.
+	AnnotationIdleMetricThreshold = "inference.llmkube.dev/idle-metric-threshold"
+
+	// AnnotationIdleMetricPath overrides the HTTP path scraped for
+	// AnnotationIdleMetric. Defaults to /metrics.
+	AnnotationIdleMetricPath = "inference.llmkube.dev/idle-metric-path"
+
 	// DefaultAgentHeartbeatInterval is how often the metal-agent re-asserts
 	// its registrations (which also self-heals any missed update, #657).
 	DefaultAgentHeartbeatInterval = 30 * time.Second

--- a/docs/operations/gpu-sharing.md
+++ b/docs/operations/gpu-sharing.md
@@ -282,6 +282,36 @@ outruns `swapBudget`, so a client that retries after the incumbent drains is
 served. It is deliberately not a `502`: nothing is broken upstream, the slot is
 just occupied.
 
+### Precise drain for a custom-image member: the metric idle probe
+
+The `llamacpp`, `vllm` and `sglang` runtimes know how to ask their server whether
+it is idle (llama.cpp's `/slots`, vLLM's `vllm:num_requests_running` gauge), so a
+swap waits for in-flight work to finish before freeing the slot. The `generic`
+runtime, used for a custom image whose entrypoint the built-in runtimes cannot
+drive, has no such knowledge. By default it can only be told a health path via
+`inference.llmkube.dev/idle-endpoint`, and a plain health check returns 2xx even
+while the server is busy, so the pool treats such a member as always idle and can
+preempt it mid-request.
+
+If the custom image exposes Prometheus metrics with an in-flight-work gauge (most
+vLLM- and SGLang-derived images do), point the generic idle probe at it instead:
+
+```yaml
+metadata:
+  annotations:
+    inference.llmkube.dev/idle-metric: "vllm:num_requests_running"
+    # optional, default 0
+    inference.llmkube.dev/idle-metric-threshold: "0"
+    # optional, default /metrics
+    inference.llmkube.dev/idle-metric-path: "/metrics"
+```
+
+The probe scrapes the metrics path, sums the named gauge, and reports the member
+idle only when the sum is at or below the threshold, the same precise drain the
+native runtimes get. It fails closed: a non-200 scrape or an absent gauge counts
+as busy, so a member whose idleness cannot be established is never preempted.
+`idle-metric` takes precedence over `idle-endpoint` when both are set.
+
 ### swapBudget, and why it is separate from the request timeout
 
 `swapBudget` (default `300s`) bounds how long the router holds a cross-model

--- a/internal/controller/runtime_generic.go
+++ b/internal/controller/runtime_generic.go
@@ -3,7 +3,9 @@ package controller
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -82,6 +84,49 @@ func (b *GenericBackend) BuildProbes(port int32) (startup, liveness, readiness *
 // returns (false, errIdleUnsupported). If present, GETs the annotated path and
 // returns true on 2xx (idle), false on non-2xx (busy).
 func (b *GenericBackend) IdleProbe(isvc *inferencev1alpha1.InferenceService, client *http.Client) func(ctx context.Context, baseURL string) (bool, error) {
+	// Metric-gated mode takes precedence: scrape a Prometheus endpoint and gate
+	// idleness on the sum of a named gauge. This gives a custom-image server
+	// (e.g. a patched vLLM) the same precise drain the native runtimes get,
+	// rather than a 2xx health check that always reads as idle.
+	if metric := isvc.Annotations[inferencev1alpha1.AnnotationIdleMetric]; metric != "" {
+		metricsPath := isvc.Annotations[inferencev1alpha1.AnnotationIdleMetricPath]
+		if metricsPath == "" {
+			metricsPath = "/metrics"
+		}
+		var threshold float64
+		if raw := isvc.Annotations[inferencev1alpha1.AnnotationIdleMetricThreshold]; raw != "" {
+			if t, err := strconv.ParseFloat(raw, 64); err == nil {
+				threshold = t
+			}
+		}
+		return func(ctx context.Context, baseURL string) (bool, error) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+metricsPath, nil)
+			if err != nil {
+				return false, fmt.Errorf("failed to create request: %w", err)
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				return false, fmt.Errorf("idle metric probe failed: %w", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				return false, fmt.Errorf("idle metric endpoint returned status %d", resp.StatusCode)
+			}
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return false, fmt.Errorf("failed to read idle metric response: %w", err)
+			}
+			sum, found := parsePrometheusGaugeSum(string(body), metric)
+			if !found {
+				// The gauge is absent. Fail closed (report busy) rather than
+				// drain a member whose idleness we cannot establish; this mirrors
+				// the native vLLM/SGLang probes.
+				return false, nil
+			}
+			return sum <= threshold, nil
+		}
+	}
+
 	path, ok := isvc.Annotations[inferencev1alpha1.AnnotationIdleEndpoint]
 	if !ok {
 		return func(ctx context.Context, baseURL string) (bool, error) {

--- a/internal/controller/runtime_test.go
+++ b/internal/controller/runtime_test.go
@@ -374,6 +374,93 @@ func TestGenericIdleProbe(t *testing.T) {
 	}
 }
 
+func TestGenericMetricIdleProbe(t *testing.T) {
+	client := &http.Client{Timeout: 5 * time.Second}
+	metricAnno := func(extra map[string]string) *inferencev1alpha1.InferenceService {
+		anno := map[string]string{inferencev1alpha1.AnnotationIdleMetric: "vllm:num_requests_running"}
+		for k, v := range extra {
+			anno[k] = v
+		}
+		return &inferencev1alpha1.InferenceService{ObjectMeta: metav1.ObjectMeta{Annotations: anno}}
+	}
+	cases := []struct {
+		name     string
+		isvc     *inferencev1alpha1.InferenceService
+		body     string
+		status   int
+		wantErr  bool
+		wantIdle bool
+	}{
+		{"idle when gauge sum is 0", metricAnno(nil), "vllm:num_requests_running{m=\"a\"} 0\n", 200, false, true},
+		{"busy when gauge sum > 0", metricAnno(nil), "vllm:num_requests_running 2\n", 200, false, false},
+		{"idle at threshold", metricAnno(map[string]string{inferencev1alpha1.AnnotationIdleMetricThreshold: "1"}), "vllm:num_requests_running 1\n", 200, false, true},
+		{"busy above threshold", metricAnno(map[string]string{inferencev1alpha1.AnnotationIdleMetricThreshold: "1"}), "vllm:num_requests_running 2\n", 200, false, false},
+		{"busy when gauge absent (fail closed)", metricAnno(nil), "other_metric 0\n", 200, false, false},
+		{"error on non-200", metricAnno(nil), "", 503, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer server.Close()
+
+			probe := (&GenericBackend{}).IdleProbe(tc.isvc, client)
+			idle, err := probe(context.Background(), server.URL)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if idle != tc.wantIdle {
+				t.Errorf("idle = %v, want %v", idle, tc.wantIdle)
+			}
+			if gotPath != "/metrics" {
+				t.Errorf("scraped path = %q, want /metrics", gotPath)
+			}
+		})
+	}
+
+	t.Run("custom metrics path", func(t *testing.T) {
+		var gotPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte("vllm:num_requests_running 0\n"))
+		}))
+		defer server.Close()
+		isvc := metricAnno(map[string]string{inferencev1alpha1.AnnotationIdleMetricPath: "/proxy/metrics"})
+		idle, err := (&GenericBackend{}).IdleProbe(isvc, client)(context.Background(), server.URL)
+		if err != nil || !idle {
+			t.Errorf("idle=%v err=%v, want idle with no error", idle, err)
+		}
+		if gotPath != "/proxy/metrics" {
+			t.Errorf("scraped path = %q, want /proxy/metrics", gotPath)
+		}
+	})
+
+	t.Run("metric annotation takes precedence over idle-endpoint", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/metrics" {
+				t.Errorf("expected /metrics scrape, got %q", r.URL.Path)
+			}
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte("vllm:num_requests_running 0\n"))
+		}))
+		defer server.Close()
+		isvc := metricAnno(map[string]string{inferencev1alpha1.AnnotationIdleEndpoint: "/health"})
+		idle, err := (&GenericBackend{}).IdleProbe(isvc, client)(context.Background(), server.URL)
+		if err != nil || !idle {
+			t.Errorf("idle=%v err=%v, want metric mode to win", idle, err)
+		}
+	})
+}
+
 func TestIdleDetectorConformance(t *testing.T) {
 	backends := []struct {
 		name    string


### PR DESCRIPTION
## What

Add a metric-gated idle probe to the `generic` runtime. A new annotation `inference.llmkube.dev/idle-metric` (plus optional `-threshold` and `-path`) tells the generic idle probe to scrape a Prometheus endpoint and gate idleness on the sum of a named gauge, instead of the 2xx health check `idle-endpoint` allows.

## Why

Fixes #1800.

The native runtimes drain precisely (llama.cpp `/slots`, vLLM `vllm:num_requests_running`), so a ModelPool swap waits for in-flight work before freeing the slot. The `generic` runtime, used for a custom image whose entrypoint the built-in runtimes cannot drive (e.g. a patched vLLM), could only be given a health path, and a 2xx health check returns idle even while the server is busy. So the pool treats such a member as always idle and can preempt it mid-request, the coarse drain there is a real gap for anyone running a custom-image server as a pool member.

## How

- `AnnotationIdleMetric` / `AnnotationIdleMetricThreshold` (default 0) / `AnnotationIdleMetricPath` (default `/metrics`).
- `GenericBackend.IdleProbe` gains a metric mode that takes precedence over `idle-endpoint`: scrape the path, sum the gauge via the existing `parsePrometheusGaugeSum`, report idle when `sum <= threshold`.
- Fails closed: a non-200 scrape or an absent gauge counts as busy, so a member whose idleness cannot be established is never preempted (mirrors the native vLLM/SGLang probes).

Example:

```yaml
metadata:
  annotations:
    inference.llmkube.dev/idle-metric: "vllm:num_requests_running"
    inference.llmkube.dev/idle-metric-threshold: "0"   # optional
    inference.llmkube.dev/idle-metric-path: "/metrics" # optional
```

## Checklist

- [x] Tests added (`TestGenericMetricIdleProbe`: idle/busy, threshold, absent-gauge fail-closed, non-200, custom path, precedence over idle-endpoint)
- [x] `make lint` clean, `make manifests generate` no drift, gofmt clean
- [x] Conventional commit, DCO signed off
- [x] AI assistance disclosed
- [x] Docs updated (docs/operations/gpu-sharing.md)
