### PR TITLE
feat(foreman): serve Agents from Anthropic-native endpoints

### DIFF
--- a/api/foreman/v1alpha1/agent_types.go
+++ b/api/foreman/v1alpha1/agent_types.go
@@ -49,15 +49,19 @@ const (
 // AgentProvider names the model-serving backend the executor dispatches
 // to. v0.2 introduces this enum so reviewer Agents can route to an
 // OpenAI-compatible cloud proxy (typically a LiteLLM gateway hitting
-// Anthropic / OpenAI / Bedrock) without changing the agent loop. The
-// default "local" preserves the v0.1 behavior of resolving an
+// Anthropic / OpenAI / Bedrock) without changing the agent loop.
+// "anthropic" dials an Anthropic-native /v1/messages endpoint directly
+// (#1627): the Messages wire carries first-class thinking blocks and
+// structured tool input, which a translation proxy degrades or drops.
+// The default "local" preserves the v0.1 behavior of resolving an
 // in-cluster InferenceService.
 //
-// Air-gapped orgs MUST keep cloud-proxy Agents out of dispatch; both
-// the operator-level kill switch (--allow-cloud-providers flag, chart
-// value foreman.allowCloudProviders) and the per-Workload opt-in
-// (Workload.spec.allowCloudReviewers) gate this.
-// +kubebuilder:validation:Enum=local;cloud-proxy
+// Air-gapped orgs MUST keep non-local Agents out of dispatch; both the
+// operator-level kill switch (--allow-cloud-providers flag, chart value
+// foreman.allowCloudProviders) and the per-Workload opt-in
+// (Workload.spec.allowCloudReviewers) gate every non-local provider,
+// including anthropic.
+// +kubebuilder:validation:Enum=local;cloud-proxy;anthropic
 type AgentProvider string
 
 const (
@@ -70,34 +74,46 @@ const (
 	// Anthropic / OpenAI / Bedrock. Data leaves the cluster on every
 	// call; subject to the operator + workload sovereignty toggles.
 	AgentProviderCloudProxy AgentProvider = "cloud-proxy"
+	// AgentProviderAnthropic dispatches via providerConfig.baseURL to
+	// an Anthropic-native /v1/messages endpoint (e.g.
+	// "https://api.anthropic.com/v1"), the official API or a compatible
+	// server. The executor uses the Messages wire directly instead of an
+	// OpenAI-compatible translation proxy (#1627). Data leaves the
+	// cluster on every call; subject to the operator + workload
+	// sovereignty toggles.
+	AgentProviderAnthropic AgentProvider = "anthropic"
 )
 
 // ProviderConfig configures a non-local AgentProvider. Required when
-// AgentSpec.Provider is "cloud-proxy"; ignored when Provider is "local"
-// or unset.
+// AgentSpec.Provider is "cloud-proxy" or "anthropic"; ignored when
+// Provider is "local" or unset.
 type ProviderConfig struct {
-	// BaseURL is the OpenAI-compatible HTTP endpoint the executor
-	// dispatches chat-completions requests to. The /chat/completions
-	// path is appended; supply the /v1 prefix (e.g.
-	// "http://foundation-router.lan:4000/v1"). Required for
-	// cloud-proxy.
+	// BaseURL is the HTTP endpoint the executor dispatches to. The path
+	// appended depends on the provider: cloud-proxy posts to
+	// /chat/completions (supply the /v1 prefix, e.g.
+	// "http://foundation-router.lan:4000/v1"); anthropic posts to
+	// /messages (supply the /v1 prefix, e.g.
+	// "https://api.anthropic.com/v1"). Required for non-local providers.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
 	BaseURL string `json:"baseURL,omitempty"`
 
-	// Model is the identifier the proxy expects in the request body
+	// Model is the identifier the upstream expects in the request body
 	// (e.g. "claude-sonnet-4-6", "gpt-4o", "anthropic/claude-sonnet-4-6"
-	// when LiteLLM is in front). Required for cloud-proxy; overrides
-	// AgentSpec.Model on the wire while AgentSpec.Model remains the
-	// human-readable handle.
+	// when LiteLLM is in front). Required for non-local providers;
+	// overrides AgentSpec.Model on the wire while AgentSpec.Model
+	// remains the human-readable handle.
 	// +kubebuilder:validation:MinLength=1
 	// +optional
 	Model string `json:"model,omitempty"`
 
-	// APIKeySecretRef references a Secret carrying the bearer token
-	// the executor sends as the Authorization header. Optional: when
-	// nil, the proxy is dialed without auth (LAN-only LiteLLM behind
-	// a network policy is a common case).
+	// APIKeySecretRef references a Secret carrying the credential the
+	// executor sends with every request. The header is provider-shaped:
+	// cloud-proxy sends it as Authorization: Bearer <value> (the
+	// LiteLLM gateway contract); anthropic sends it verbatim as the
+	// x-api-key header (the Messages API contract). Optional: when nil,
+	// the endpoint is dialed without auth (LAN-only proxies behind a
+	// network policy are a common case).
 	// +optional
 	APIKeySecretRef *corev1.SecretKeySelector `json:"apiKeySecretRef,omitempty"`
 }

--- a/charts/foreman/templates/crds/agents.yaml
+++ b/charts/foreman/templates/crds/agents.yaml
@@ -457,6 +457,7 @@ spec:
                 enum:
                 - local
                 - cloud-proxy
+                - anthropic
                 type: string
               providerConfig:
                 description: |-
@@ -465,10 +466,13 @@ spec:
                 properties:
                   apiKeySecretRef:
                     description: |-
-                      APIKeySecretRef references a Secret carrying the bearer token
-                      the executor sends as the Authorization header. Optional: when
-                      nil, the proxy is dialed without auth (LAN-only LiteLLM behind
-                      a network policy is a common case).
+                      APIKeySecretRef references a Secret carrying the credential the
+                      executor sends with every request. The header is provider-shaped:
+                      cloud-proxy sends it as Authorization: Bearer <value> (the
+                      LiteLLM gateway contract); anthropic sends it verbatim as the
+                      x-api-key header (the Messages API contract). Optional: when nil,
+                      the endpoint is dialed without auth (LAN-only proxies behind a
+                      network policy are a common case).
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -493,20 +497,21 @@ spec:
                     x-kubernetes-map-type: atomic
                   baseURL:
                     description: |-
-                      BaseURL is the OpenAI-compatible HTTP endpoint the executor
-                      dispatches chat-completions requests to. The /chat/completions
-                      path is appended; supply the /v1 prefix (e.g.
-                      "http://foundation-router.lan:4000/v1"). Required for
-                      cloud-proxy.
+                      BaseURL is the HTTP endpoint the executor dispatches to. The path
+                      appended depends on the provider: cloud-proxy posts to
+                      /chat/completions (supply the /v1 prefix, e.g.
+                      "http://foundation-router.lan:4000/v1"); anthropic posts to
+                      /messages (supply the /v1 prefix, e.g.
+                      "https://api.anthropic.com/v1"). Required for non-local providers.
                     minLength: 1
                     type: string
                   model:
                     description: |-
-                      Model is the identifier the proxy expects in the request body
+                      Model is the identifier the upstream expects in the request body
                       (e.g. "claude-sonnet-4-6", "gpt-4o", "anthropic/claude-sonnet-4-6"
-                      when LiteLLM is in front). Required for cloud-proxy; overrides
-                      AgentSpec.Model on the wire while AgentSpec.Model remains the
-                      human-readable handle.
+                      when LiteLLM is in front). Required for non-local providers;
+                      overrides AgentSpec.Model on the wire while AgentSpec.Model
+                      remains the human-readable handle.
                     minLength: 1
                     type: string
                 type: object

--- a/config/crd/bases/foreman.llmkube.dev_agents.yaml
+++ b/config/crd/bases/foreman.llmkube.dev_agents.yaml
@@ -456,6 +456,7 @@ spec:
                 enum:
                 - local
                 - cloud-proxy
+                - anthropic
                 type: string
               providerConfig:
                 description: |-
@@ -464,10 +465,13 @@ spec:
                 properties:
                   apiKeySecretRef:
                     description: |-
-                      APIKeySecretRef references a Secret carrying the bearer token
-                      the executor sends as the Authorization header. Optional: when
-                      nil, the proxy is dialed without auth (LAN-only LiteLLM behind
-                      a network policy is a common case).
+                      APIKeySecretRef references a Secret carrying the credential the
+                      executor sends with every request. The header is provider-shaped:
+                      cloud-proxy sends it as Authorization: Bearer <value> (the
+                      LiteLLM gateway contract); anthropic sends it verbatim as the
+                      x-api-key header (the Messages API contract). Optional: when nil,
+                      the endpoint is dialed without auth (LAN-only proxies behind a
+                      network policy are a common case).
                     properties:
                       key:
                         description: The key of the secret to select from.  Must be
@@ -492,20 +496,21 @@ spec:
                     x-kubernetes-map-type: atomic
                   baseURL:
                     description: |-
-                      BaseURL is the OpenAI-compatible HTTP endpoint the executor
-                      dispatches chat-completions requests to. The /chat/completions
-                      path is appended; supply the /v1 prefix (e.g.
-                      "http://foundation-router.lan:4000/v1"). Required for
-                      cloud-proxy.
+                      BaseURL is the HTTP endpoint the executor dispatches to. The path
+                      appended depends on the provider: cloud-proxy posts to
+                      /chat/completions (supply the /v1 prefix, e.g.
+                      "http://foundation-router.lan:4000/v1"); anthropic posts to
+                      /messages (supply the /v1 prefix, e.g.
+                      "https://api.anthropic.com/v1"). Required for non-local providers.
                     minLength: 1
                     type: string
                   model:
                     description: |-
-                      Model is the identifier the proxy expects in the request body
+                      Model is the identifier the upstream expects in the request body
                       (e.g. "claude-sonnet-4-6", "gpt-4o", "anthropic/claude-sonnet-4-6"
-                      when LiteLLM is in front). Required for cloud-proxy; overrides
-                      AgentSpec.Model on the wire while AgentSpec.Model remains the
-                      human-readable handle.
+                      when LiteLLM is in front). Required for non-local providers;
+                      overrides AgentSpec.Model on the wire while AgentSpec.Model
+                      remains the human-readable handle.
                     minLength: 1
                     type: string
                 type: object

--- a/config/foreman/agents/claude-native-anthropic-reviewer.yaml
+++ b/config/foreman/agents/claude-native-anthropic-reviewer.yaml
@@ -55,9 +55,471 @@ spec:
             name: anthropic-api-key
             key: api-key
     systemPrompt: |
-        You are a code reviewer. Read the fetched diff, ground every
-        finding in a file and line, and submit your verdict with
-        submit_result.
+        # Foreman reviewer Agent system prompt
+
+        This is the reference copy of the system prompt the
+        `qwen36-35b-a3b-reviewer` Agent CR carries inline (see
+        `config/foreman/agents/qwen36-35b-a3b-reviewer.yaml`). Edit this file
+        when iterating on the prompt; re-paste into the Agent CR when you
+        ship a change. Keeping a checked-in copy at this path means prompt
+        edits show up in `git log` next to code changes.
+
+        The reviewer is pipeline step 3, after the coder Agent has produced a
+        branch on the fork and the gate Job has run `make fmt vet lint test`
+        + codegen-sync against that branch. The reviewer answers the question
+        the gate cannot: does this diff actually address the issue it claims
+        to fix, in a way a human maintainer would merge?
+
+        ---
+
+        You review one LLMKube branch per run. The workspace contains a
+        fresh clone of the fork, currently checked out on a throwaway branch
+        the executor creates for every task (it does not know this is a
+        review). Your first action is to navigate to the branch under review
+        using `bash`; see Step 1 below. Your task payload carries:
+
+        - `repo`         :: owner/name on GitHub (e.g. `defilantech/LLMKube`)
+        - `issue`        :: the integer issue number the coder claimed to fix
+        - `branch`       :: the branch name on the fork (e.g. `foreman/issue-510`)
+        - `gateVerdict`  :: the gate's verdict on this branch
+                            (`GATE-PASS` or `GATE-FAIL`); skip approving
+                            anything where this is not `GATE-PASS`
+        - `coderSummary` :: the one-line summary the coder submitted
+
+        You communicate by calling tools. Every tool call must produce
+        structured `tool_calls` in the OpenAI function-calling shape; do not
+        emit free-form review text outside of tool calls. Your run ends when
+        you call the terminal `submit_result` tool.
+
+        ## Tools available
+
+        - `read_file(path, offset?, limit?)` :: read a workspace file. Output
+          capped at 16 KiB; pass `offset` (1-based line) and `limit` for
+          ranged reads of long files. Use this to look at edited files and
+          the tests around them.
+        - `grep(pattern, path?, max?)` :: regex search across the workspace.
+          Useful for finding all call sites of a symbol the diff touched.
+        - `bash(command)` :: run a shell command under `sh -c` with a bounded
+          timeout. You will use this for:
+          - `git show HEAD` or `git diff main...HEAD` to see the full diff.
+          - `git log -1 --pretty=full HEAD` to read the commit message
+            verbatim.
+          - `git diff --stat main...HEAD` to see the touched-files summary.
+        - `fetch_issue(repo, number)` :: read the issue body + title + labels
+          from GitHub via the foreman-agent's own token. This is the source
+          of truth for what the issue actually asks for; do NOT skip it.
+          Replaces the old `bash("gh issue view ...")` recipe, which silently
+          degraded to an auth-error stub on FleetNodes where `gh` was not
+          separately authenticated (see issue #580).
+        - `submit_result(verdict, summary, extra?)` :: terminal. The loop
+          exits after this call. Reviewers do not author commits; leave
+          `commit_message` empty.
+
+        You do NOT have `write_file` or `str_replace`. You cannot edit the
+        branch. If you find something that needs fixing, you say so in your
+        review; you do not fix it yourself.
+
+        ## Step 1 :: Navigate to the branch + gather evidence
+
+        Always do these reads, in this order, before forming a judgment.
+        The first step is mandatory: until you run it, the workspace is on
+        an unrelated empty branch off main, and any diff you compute is
+        wrong.
+
+        1. `bash("git fetch origin {branch}:refs/remotes/origin/{branch} && git checkout origin/{branch}")`
+           to navigate to the branch under review. After this, `HEAD` is
+           the coder's commit. If this fails, submit
+           `verdict="ERROR"` with a `summary` naming the fetch failure;
+           do not guess at the diff.
+        2. `fetch_issue(repo, issue)` to read the issue title, body, and
+           labels. The issue body is your scope anchor: a `submit_result`
+           that approves a diff without quoting from the issue body is one
+           you did not do enough work for. (Earlier versions of this prompt
+           asked you to shell out to `gh issue view`; that path required
+           `gh` to be separately authed on every reviewer FleetNode and
+           silently degraded to an auth-error stub when it was not.)
+        3. `bash("git log -1 --pretty=full HEAD")` to read the commit
+           message.
+        4. `bash("git diff --stat main...HEAD")` for the file list.
+        5. `bash("git diff main...HEAD")` for the full diff (if more than
+           ~800 lines, fall back to `git show --stat` plus targeted
+           `read_file` reads of each touched file).
+        6. For each touched file, at least skim the surrounding code with
+           `read_file` so you can judge whether the change fits.
+        7. When the diff touches `.go` files, run the diff's own new tests,
+           narrowly: `bash("go test ./<package-of-touched-files>/ -run
+           '<NewTestName>' -count=1")` for the most load-bearing new test. The
+           gate already ran the whole suite; your run is for reading the
+           FAILURE OUTPUT SHAPE: a test that cannot fail informatively is a
+           finding under C.
+        8. When the diff touches `.go` files, probe one near-miss the diff
+           does NOT test. Construct the closest input that must NOT satisfy
+           the new behavior (the prefix-overlap name, the wrong import, the
+           boundary value one off) and execute it. Without write tools, use
+           bash: heredoc a small `_probe_test.go` into the package,
+           `go test -run` it, then `rm` it. One probe, chosen adversarially,
+           beats ten read-the-code-again passes. If the near-miss PASSES when
+           it must not, that is a NO-GO finding with the probe quoted.
+
+        If `gateVerdict` is not `GATE-PASS`, you still do the reads and
+        write a useful review; you just do not approve. The branch already
+        failed objective checks.
+
+        ## Step 2 :: Apply the review checklist
+
+        Score the diff against these criteria. Each finding must cite a
+        specific file/line, symbol, or quoted text from the issue. Vague
+        "looks fine" is not a finding.
+
+        ### A. Scope alignment (most important)
+
+        - Does the diff address what the issue body asks for? Quote the
+          specific ask from the issue body and point to the matching change.
+        - Do the files/symbols/paths the issue body names actually appear in
+          the diff? If the issue says "edit `scripts/foo.sh`" and the diff
+          doesn't touch that path, that is a scope-drift finding.
+        - Is the commit subject and `Fixes #N` trailer consistent with what
+          the diff does? If they disagree, the diff is wrong, not the commit
+          message.
+
+        The May 2026 v5 batch contains a calibration case: a commit titled
+        `fix(foreman): cascade-fail tasks with missing dependencies` that
+        claimed `Fixes #379`, where #379 actually asked for a Helm vs
+        kustomize RBAC sync check script. Same project, same agent, GATE
+        green, but wrong scope. That is a `REQUEST-CHANGES` review with the
+        explicit finding "diff addresses a different bug; #379 asks for X,
+        this delivers Y."
+
+        ### B. Change is minimal and idiomatic
+
+        - Are the edits proportionate to the issue? A 200-line refactor for
+          a typo fix is over-broad. A two-line patch for a feature request
+          is under-broad.
+        - Does the change match surrounding code style? Naming, error
+          handling, log fields, indentation should match neighbors.
+        - Did the agent edit generated files (`zz_generated.*`, CRD YAML
+          under `config/crd/bases/` or `charts/*/templates/crds/`)? Those
+          should only change via `make manifests` / `make chart-crds`; if
+          they were hand-edited, that is a finding.
+
+        ### C. Tests are meaningful
+
+        - Did the agent add tests for behavior changes? A bug fix without a
+          regression test is a finding.
+        - Do the new tests assert real behavior, or are they tautological
+          (asserting a constant the new code returns)? Read each new test
+          carefully.
+        - Were any existing tests weakened, skipped, or deleted to make the
+          diff go green? That is a serious finding.
+
+        ### D. Side effects
+
+        **Budget: spend at most 5 `grep` / `bash` calls in this section.** The
+        gate has already run `make test`, so existing exported-symbol callers
+        that depend on the old behavior usually surface as test failures
+        before you see the diff at all. Your value in Section D is the
+        *minority* case where a call site lives outside Go test coverage:
+        shell scripts, YAML templates, Helm value chains, generated CRDs,
+        docs that pin a flag name. Pick the 1-3 most-likely-to-be-misused
+        symbols changed by the diff and grep those. Stop after 5 calls. If
+        the diff only touches generated files, YAML, or markdown (no Go
+        exported symbols), skip Section D entirely.
+
+        - Use `grep` to find call sites of any modified function or
+          changed exported symbol; if call sites assume the old behavior,
+          call that out.
+        - Does the change touch RBAC, CRDs, Helm chart values, or operator
+          reconciler logic? Cross-component changes deserve closer reading.
+        - Are there magic numbers, hardcoded paths, or environment
+          assumptions that will surprise other contributors?
+
+        ### E. Documentation and ergonomics
+
+        - If the change adds a flag, env var, or CLI command, are the
+          user-facing docs (README, AGENTS.md, CONTRIBUTING.md, docs/site)
+          updated to mention it?
+        - If the change is purely internal, this section may not apply;
+          skip it cleanly rather than fishing.
+
+        ### F. Regression check (read `main` for every touched file)
+
+        Same-model coders rewrite more than they augment. For every file in
+        `git diff --stat main...HEAD`, fetch its pre-diff form with
+        `bash("git show main:path/to/file")` (or `read_file` on the worktree
+        after checking out `main`) and look for:
+
+        - Working logic that the diff *removed* rather than augmented. If the
+          issue body did not explicitly ask for removal, the removed path is
+          a likely regression. The May 2026 v0.3 batch contains a calibration
+          case: a `pkg/agent/registry.go` fix removed the entire
+          `host.minikube.internal` / `host.docker.internal` DNS fallback. The
+          issue body asked for better multi-NIC detection; it did not ask for
+          the DNS path to be deleted. That is a major regression finding.
+        - Documented environments the original code supported that the new
+          code no longer supports. If the codebase advertises a Docker
+          Desktop install path and the diff invalidates it, flag it.
+        - Exported symbols that disappeared. Use `grep` against `pkg/` and
+          `cmd/` to find call sites that will break.
+
+        If you cannot find a removed path that matters, say so explicitly in
+        your `extra.findings` rather than omitting the section: positive
+        signal that the regression check was performed.
+
+        ### G. Documentation / code consistency
+
+        Read every godoc comment immediately above a changed function,
+        method, or type. Compare what the doc claims to what the code does.
+        Disagreements are findings. Examples:
+
+        - Godoc says "returns an error when X" but the implementation panics
+          on X (different behavior).
+        - Godoc lists a numbered preference order ("1. Foo, 2. Bar, 3. Baz")
+          but the code skips one of the cases entirely (the May 2026 v0.3
+          case: godoc said "Loopback only as a last resort" but the
+          implementation `continue`s on `FlagLoopback` and never tries it;
+          the hardcoded `127.0.0.1` fallback at the bottom is what handles
+          it instead, but the doc doesn't say so).
+        - Godoc parameter names or types don't match the function signature
+          (e.g. doc says `timeout time.Duration` but signature has
+          `timeoutSec int`).
+
+        These are almost always cheap to fix and almost always catch a real
+        defect: the model wrote the doc *before* the implementation drifted,
+        or vice versa, and never reconciled them.
+
+        ### H. Magic number / constant justification
+
+        For every numeric literal, CIDR, regex, timeout, threshold, or
+        exclusion list added by the diff, ask: *what defends this value?*
+
+        - A test case that pins the value (a `wantCount = 5` assertion) is a
+          defense.
+        - A code comment that names the source (RFC 1918, kubebuilder
+          default, Kubernetes service CIDR convention) is a defense.
+        - A reference to the issue body that justifies the choice is a
+          defense.
+        - Nothing at all is a finding.
+
+        For exclusion lists specifically: check the *width* of every CIDR.
+        A `/24` excludes 256 addresses; a `/8` excludes 16 million. The May
+        2026 v0.3 case: a `getHostIP` fix excluded `10.0.0.0/8` "to avoid
+        VMs", which silently invalidates every corporate LAN that uses
+        RFC 1918 10.x ranges. The accompanying comment also mislabeled
+        families (`100.x.x.x` is CGNAT in `100.64.0.0/10`, not in
+        `10.0.0.0/8`). Both findings are visible from the diff alone.
+
+        When unsure whether a constant is justified, say so in the finding
+        rather than omitting it.
+
+        ### I. Real values, not placeholders
+
+        Do the tests exercise the change with the REAL values the system uses
+        in production (CRD enum values, real field/label/annotation strings,
+        real status phases, real runtime names), or with invented placeholders?
+        If a change touches a cross-component contract (a value the producer
+        emits and a consumer must handle), the test must use the actual
+        contract value. A test that passes only because it uses a placeholder
+        that happens to match the new code is a false positive.
+
+        Worked example: a change to the runtime registry adds support for
+        `"llamacpp"`. The test only exercises `"mlx-server"` — the value the
+        test author picked because it was already in the test file. The CRD
+        `+kubebuilder:default` and every real InferenceService CR use
+        `"llamacpp"`. The test passes in isolation but the unregistered
+        `"llamacpp"` key breaks production. This is the exact escape in
+        issue #784.
+
+        ### J. Wired-up, not inert
+
+        Is every new exported metric, flag, field, or runtime actually
+        referenced by a production code path, or is it only touched by tests?
+        A symbol that is defined, registered, and tested but never
+        emitted/consumed in production is a defect. Use `grep` to find
+        call sites of any new exported symbol; if the only hits are in test
+        files or the registration site itself, flag it.
+
+        Worked example: `llmkube_inference_ttft_seconds` and
+        `llmkube_inference_request_errors_total` were registered and tested
+        via self-increment, but never emitted by any production path. The
+        dashboard shows a permanent flat zero. This is the exact escape in
+        issue #786.
+
+        ### K. Verify by execution, not inspection
+
+        Reading a diff tells you what the code says. Only running it tells
+        you what the code does. Two escapes this section exists to prevent:
+        a rail merged whose central guard was reachable but never fired on
+        the case its own PR cited, and a PR that claimed two reproductions
+        fixed when its code structurally excluded one of them. Both passed
+        gate and read-only review; both fell in minutes to a reviewer who
+        executed the change instead of reading it.
+
+        When the diff touches `.go` files, the two runs are Step 1 items 7
+        and 8: run the diff's own new tests narrowly, then probe one
+        near-miss the diff does not test. They are cheap, mandatory, and
+        they come first — before you form a judgment, not after. A review
+        of a Go diff whose transcript carries no `go test` is recorded as
+        skipping the execution rail.
+
+        Then two audits that need no execution:
+
+        1. **Claim-scope audit.** List every issue, reproduction, or
+           behavior the commit message and code comments claim. Each claim
+           must be traceable to something you executed or read in the
+           diff. A claim you cannot trace is a finding; a claim the code
+           structurally cannot satisfy is a finding EVEN WHEN YOU APPROVE,
+           because the next person hitting that case will conclude the
+           code is broken rather than the claim was loose.
+
+        2. **Rationale audit.** When a comment justifies a restriction or
+           a design ("only X because Y"), check that Y is the load-bearing
+           reason. A guard justified by cost that actually exists for
+           soundness will be deleted by the first optimizer who disproves
+           the cost.
+
+        ## Step 3 :: Report
+
+        Call `submit_result` exactly once. Required fields:
+
+        - `verdict` :: one of `GO`, `NO-GO`, `ERROR`. The Foreman schema
+          reuses these three; for review tasks the mapping is:
+          - `GO`     = APPROVE. The diff addresses the issue at the right
+                       scope, is minimal and idiomatic, has meaningful
+                       tests, and no significant side effects you can find.
+          - `NO-GO`  = REQUEST-CHANGES. You found at least one substantive
+                       concern (scope drift, missing tests, tautological
+                       tests, weakened tests, scope creep, behavior-change-
+                       without-callers-updated, etc.).
+          - `ERROR`  = could-not-review. The branch fails to clone, the
+                       commit history is unreadable, the gate verdict is
+                       `GATE-FAIL` AND the failures are not obvious from the
+                       diff, or some technical issue prevents you from
+                       forming an opinion.
+
+          When in doubt between APPROVE and REQUEST-CHANGES, choose
+          REQUEST-CHANGES. False negatives (humans re-review approvals) are
+          cheap; false positives (auto-merging a wrong-scope diff) are
+          expensive.
+
+        - In `extra`, set `onTrust` :: a short list of what you did NOT
+          verify and why ("full suite not run, exceeds my turn budget;
+          taking the gate's pass on trust"). An empty list claims you
+          verified everything, so leave it empty only when that is true.
+          A review that cannot say what it skipped is claiming an
+          exhaustiveness no bounded review has.
+
+        - `summary` :: one-sentence outcome, 280 characters or fewer. This
+          becomes `AgenticTask.status.result.summary` and the human-readable
+          condition message. Lead with the verdict and the single most
+          important reason. Examples:
+          - `"APPROVE: diff matches #506's ask, regression test covers the
+            new branch, minimal scope."`
+          - `"REQUEST-CHANGES: #379 asks for a Helm vs kustomize RBAC sync
+            check; diff fixes an unrelated AgenticTaskReconciler bug."`
+          - `"ERROR: gate verdict was GATE-FAIL but no clear test failure
+            in diff context; needs human re-run."`
+
+        - `extra` :: structured fields the next pipeline step or a human
+          triage UI can pivot on. Required keys:
+          - `reviewOutcome`   :: `"APPROVE" | "REQUEST-CHANGES" | "REJECT"`
+                                 (REJECT is `NO-GO` + "do not retry"; reserve
+                                 for scope mismatches that the agent cannot
+                                 fix in a re-run, e.g. wrong issue
+                                 identification.)
+          - `findings`        :: `[]` of `{severity: "blocker" | "major" |
+                                 "minor", area: "scope" | "tests" | "style"
+                                 | "side-effects" | "docs", message: "...",
+                                 file: "path", line: N}`. Each finding must
+                                 include enough specifics (file path, line
+                                 number, quoted issue text) that a maintainer
+                                 can act on it without re-deriving your
+                                 reasoning.
+
+                                 Every BLOCKING finding (severity `blocker`
+                                 or `major`) MUST set `file` and `line` to a
+                                 line THIS diff changed (a line inside a
+                                 `git diff main...HEAD` hunk). A blocking
+                                 finding without a `file` + `line` on changed
+                                 code is IGNORED by the harness and cannot
+                                 sustain a REQUEST-CHANGES verdict; minor
+                                 findings may omit `file`/`line`.
+          - `issueAsk`        :: a short quote (≤200 chars) capturing the
+                                 operative ask of the issue body, taken from
+                                 the `fetch_issue` result as closely as you
+                                 can. Quote rather than paraphrase where
+                                 possible, but the executor verifies and, if
+                                 needed, corrects this field against the
+                                 fetched body server-side (an unverifiable
+                                 quote also demotes a GO verdict to NO-GO),
+                                 so give your best understanding and never
+                                 block or delay your verdict over quote
+                                 precision.
+          - `filesTouched`    :: `[]` of paths the diff actually changes.
+                                 You should derive this from
+                                 `git diff --name-only main...HEAD` you ran
+                                 in Step 1, but the executor ground-truths
+                                 this field server-side against the same
+                                 command before storing the result, so do
+                                 your best and the harness corrects any
+                                 drift. Your original list (if it differed)
+                                 lands at `filesTouchedClaimed` for the
+                                 operator to inspect; chronic drift here is
+                                 a model-quality signal.
+
+          - `prBody`          :: the full pull-request description, in
+                                 Markdown, with no length limit. Set it
+                                 whenever you APPROVE; it is ignored
+                                 otherwise. Write for someone who will read the
+                                 PR WITHOUT reading the diff: what changed, why
+                                 it was needed, and what a maintainer should
+                                 know. You have just read the diff and the
+                                 issue, so you are the best-placed step to
+                                 write it.
+
+                                 `summary` is capped at 280 characters and is
+                                 the wrong home for this. When `prBody` is
+                                 absent the executor falls back to `summary`,
+                                 so the PR description becomes a truncated
+                                 fragment of a single sentence.
+
+                                 This does not make you the PR author: the
+                                 executor still opens the PR and applies the
+                                 target repository's template. You supply the
+                                 text, you do not perform the action the Hard
+                                 rules below forbid.
+
+          Optional keys: `testsAdded` (int), `newSymbols` ([]string),
+          `riskLevel` (`"low" | "medium" | "high"`).
+
+        ## Hard rules
+
+        - Do NOT call `write_file`, `str_replace`, `git commit`, `git push`,
+          `git checkout`, or any branch operation. You are reading only.
+        - Do NOT call `gh pr create` or any PR-mutating command. PR
+          authorship is a separate v0.2 pipeline step.
+        - Do NOT approve based on the gate verdict alone. The gate already
+          ran; your value is everything the gate cannot check.
+        - Do NOT skip reading the issue body. Same-model coders and
+          reviewers share priors; the issue body is the only external
+          anchor that catches scope drift.
+        - No AI or tool attribution in the review text.
+        - If you cannot find the issue (`fetch_issue` returns "issue not
+          found" or "unauthorized", repo inaccessible, etc.) submit
+          `verdict="ERROR"` with a clear `summary` saying so. Do not guess
+          the issue's content from the diff alone.
+
+        ## Calibration
+
+        Reviews from this prompt are graded against three benchmarks:
+
+        - The v5 #379 case: must produce `NO-GO` / `REQUEST-CHANGES` with a
+          scope-drift finding.
+        - The v5 #449, #506, #510 cases: must produce `GO` / `APPROVE` with
+          at most minor findings.
+        - Any branch where `gateVerdict != "GATE-PASS"`: must NOT produce
+          `GO`; appropriate verdicts are `NO-GO` (if the gate failure is
+          expected given the diff) or `ERROR` (if the gate failure is
+          surprising and needs human triage).
     tools:
         - fetch_issue
         - submit_result

--- a/config/foreman/agents/claude-native-anthropic-reviewer.yaml
+++ b/config/foreman/agents/claude-native-anthropic-reviewer.yaml
@@ -1,0 +1,63 @@
+# Foreman Anthropic-native reviewer Agent (#1627).
+#
+# Dials an Anthropic-native /v1/messages endpoint directly instead of
+# an OpenAI-compatible translation proxy. Reach for this when the
+# translation is where fidelity is lost: the Messages wire carries the
+# model's reasoning as a first-class thinking channel and tool input
+# as structured JSON, both of which an OpenAI-shim degrades or drops
+# (e.g. reasoning leaking back into conversation content).
+#
+# Endpoint forms:
+#   - api.anthropic.com:            https://api.anthropic.com/v1
+#   - MiniMax Anthropic surface:    https://api.minimax.io/anthropic/v1
+#   - any Messages-compatible server (LiteLLM /v1/anthropic passthrough,
+#     a local proxy): supply its version prefix.
+# The client appends /messages; supply the /v1 prefix.
+#
+# Sovereignty
+# -----------
+# Anthropic Agents are non-local: the same TWO gates as cloud-proxy
+# apply — the operator --allow-cloud-providers kill switch (chart value
+# foreman.allowCloudProviders) and the per-Workload
+# spec.allowCloudReviewers opt-in. Either one closed suppresses this
+# Agent's tasks with a CloudReviewersSuppressed condition.
+#
+# The API key Secret
+# ------------------
+# Create the referenced Secret in the same namespace as the Workload:
+#
+#   kubectl create secret generic anthropic-api-key \
+#     --from-literal=api-key="<your Anthropic API key>" \
+#     -n default
+#
+# Unlike cloud-proxy (Authorization: Bearer), the value is sent
+# verbatim as the x-api-key header, the Messages API contract.
+apiVersion: foreman.llmkube.dev/v1alpha1
+kind: Agent
+metadata:
+    name: claude-native-anthropic-reviewer
+    namespace: default
+    labels:
+        app.kubernetes.io/part-of: foreman
+        foreman.llmkube.dev/role: reviewer
+        foreman.llmkube.dev/provider: anthropic
+spec:
+    role: reviewer
+    provider: anthropic
+    providerConfig:
+        # Anthropic-native Messages endpoint; must include the /v1
+        # prefix; the client appends /messages.
+        baseURL: https://api.anthropic.com/v1
+        # Model identifier as the Messages API expects it (no proxy
+        # routing layer in front this time).
+        model: claude-sonnet-4-6
+        apiKeySecretRef:
+            name: anthropic-api-key
+            key: api-key
+    systemPrompt: |
+        You are a code reviewer. Read the fetched diff, ground every
+        finding in a file and line, and submit your verdict with
+        submit_result.
+    tools:
+        - fetch_issue
+        - submit_result

--- a/internal/foreman/webhook/agent_webhook.go
+++ b/internal/foreman/webhook/agent_webhook.go
@@ -167,12 +167,13 @@ func validateAgentPromptShape(agent *foremanv1alpha1.Agent, specPath *field.Path
 	}
 
 	// LLM-driven Agent. Name whichever field actually made it LLM-driven: a
-	// cloud-proxy Agent has no inferenceServiceRef, so citing that field sends
-	// the operator looking at something they never set.
+	// non-local Agent (cloud-proxy or anthropic) has no inferenceServiceRef,
+	// so citing that field sends the operator looking at something they never
+	// set.
 	if strings.TrimSpace(agent.Spec.SystemPrompt) == "" {
 		because := "inferenceServiceRef is set"
-		if agent.Spec.Provider == foremanv1alpha1.AgentProviderCloudProxy {
-			because = "provider is cloud-proxy"
+		if p := agent.Spec.Provider; p != "" && p != foremanv1alpha1.AgentProviderLocal {
+			because = "provider is " + string(p)
 		}
 		errs = append(errs, field.Required(
 			specPath.Child("systemPrompt"),

--- a/pkg/foreman/agent/anthropic/client.go
+++ b/pkg/foreman/agent/anthropic/client.go
@@ -1,0 +1,588 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropic
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// Client is a minimal client for the Anthropic Messages API.
+//
+// As with the oai client it is deliberately not the official SDK: Foreman
+// needs exactly one HTTP shape, wants provider-specific retry semantics,
+// and does not want the SDK's transitive cone (#1627).
+//
+// Wire protocol is SSE (text/event-stream) only. Aggregation happens
+// transparently inside Chat; callers see the same oai-shaped
+// ChatResponse regardless of which native endpoint they dialed. The two
+// clients therefore sit behind the same ChatCompleter seam in the loop.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+	maxRetries int
+	// apiKey, when non-empty, is sent on every request as the x-api-key
+	// header (the Messages API's auth scheme — not Authorization/Bearer,
+	// which is what the oai client's WithAuthHeader sends). Empty dials
+	// without auth (local Anthropic-compatible servers).
+	apiKey string
+	// backoffs are the inter-attempt delays, each wrapped with +/- 20%
+	// jitter so a fleet of agents does not retry in lockstep.
+	backoffs []time.Duration
+}
+
+// Option configures the Client.
+type Option func(*Client)
+
+// WithAPIKey sets the x-api-key header value sent on every request.
+// Anthropic's scheme is a dedicated header, not Authorization: Bearer;
+// the oai client's WithAuthHeader is deliberately not reused here so a
+// caller cannot conflate the two. Empty disables the header.
+func WithAPIKey(key string) Option {
+	return func(c *Client) { c.apiKey = key }
+}
+
+// WithHTTPClient overrides the default http.Client (mainly for tests).
+func WithHTTPClient(c *http.Client) Option {
+	return func(cl *Client) { cl.httpClient = c }
+}
+
+// WithBackoffs replaces the default 50ms / 250ms / 1s schedule. Useful
+// in tests to keep the suite fast.
+func WithBackoffs(b []time.Duration) Option {
+	return func(cl *Client) {
+		cl.backoffs = append([]time.Duration(nil), b...)
+	}
+}
+
+// New builds a client. baseURL must include the API version prefix
+// ("https://api.anthropic.com/v1"); requests POST to <baseURL>/messages.
+// requestTimeout bounds how long we wait for the upstream to start
+// sending response headers; it does not bound the total streaming
+// duration (a long thinking stream would otherwise spuriously time
+// out). The caller's context.Context is the overall guard. maxRetries
+// bounds how many additional attempts are made on a truncated tool-call
+// stream or transient transport failure; pass 0 to disable retries
+// entirely.
+func New(baseURL string, requestTimeout time.Duration, maxRetries int, opts ...Option) *Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.ResponseHeaderTimeout = requestTimeout
+	c := &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Transport: transport,
+			// No Client.Timeout: the streaming body can legitimately
+			// take longer than the header wait (a thinking model
+			// emitting a long reasoning trace). ctx.Done is the
+			// overall guard.
+		},
+		maxRetries: maxRetries,
+		backoffs: []time.Duration{
+			50 * time.Millisecond,
+			250 * time.Millisecond,
+			time.Second,
+		},
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
+}
+
+// Chat sends a single Messages request and returns the aggregated
+// streamed response. On oai.ErrTruncatedToolCallArguments, a transient
+// header timeout, or a transient transport disconnect the call is
+// retried up to MaxRetries times with bounded backoff plus jitter
+// (mirroring the oai client's policy). Any other error (HTTP non-2xx,
+// stream-embedded error, SSE parse failure) is returned to the caller
+// immediately without retry.
+func (c *Client) Chat(ctx context.Context, req oai.ChatRequest) (*oai.ChatResponse, error) {
+	var lastErr error
+	for attempt := 0; attempt <= c.maxRetries; attempt++ {
+		if attempt > 0 {
+			if err := c.sleepBackoff(ctx, attempt-1); err != nil {
+				return nil, err
+			}
+		}
+		resp, err := c.doOnce(ctx, req)
+		if err == nil {
+			return resp, nil
+		}
+		// Never retry once the parent context is done: a loop-wide
+		// budget (#532) or external cancellation must propagate so the
+		// caller can exit gracefully instead of spinning retries.
+		// Checked before classification because a context deadline
+		// also satisfies net.Error.Timeout().
+		if ctx.Err() != nil {
+			return nil, err
+		}
+		if errors.Is(err, oai.ErrTruncatedToolCallArguments) || isRetryableTimeout(err) || isRetryableTransportError(err) {
+			lastErr = err
+			continue
+		}
+		return nil, err
+	}
+	return nil, fmt.Errorf("after %d retries: %w", c.maxRetries, lastErr)
+}
+
+// isRetryableTimeout reports whether err is a network timeout (e.g. the
+// transport's ResponseHeaderTimeout firing while awaiting the first
+// byte). Mirrors oai.isRetryableTimeout (unexported there, so duplicated
+// here — keep the two in sync). Callers must rule out a done parent
+// context first, since context.DeadlineExceeded also satisfies
+// net.Error.Timeout().
+func isRetryableTimeout(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}
+
+// isRetryableTransportError reports whether err is a transient transport
+// failure that can be retried by re-issuing the same request: mid-stream
+// disconnects (io.ErrUnexpectedEOF, io.EOF), network timeouts, and
+// connection resets. Genuine API errors (non-2xx, stream-embedded error
+// events) are NOT retryable and must pass through unchanged. Mirrors
+// oai.isRetryableTransportError (unexported there, so duplicated here —
+// keep the two in sync).
+func isRetryableTransportError(err error) bool {
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
+	}
+	if errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+	if strings.Contains(err.Error(), "connection reset by peer") {
+		return true
+	}
+	return false
+}
+
+// sleepBackoff blocks for backoffs[i] +/- 20% jitter, honoring ctx
+// cancellation. i is clamped to the last backoff if the schedule is
+// shorter than the retry count.
+func (c *Client) sleepBackoff(ctx context.Context, i int) error {
+	if len(c.backoffs) == 0 {
+		return nil
+	}
+	if i >= len(c.backoffs) {
+		i = len(c.backoffs) - 1
+	}
+	d := c.backoffs[i]
+	// math/rand/v2 is intentional here: this is jitter to de-synchronize a
+	// fleet of agents retrying at the same time, not a security primitive.
+	// crypto/rand would be a wasteful overcorrection and add an unbounded
+	// failure mode (entropy exhaustion under load).
+	jitter := time.Duration(float64(d) * 0.4 * (rand.Float64() - 0.5)) //nolint:gosec // G404: jitter, not security
+	d += jitter
+	if d < 0 {
+		d = 0
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// doOnce performs a single streaming round trip with no retry. Returns
+// the aggregated response on 2xx + a stream with substance, or one of:
+//
+//   - oai.ErrNoChoices                   :: 2xx but no text/thinking/tool content
+//   - oai.ErrTruncatedToolCallArguments  :: 2xx but tool_use input is not a JSON object
+//   - *statusError                       :: non-2xx (wraps *oai.StatusError)
+//   - a stream-embedded error            :: the API's in-stream abort
+//   - a wrapped transport error          :: dial / TLS / read failure
+func (c *Client) doOnce(ctx context.Context, req oai.ChatRequest) (*oai.ChatResponse, error) {
+	wire, err := translateRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(wire)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: marshal request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		c.baseURL+"/messages", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "text/event-stream")
+	httpReq.Header.Set("anthropic-version", APIVersion)
+	if c.apiKey != "" {
+		httpReq.Header.Set("x-api-key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic: dispatch request: %w", err)
+	}
+	defer func() {
+		// Drain so the TCP connection can be reused, but bound the
+		// drain so a server that holds the connection open after
+		// message_stop cannot stall the caller. Cap at 64 KiB and
+		// 100ms; on hit, we close without reuse and the next call
+		// opens a fresh conn.
+		drained := make(chan struct{})
+		go func() {
+			_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+			close(drained)
+		}()
+		select {
+		case <-drained:
+		case <-time.After(100 * time.Millisecond):
+		}
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		// Cap the body in the message: provider error bodies can be
+		// verbose and this string lands in task status. 500 bytes is
+		// enough to identify the failure (the "temperature"-style
+		// keywords rejectsTemperature looks for arrive early).
+		excerpt := string(b)
+		if len(excerpt) > 500 {
+			excerpt = excerpt[:500]
+		}
+		return nil, &statusError{
+			code:  resp.StatusCode,
+			path:  httpReq.URL.String(),
+			body:  excerpt,
+			inner: &oai.StatusError{Code: resp.StatusCode, Body: excerpt},
+		}
+	}
+
+	return readSSEStream(resp.Body)
+}
+
+// statusError is a non-2xx response from the Messages API. It wraps
+// *oai.StatusError (via Unwrap) so the loop's rejectsTemperature check
+// — which does errors.As for *oai.StatusError and looks for a 400 whose
+// body mentions "temperature" — works identically against both native
+// endpoints.
+type statusError struct {
+	code  int
+	path  string
+	body  string
+	inner *oai.StatusError
+}
+
+func (e *statusError) Error() string {
+	return fmt.Sprintf("anthropic: POST %s: %d: %s", e.path, e.code, e.body)
+}
+
+func (e *statusError) Unwrap() error { return e.inner }
+
+// readSSEStream reads the Messages SSE stream and aggregates it into a
+// single oai-shaped ChatResponse.
+//
+// The wire format is standard SSE: events are separated by blank lines,
+// each with an `event:` name line and one `data:` line carrying a JSON
+// object whose `type` field duplicates the event name. This parser
+// dispatches on the type field and uses the event: name only as a
+// fallback, so an endpoint that omits one or the other still works.
+// `ping` keep-alives and unknown event types are ignored (forward
+// compatibility). The stream ends on message_stop, but a clean EOF
+// before it is also valid — some Anthropic-compatible endpoints stop
+// sending at the last content_block_stop without the terminator, as
+// llama.cpp does with [DONE].
+func readSSEStream(body io.Reader) (*oai.ChatResponse, error) {
+	scanner := bufio.NewScanner(body)
+	// SSE data lines carry complete JSON objects and can be large
+	// (a thinking block or a big tool input fragment). Same max-token
+	// budget as the oai reader.
+	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+
+	agg := &messageAggregator{blockByIndex: make(map[int]*toolBlock)}
+	pendingEvent := ""
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event:") {
+			pendingEvent = strings.TrimSpace(line[len("event:"):])
+			continue
+		}
+		if !strings.HasPrefix(line, "data:") {
+			// Blank lines, comments, and other fields are protocol
+			// noise for our purposes.
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" {
+			continue
+		}
+
+		evt := ""
+		if strings.HasPrefix(payload, "{") {
+			var probe struct {
+				Type string `json:"type"`
+			}
+			if err := json.Unmarshal([]byte(payload), &probe); err == nil {
+				evt = probe.Type
+			}
+		}
+		if evt == "" {
+			evt = pendingEvent
+		}
+		pendingEvent = ""
+
+		if err := agg.absorb(evt, payload); err != nil {
+			return nil, err
+		}
+		if agg.done {
+			break
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("anthropic: read SSE: %w", err)
+	}
+	if agg.streamErr != nil {
+		return nil, agg.streamErr
+	}
+	return agg.build()
+}
+
+// toolBlock is one in-flight tool_use content block, accumulated from
+// its content_block_start (id, name, and the initial input field) plus
+// the input_json_delta fragments.
+type toolBlock struct {
+	index    int
+	id       string
+	name     string
+	inputBuf strings.Builder
+	// inputStart is the input field of the content_block_start payload.
+	// The Anthropic API sends a "{}" placeholder (the real arguments
+	// arrive as partial_json deltas), but a third-party endpoint could
+	// send the full object up front and no deltas — build() falls back
+	// to it only when the delta buffer is empty.
+	inputStart json.RawMessage
+}
+
+// messageAggregator collapses the Messages SSE events into one
+// oai-shaped ChatResponse. Content and reasoning accumulate as strings
+// (the oai Message shape); tool_use blocks are tracked by their stream
+// index and emitted in start order.
+type messageAggregator struct {
+	id           string
+	content      strings.Builder
+	reasoning    strings.Builder
+	hadSubstance bool // any non-empty text or thinking delta, or a tool_use block
+	blocks       []*toolBlock
+	blockByIndex map[int]*toolBlock
+	stopReason   string
+	// inputTokens / outputTokens are parsed from message_start and
+	// message_delta but not yet surfaced: the oai-shaped ChatResponse
+	// has no Usage field. They exist so a future usage field has a
+	// ready source (#1627).
+	inputTokens  int
+	outputTokens int
+	done         bool
+	streamErr    error
+}
+
+// absorb folds one SSE event into the aggregator. evt is the event type
+// (from the data JSON's type field, or the event: name as fallback).
+// Unknown types are ignored so a newer API version can add events
+// without breaking older clients.
+func (a *messageAggregator) absorb(evt, payload string) error {
+	switch evt {
+	case sseTypePing:
+		// Keep-alive; nothing to do.
+
+	case sseTypeMsgStart:
+		var e sseMessageStart
+		if err := json.Unmarshal([]byte(payload), &e); err != nil {
+			return fmt.Errorf("anthropic: decode message_start: %w", err)
+		}
+		a.id = e.Message.ID
+		a.inputTokens = e.Message.Usage.InputTokens
+
+	case sseTypeBlkStart:
+		var e sseContentBlockStart
+		if err := json.Unmarshal([]byte(payload), &e); err != nil {
+			return fmt.Errorf("anthropic: decode content_block_start: %w", err)
+		}
+		switch e.ContentBlock.Type {
+		case blockTypeText, blockTypeThinking:
+			// The block opens; bytes arrive as deltas.
+		case blockTypeToolUse:
+			tb := &toolBlock{
+				index:      e.Index,
+				id:         e.ContentBlock.ID,
+				name:       e.ContentBlock.Name,
+				inputStart: e.ContentBlock.Input,
+			}
+			a.blockByIndex[e.Index] = tb
+			a.blocks = append(a.blocks, tb)
+			a.hadSubstance = true
+		default:
+			// Unknown block kind (e.g. a future type): its deltas
+			// will not match a known delta type and are dropped.
+		}
+
+	case sseTypeBlkDelta:
+		var e sseContentBlockDelta
+		if err := json.Unmarshal([]byte(payload), &e); err != nil {
+			return fmt.Errorf("anthropic: decode content_block_delta: %w", err)
+		}
+		switch e.Delta.Type {
+		case deltaTypeText:
+			if e.Delta.Text != "" {
+				a.hadSubstance = true
+			}
+			a.content.WriteString(e.Delta.Text)
+		case deltaTypeThinking:
+			if e.Delta.Thinking != "" {
+				a.hadSubstance = true
+			}
+			a.reasoning.WriteString(e.Delta.Thinking)
+		case deltaTypeInputJSON:
+			if b := a.blockByIndex[e.Index]; b != nil {
+				b.inputBuf.WriteString(e.Delta.PartialJSON)
+			}
+		case deltaTypeSignature:
+			// The thinking block's signature. It is required to
+			// replay a thinking block and unusable here (third-party
+			// endpoints emit unsigned ones); dropped with the rest
+			// of the reasoning on the way back into history.
+		default:
+			// Unknown delta kind: dropped.
+		}
+
+	case sseTypeBlkStop:
+		// Blocks close in the same order they open; no state to update.
+
+	case sseTypeMsgDelta:
+		var e sseMessageDelta
+		if err := json.Unmarshal([]byte(payload), &e); err != nil {
+			return fmt.Errorf("anthropic: decode message_delta: %w", err)
+		}
+		a.stopReason = e.Delta.StopReason
+		a.outputTokens = e.Usage.OutputTokens
+
+	case sseTypeMsgStop:
+		a.done = true
+
+	case sseTypeErrorEvent:
+		var e sseStreamError
+		if err := json.Unmarshal([]byte(payload), &e); err != nil {
+			return fmt.Errorf("anthropic: decode stream error: %w", err)
+		}
+		a.streamErr = fmt.Errorf("anthropic: stream error: %s: %s", e.Error.Type, e.Error.Message)
+
+	default:
+		// Unknown event type: ignore (forward compatibility).
+	}
+	return nil
+}
+
+// build assembles the aggregated oai-shaped response. A stream that
+// carried no substance at all maps to oai.ErrNoChoices (a misconfigured
+// upstream, non-retryable). Tool-call arguments that are non-empty but
+// not a JSON object map to oai.ErrTruncatedToolCallArguments (a
+// mid-stream truncation, retryable — the same class of failure as the
+// oai client's, and the loop's retry budget covers both).
+func (a *messageAggregator) build() (*oai.ChatResponse, error) {
+	if !a.hadSubstance {
+		return nil, fmt.Errorf("%w: stream ended with no text, thinking, or tool content", oai.ErrNoChoices)
+	}
+
+	var toolCalls []oai.ToolCall
+	for _, b := range a.blocks {
+		args := b.inputBuf.String()
+		if args == "" && len(b.inputStart) > 0 && string(b.inputStart) != "{}" {
+			args = string(b.inputStart)
+		}
+		if args != "" {
+			var probe map[string]any
+			if err := json.Unmarshal([]byte(args), &probe); err != nil {
+				return nil, fmt.Errorf("%w (tool_use %s): %w", oai.ErrTruncatedToolCallArguments, b.id, err)
+			}
+		}
+		// An empty argument string is kept as-is: the loop's dispatch
+		// converts "" to "{}", same as the oai path.
+		toolCalls = append(toolCalls, oai.ToolCall{
+			ID:   b.id,
+			Type: "function",
+			Function: oai.ToolCallFunction{
+				Name:      b.name,
+				Arguments: args,
+			},
+		})
+	}
+
+	msg := oai.Message{
+		Role:      oai.RoleAssistant,
+		Content:   a.content.String(),
+		ToolCalls: toolCalls,
+	}
+	if a.reasoning.Len() > 0 {
+		msg.ReasoningContent = a.reasoning.String()
+	}
+	return &oai.ChatResponse{
+		ID: a.id,
+		Choices: []oai.Choice{{
+			Index:        0,
+			Message:      msg,
+			FinishReason: mapStopReason(a.stopReason),
+		}},
+	}, nil
+}
+
+// mapStopReason maps an Anthropic stop_reason to the OpenAI finish_reason
+// vocabulary the loop switches on. end_turn and stop_sequence are both
+// "the model finished normally" (the loop treats them as the same);
+// tool_use is the tool-call turn; max_tokens is a token-cap truncation
+// (the loop's truncation-continuation path). Anything else — including
+// the empty value of a stream that ended before message_delta — is
+// passed through verbatim so a new reason degrades to "unknown" rather
+// than being silently reclassified.
+func mapStopReason(s string) string {
+	switch s {
+	case "end_turn", "stop_sequence":
+		return "stop"
+	case "tool_use":
+		return "tool_calls"
+	case "max_tokens":
+		return "length"
+	default:
+		return s
+	}
+}

--- a/pkg/foreman/agent/anthropic/client_test.go
+++ b/pkg/foreman/agent/anthropic/client_test.go
@@ -1,0 +1,639 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// scriptedResponse is one canned HTTP response. status 0 means 200.
+type scriptedResponse struct {
+	status int
+	body   string
+}
+
+// recordedRequest is one captured inbound request, for wire assertions.
+type recordedRequest struct {
+	path    string
+	headers http.Header
+	body    []byte
+}
+
+// scriptedAnthropicServer replays canned responses in sequence (the last
+// one repeats once the script is exhausted) and records every request so
+// tests can assert on the exact wire shape.
+func scriptedAnthropicServer(t *testing.T, responses ...scriptedResponse) (*httptest.Server, *[]recordedRequest) {
+	t.Helper()
+	rec := &[]recordedRequest{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		*rec = append(*rec, recordedRequest{path: r.URL.Path, headers: r.Header.Clone(), body: body})
+
+		idx := len(*rec) - 1
+		if idx >= len(responses) {
+			idx = len(responses) - 1
+		}
+		resp := responses[idx]
+		if resp.status == 0 {
+			resp.status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(resp.status)
+		_, _ = io.WriteString(w, resp.body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, rec
+}
+
+func decodeBody(t *testing.T, req *recordedRequest) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(req.body, &m); err != nil {
+		t.Fatalf("recorded request body is not JSON: %v\n%s", err, req.body)
+	}
+	return m
+}
+
+const sseHappyText = `event: ping
+data: {"type":"ping"}
+
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_01","model":"claude-sonnet-4-6","usage":{"input_tokens":10}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hel"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"lo"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":2}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+func TestChat_HappyText(t *testing.T) {
+	srv, reqs := scriptedAnthropicServer(t, scriptedResponse{body: sseHappyText})
+	client := New(srv.URL+"/v1", time.Second, 0, WithAPIKey("sk-test"))
+
+	resp, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model:    "claude-sonnet-4-6",
+		Messages: []oai.Message{{Role: oai.RoleUser, Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.ID != "msg_01" {
+		t.Errorf("id: want msg_01 got %q", resp.ID)
+	}
+	if len(resp.Choices) != 1 {
+		t.Fatalf("want 1 choice, got %d", len(resp.Choices))
+	}
+	ch := resp.Choices[0]
+	if ch.Message.Role != oai.RoleAssistant || ch.Message.Content != "Hello" {
+		t.Errorf("message: %+v", ch.Message)
+	}
+	if ch.Message.ReasoningContent != "" || len(ch.Message.ToolCalls) != 0 {
+		t.Errorf("unexpected reasoning/tool calls: %+v", ch.Message)
+	}
+	if ch.FinishReason != "stop" {
+		t.Errorf("finish: want stop got %q", ch.FinishReason)
+	}
+
+	if len(*reqs) != 1 {
+		t.Fatalf("want 1 request, got %d", len(*reqs))
+	}
+	r := (*reqs)[0]
+	if r.path != "/v1/messages" {
+		t.Errorf("path: want /v1/messages got %q", r.path)
+	}
+	for hdr, want := range map[string]string{
+		"x-api-key":         "sk-test",
+		"anthropic-version": APIVersion,
+		"Content-Type":      "application/json",
+		"Accept":            "text/event-stream",
+	} {
+		if got := r.headers.Get(hdr); got != want {
+			t.Errorf("header %s: want %q got %q", hdr, want, got)
+		}
+	}
+	body := decodeBody(t, &r)
+	if body["model"] != "claude-sonnet-4-6" {
+		t.Errorf("model: %v", body["model"])
+	}
+	if body["stream"] != true {
+		t.Errorf("stream must be true: %v", body["stream"])
+	}
+	if body["max_tokens"] != float64(DefaultMaxTokens) {
+		t.Errorf("max_tokens: want %d got %v", DefaultMaxTokens, body["max_tokens"])
+	}
+	if _, ok := body["system"]; ok {
+		t.Error("system must be omitted when no system messages exist")
+	}
+	if _, ok := body["temperature"]; ok {
+		t.Error("temperature must be omitted when nil")
+	}
+	msgs, _ := body["messages"].([]any)
+	if len(msgs) != 1 {
+		t.Fatalf("want 1 message, got %d", len(msgs))
+	}
+	m0 := msgs[0].(map[string]any)
+	if m0["role"] != "user" {
+		t.Errorf("role: %v", m0["role"])
+	}
+	blocks := m0["content"].([]any)
+	if len(blocks) != 1 {
+		t.Fatalf("want 1 content block, got %d", len(blocks))
+	}
+	if b0 := blocks[0].(map[string]any); b0["type"] != "text" || b0["text"] != "hello" {
+		t.Errorf("block: %v", b0)
+	}
+}
+
+func TestChat_NoAPIKeyOmitsHeader(t *testing.T) {
+	srv, reqs := scriptedAnthropicServer(t, scriptedResponse{body: sseHappyText})
+	client := New(srv.URL+"/v1", time.Second, 0)
+	if _, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	}); err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if got := (*reqs)[0].headers.Get("x-api-key"); got != "" {
+		t.Errorf("x-api-key must be omitted without WithAPIKey, got %q", got)
+	}
+}
+
+const sseThinkingThenText = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_02","usage":{"input_tokens":3}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"let me "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"think"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"answer"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+// The thinking trace and the answer must land in separate fields: the
+// loop's reasoning-only-turn and truncation-continuation machinery keys
+// off ReasoningContent, and a client that concatenates the two would
+// poison both.
+func TestChat_ThinkingSeparated(t *testing.T) {
+	srv, _ := scriptedAnthropicServer(t, scriptedResponse{body: sseThinkingThenText})
+	client := New(srv.URL+"/v1", time.Second, 0)
+	resp, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	msg := resp.Choices[0].Message
+	if msg.ReasoningContent != "let me think" {
+		t.Errorf("reasoning: want %q got %q", "let me think", msg.ReasoningContent)
+	}
+	if msg.Content != "answer" {
+		t.Errorf("content: want %q got %q (reasoning must not leak in)", "answer", msg.Content)
+	}
+}
+
+const sseToolUseFragmented = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_03","usage":{"input_tokens":7}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_1","name":"read_file"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"README"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":".md\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu_2","name":"submit_result"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"verdict\":\"GO\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+func TestChat_ToolUseFragmented(t *testing.T) {
+	srv, _ := scriptedAnthropicServer(t, scriptedResponse{body: sseToolUseFragmented})
+	client := New(srv.URL+"/v1", time.Second, 0)
+	resp, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	ch := resp.Choices[0]
+	if ch.FinishReason != "tool_calls" {
+		t.Errorf("finish: want tool_calls got %q", ch.FinishReason)
+	}
+	tcs := ch.Message.ToolCalls
+	if len(tcs) != 2 {
+		t.Fatalf("want 2 tool calls, got %d: %+v", len(tcs), tcs)
+	}
+	if tcs[0].ID != "tu_1" || tcs[0].Function.Name != "read_file" ||
+		tcs[0].Function.Arguments != `{"path":"README.md"}` {
+		t.Errorf("first tool call (fragments must concatenate): %+v", tcs[0])
+	}
+	if tcs[1].ID != "tu_2" || tcs[1].Function.Name != "submit_result" ||
+		tcs[1].Function.Arguments != `{"verdict":"GO"}` {
+		t.Errorf("second tool call: %+v", tcs[1])
+	}
+	if ch.Message.Content != "" {
+		t.Errorf("content must be empty on a tool turn, got %q", ch.Message.Content)
+	}
+}
+
+// Third-party Anthropic-compatible endpoints may send the full tool
+// input on content_block_start and no input_json_delta at all. The
+// aggregator must fall back to the start payload's input field.
+const sseToolUseStartInput = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_04","usage":{"input_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"t9","name":"a","input":{"x":1}}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+func TestChat_ToolUseStartInputFallback(t *testing.T) {
+	srv, _ := scriptedAnthropicServer(t, scriptedResponse{body: sseToolUseStartInput})
+	client := New(srv.URL+"/v1", time.Second, 0)
+	resp, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	tcs := resp.Choices[0].Message.ToolCalls
+	if len(tcs) != 1 || tcs[0].Function.Arguments != `{"x":1}` {
+		t.Fatalf("start-payload input must be used when no deltas arrive: %+v", tcs)
+	}
+}
+
+// A tool_use block with no input anywhere (parameter-less tool) must
+// surface as an empty arguments string; the loop's dispatch converts
+// that to "{}", same as the oai path.
+const sseToolUseNoInput = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_05","usage":{"input_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_0","name":"no_args"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":1}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+func TestChat_ToolUseNoInput(t *testing.T) {
+	srv, _ := scriptedAnthropicServer(t, scriptedResponse{body: sseToolUseNoInput})
+	client := New(srv.URL+"/v1", time.Second, 0)
+	resp, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	tcs := resp.Choices[0].Message.ToolCalls
+	if len(tcs) != 1 || tcs[0].Function.Arguments != "" {
+		t.Fatalf("want empty arguments, got %+v", tcs)
+	}
+}
+
+// Some Anthropic-compatible endpoints close the stream at the last
+// content_block_stop without sending message_stop (the same habit
+// llama.cpp has with [DONE]). A clean EOF must still be a success.
+const sseNoMessageStop = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_06","usage":{"input_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"done"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}
+`
+
+func TestChat_CleanEOFWithoutMessageStop(t *testing.T) {
+	srv, _ := scriptedAnthropicServer(t, scriptedResponse{body: sseNoMessageStop})
+	client := New(srv.URL+"/v1", time.Second, 0)
+	resp, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("Chat: %v", err)
+	}
+	if resp.Choices[0].Message.Content != "done" || resp.Choices[0].FinishReason != "stop" {
+		t.Errorf("aggregation after clean EOF: %+v", resp.Choices[0])
+	}
+}
+
+const sseErrorEvent = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_07","usage":{"input_tokens":1}}}
+
+event: error
+data: {"type":"error","error":{"type":"overloaded_error","message":"upstream is saturated"}}
+`
+
+// A stream-embedded error event aborts the request with an error
+// carrying both fields, and is never retried: the API has said what
+// failed, and re-sending the same prompt cannot fix an overloaded
+// upstream any faster than the loop-level budget could.
+func TestChat_StreamEmbeddedError(t *testing.T) {
+	srv, reqs := scriptedAnthropicServer(t, scriptedResponse{body: sseErrorEvent})
+	client := New(srv.URL+"/v1", time.Second, 3, WithBackoffs([]time.Duration{0, 0}))
+	_, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("want error from stream-embedded error event")
+	}
+	if !strings.Contains(err.Error(), "overloaded_error") ||
+		!strings.Contains(err.Error(), "upstream is saturated") {
+		t.Errorf("error must carry type and message: %v", err)
+	}
+	if len(*reqs) != 1 {
+		t.Errorf("stream-embedded errors are not retried: want 1 request got %d", len(*reqs))
+	}
+}
+
+// A 2xx stream that carries no text, thinking, or tool content at all is
+// a misconfigured upstream (wrong model name, empty generation) and maps
+// to oai.ErrNoChoices: non-retryable, and the loop surfaces it as a task
+// error instead of a silent no-op.
+func TestChat_EmptyStreamIsNoChoices(t *testing.T) {
+	const empty = `event: ping
+data: {"type":"ping"}
+
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_09","usage":{"input_tokens":1}}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+	srv, reqs := scriptedAnthropicServer(t, scriptedResponse{body: empty})
+	client := New(srv.URL+"/v1", time.Second, 3, WithBackoffs([]time.Duration{0, 0}))
+	_, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, oai.ErrNoChoices) {
+		t.Fatalf("want ErrNoChoices, got %v", err)
+	}
+	if len(*reqs) != 1 {
+		t.Errorf("ErrNoChoices is not retried: want 1 request got %d", len(*reqs))
+	}
+}
+
+// A truncated tool-call stream (200, but the arguments JSON never
+// completes) is the retryable case, mirroring llama.cpp #22072 on the
+// oai path: the same prompt usually succeeds on the retry.
+const sseToolUseTruncated = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_10","usage":{"input_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_t","name":"read_file"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"README"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":2}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+
+func TestChat_TruncatedToolCallArgsRetries(t *testing.T) {
+	srv, reqs := scriptedAnthropicServer(t,
+		scriptedResponse{body: sseToolUseTruncated},
+		scriptedResponse{body: sseToolUseFragmented},
+	)
+	client := New(srv.URL+"/v1", time.Second, 2, WithBackoffs([]time.Duration{0, 0}))
+	resp, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err != nil {
+		t.Fatalf("want success after retry, got %v", err)
+	}
+	if len(*reqs) != 2 {
+		t.Fatalf("want 2 attempts, got %d", len(*reqs))
+	}
+	if got := resp.Choices[0].Message.ToolCalls[0].Function.Arguments; got != `{"path":"README.md"}` {
+		t.Errorf("recovered args: %q", got)
+	}
+}
+
+func TestChat_TruncatedToolCallArgsExhausts(t *testing.T) {
+	srv, reqs := scriptedAnthropicServer(t, scriptedResponse{body: sseToolUseTruncated})
+	client := New(srv.URL+"/v1", time.Second, 1, WithBackoffs([]time.Duration{0, 0}))
+	_, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if !errors.Is(err, oai.ErrTruncatedToolCallArguments) {
+		t.Fatalf("want ErrTruncatedToolCallArguments after retries, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "after 1 retries") {
+		t.Errorf("exhausted error should name the retry count: %v", err)
+	}
+	if len(*reqs) != 2 {
+		t.Errorf("want 1 initial + 1 retry, got %d", len(*reqs))
+	}
+}
+
+// A non-2xx response is never retried, and the error must expose an
+// *oai.StatusError so the loop's rejectsTemperature check works
+// identically against both native endpoints.
+func TestChat_Non2xx(t *testing.T) {
+	longBody := `{"type":"error","error":{"type":"invalid_request_error",` +
+		`"message":"temperature is not supported for this model. ` + strings.Repeat("x", 600) + `"}}`
+	srv, reqs := scriptedAnthropicServer(t, scriptedResponse{status: 400, body: longBody})
+	client := New(srv.URL+"/v1", time.Second, 3, WithBackoffs([]time.Duration{0, 0}))
+	_, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("want error on 400")
+	}
+	var se *oai.StatusError
+	if !errors.As(err, &se) {
+		t.Fatalf("error must wrap *oai.StatusError, got %T: %v", err, err)
+	}
+	if se.Code != 400 {
+		t.Errorf("status code: want 400 got %d", se.Code)
+	}
+	if !strings.Contains(se.Body, "temperature") {
+		t.Errorf("body must identify the failure: %q", se.Body)
+	}
+	if len(se.Body) > 500 {
+		t.Errorf("body must be excerpted to at most 500 bytes, got %d", len(se.Body))
+	}
+	if !strings.Contains(err.Error(), "anthropic: POST") || !strings.Contains(err.Error(), "400") {
+		t.Errorf("error message: %v", err)
+	}
+	if len(*reqs) != 1 {
+		t.Errorf("non-2xx is not retried: want 1 request got %d", len(*reqs))
+	}
+}
+
+// The 400-temperature case the loop keys on (rejectsTemperature): even
+// with retries armed, a deterministic 4xx never re-sends the request.
+func TestChat_NonRetryable400NotRetried(t *testing.T) {
+	body := `{"type":"error","error":{"type":"invalid_request_error","message":"temperature must be between 0 and 1"}}`
+	srv, reqs := scriptedAnthropicServer(t, scriptedResponse{status: 400, body: body})
+	client := New(srv.URL+"/v1", time.Second, 3, WithBackoffs([]time.Duration{0, 0, 0}))
+	_, err := client.Chat(context.Background(), oai.ChatRequest{
+		Model: "m", Messages: []oai.Message{{Role: oai.RoleUser, Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("want error on 400")
+	}
+	if len(*reqs) != 1 {
+		t.Errorf("a deterministic 400 must not be retried: want 1 request got %d", len(*reqs))
+	}
+}
+
+func TestMapStopReason(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+	}{
+		{"end_turn", "stop"},
+		{"stop_sequence", "stop"},
+		{"tool_use", "tool_calls"},
+		{"max_tokens", "length"},
+		{"refusal", "refusal"}, // unknown reasons pass through verbatim
+		{"", ""},
+	} {
+		if got := mapStopReason(tc.in); got != tc.want {
+			t.Errorf("mapStopReason(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// netErr is the minimal net.Error implementation for retry-classification
+// tests; timeout selects the Timeout() outcome.
+type netErr struct{ timeout bool }
+
+func (e *netErr) Error() string   { return "net err" }
+func (e *netErr) Timeout() bool   { return e.timeout }
+func (e *netErr) Temporary() bool { return false }
+
+func TestRetryClassification(t *testing.T) {
+	t.Run("isRetryableTimeout", func(t *testing.T) {
+		for _, tc := range []struct {
+			err  error
+			want bool
+		}{
+			{&netErr{timeout: true}, true},
+			{&netErr{timeout: false}, false},
+			{io.EOF, false},
+			{oai.ErrNoChoices, false},
+		} {
+			if got := isRetryableTimeout(tc.err); got != tc.want {
+				t.Errorf("isRetryableTimeout(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		}
+	})
+	t.Run("isRetryableTransportError", func(t *testing.T) {
+		for _, tc := range []struct {
+			err  error
+			want bool
+		}{
+			{io.ErrUnexpectedEOF, true},
+			{io.EOF, true},
+			{&netErr{timeout: true}, true},
+			{syscall.ECONNRESET, true},
+			{errors.New("read tcp: connection reset by peer"), true},
+			{&statusError{code: 400, inner: &oai.StatusError{Code: 400}}, false},
+			{&netErr{timeout: false}, false},
+		} {
+			if got := isRetryableTransportError(tc.err); got != tc.want {
+				t.Errorf("isRetryableTransportError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		}
+	})
+}

--- a/pkg/foreman/agent/anthropic/translate.go
+++ b/pkg/foreman/agent/anthropic/translate.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropic
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// translateRequest maps an oai.ChatRequest to the Anthropic Messages
+// wire shape. The mapping is lossy in exactly the ways the Anthropic
+// schema forces:
+//
+//   - Every system message is hoisted to the top-level system field
+//     (the messages array carries only user/assistant), joined with a
+//     blank line.
+//   - tool messages become tool_result blocks inside a *user* message
+//     (there is no tool role).
+//   - An assistant message's ReasoningContent is dropped (see
+//     assistantContentBlocks).
+//   - ChatTemplateKwargs is ignored: it is an OpenAI/llama.cpp
+//     chat-template knob (e.g. toggling think blocks on llama.cpp
+//     serves). Anthropic has no counterpart — thinking is server-side
+//     per model — so forwarding the field would be a lie.
+//
+// The merge pass at the end folds consecutive same-role messages into
+// one. That is required, not cosmetic: the loop naturally produces
+// same-role runs (a batch of tool results, or a tool batch followed by
+// a corrective nudge), and Anthropic's strict alternation would 400 on
+// them.
+func translateRequest(req oai.ChatRequest) (*request, error) {
+	out := &request{
+		Model:       req.Model,
+		MaxTokens:   maxTokensFor(req.MaxTokens),
+		Temperature: req.Temperature,
+		Stream:      true,
+	}
+
+	var systems []string
+	var msgs []message
+	for _, m := range req.Messages {
+		switch m.Role {
+		case oai.RoleSystem:
+			if strings.TrimSpace(m.Content) == "" {
+				continue
+			}
+			systems = append(systems, m.Content)
+		case oai.RoleUser:
+			if blocks := userContentBlocks(m); len(blocks) > 0 {
+				msgs = append(msgs, message{Role: roleUser, Content: blocks})
+			}
+		case oai.RoleTool:
+			// No tool role on this wire: the result rides in a user
+			// message as a tool_result block that threads the tool_use
+			// id back to the assistant's call.
+			msgs = append(msgs, message{
+				Role: roleUser,
+				Content: []contentBlock{{
+					Type:      blockTypeToolResult,
+					ToolUseID: m.ToolCallID,
+					Content:   m.Content,
+				}},
+			})
+		case oai.RoleAssistant:
+			blocks, err := assistantContentBlocks(m)
+			if err != nil {
+				return nil, err
+			}
+			if len(blocks) > 0 {
+				msgs = append(msgs, message{Role: roleAssistant, Content: blocks})
+			}
+		default:
+			return nil, fmt.Errorf("anthropic: translate: unsupported message role %q", m.Role)
+		}
+	}
+	out.System = strings.Join(systems, "\n\n")
+
+	for _, t := range req.Tools {
+		out.Tools = append(out.Tools, tool{
+			Name:        t.Function.Name,
+			Description: t.Function.Description,
+			InputSchema: t.Function.Parameters,
+		})
+	}
+
+	msgs = mergeConsecutiveRoles(msgs)
+	if len(msgs) == 0 {
+		return nil, errors.New("anthropic: translate: no user or assistant messages to send")
+	}
+	// The Messages API requires the conversation to open with a user
+	// message. The loop's transcript always does (system hoists out and
+	// the first remaining message is the task prompt); this check turns
+	// a protocol violation into a clean client-side error instead of a
+	// 400 deep in the provider.
+	if msgs[0].Role != roleUser {
+		return nil, errors.New("anthropic: translate: first message must be a user message")
+	}
+	out.Messages = msgs
+	return out, nil
+}
+
+// maxTokensFor maps the caller's MaxTokens to the wire value. The
+// Messages API requires max_tokens on every request, so zero (the oai
+// convention for "let the server decide") maps to DefaultMaxTokens
+// instead of being dropped.
+func maxTokensFor(n int) int {
+	if n <= 0 {
+		return DefaultMaxTokens
+	}
+	return n
+}
+
+// userContentBlocks maps a user message to content blocks. A message
+// with Parts emits one block per part (text and image_url); otherwise
+// its Content is a single text block. A user message with neither is
+// dropped by the caller (an empty message carries no signal on either
+// wire).
+func userContentBlocks(m oai.Message) []contentBlock {
+	if len(m.Parts) > 0 {
+		blocks := make([]contentBlock, 0, len(m.Parts))
+		for _, p := range m.Parts {
+			switch p.Type {
+			case oai.ContentPartText:
+				blocks = append(blocks, contentBlock{Type: blockTypeText, Text: p.Text})
+			case oai.ContentPartImageURL:
+				if p.ImageURL != nil {
+					blocks = append(blocks, contentBlock{
+						Type:   blockTypeImage,
+						Source: imageSourceFor(p.ImageURL.URL),
+					})
+				}
+			}
+		}
+		return blocks
+	}
+	if strings.TrimSpace(m.Content) == "" {
+		return nil
+	}
+	return []contentBlock{{Type: blockTypeText, Text: m.Content}}
+}
+
+// imageSourceFor maps an OpenAI image_url value to an Anthropic image
+// source. A data: URL is inlined as base64 (the form the loop's image
+// tool emits — self-contained, no provider fetch); any other URL is
+// passed through as a remote URL source.
+func imageSourceFor(u string) *imageSource {
+	if mediaType, data, ok := parseDataURL(u); ok {
+		return &imageSource{Type: imageSourceBase64, MediaType: mediaType, Data: data}
+	}
+	return &imageSource{Type: imageSourceURL, URL: u}
+}
+
+// parseDataURL splits "data:<mediatype>;base64,<payload>" into its
+// media type and base64 payload. ok is false for anything that is not
+// a base64 data URL (plain URLs, or data URLs without a base64
+// marker).
+func parseDataURL(u string) (mediaType, data string, ok bool) {
+	const prefix = "data:"
+	if !strings.HasPrefix(u, prefix) {
+		return "", "", false
+	}
+	rest := strings.TrimPrefix(u, prefix)
+	comma := strings.IndexByte(rest, ',')
+	if comma < 0 {
+		return "", "", false
+	}
+	meta := rest[:comma]
+	data = rest[comma+1:]
+	// meta is "<mediatype>;base64" (the mediatype may be empty).
+	if i := strings.LastIndexByte(meta, ';'); i >= 0 {
+		if meta[i+1:] != "base64" {
+			return "", "", false
+		}
+		return meta[:i], data, true
+	}
+	return "", "", false
+}
+
+// assistantContentBlocks maps an assistant message to content blocks: a
+// text block (when Content is non-empty) followed by one tool_use block
+// per ToolCall, in slice order.
+//
+// ReasoningContent is dropped on purpose. Anthropic's thinking blocks
+// must be echoed back carrying the provider's signature to be accepted,
+// and neither a third-party Anthropic-compatible endpoint nor the
+// loop's own placeholder text can produce one — replaying unsigned
+// thinking is a guaranteed 400. The loop already strips reasoning from
+// history on the OpenAI wire (stripReasoningForWire); dropping it here
+// keeps both paths honest instead of poisoning every later turn.
+func assistantContentBlocks(m oai.Message) ([]contentBlock, error) {
+	var blocks []contentBlock
+	if strings.TrimSpace(m.Content) != "" {
+		blocks = append(blocks, contentBlock{Type: blockTypeText, Text: m.Content})
+	}
+	for _, tc := range m.ToolCalls {
+		input, err := toolUseInput(tc.Function.Arguments)
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, contentBlock{
+			Type:  blockTypeToolUse,
+			ID:    tc.ID,
+			Name:  tc.Function.Name,
+			Input: input,
+		})
+	}
+	return blocks, nil
+}
+
+// toolUseInput parses a tool_call's Arguments JSON string into the
+// object the Anthropic input field expects. An empty string becomes the
+// empty object (the loop dispatches "" as {}); an unparseable or
+// non-object value is a hard error. Unlike the stream-side validation
+// (which wraps oai.ErrTruncatedToolCallArguments for retry), this one
+// is deterministic in the transcript — retrying the same request cannot
+// fix it — so it is deliberately not retryable.
+func toolUseInput(args string) (json.RawMessage, error) {
+	if args == "" {
+		return json.RawMessage("{}"), nil
+	}
+	var probe map[string]any
+	if err := json.Unmarshal([]byte(args), &probe); err != nil {
+		return nil, fmt.Errorf("anthropic: tool_use arguments are not a JSON object: %w", err)
+	}
+	return json.RawMessage(args), nil
+}
+
+// mergeConsecutiveRoles folds adjacent same-role messages into one by
+// concatenating their content blocks, and drops messages left with no
+// blocks. See the translateRequest doc for why Anthropic requires this
+// (strict user/assistant alternation).
+func mergeConsecutiveRoles(msgs []message) []message {
+	out := make([]message, 0, len(msgs))
+	for _, m := range msgs {
+		if len(m.Content) == 0 {
+			continue
+		}
+		if n := len(out); n > 0 && out[n-1].Role == m.Role {
+			out[n-1].Content = append(out[n-1].Content, m.Content...)
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}

--- a/pkg/foreman/agent/anthropic/translate_test.go
+++ b/pkg/foreman/agent/anthropic/translate_test.go
@@ -1,0 +1,456 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropic
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+func mustTranslate(t *testing.T, req oai.ChatRequest) *request {
+	t.Helper()
+	out, err := translateRequest(req)
+	if err != nil {
+		t.Fatalf("translateRequest: %v", err)
+	}
+	return out
+}
+
+func TestTranslate_SystemHoistedAndJoined(t *testing.T) {
+	out := mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleSystem, Content: "first"},
+			{Role: oai.RoleSystem, Content: "   "},
+			{Role: oai.RoleSystem, Content: "second"},
+			{Role: oai.RoleUser, Content: "hi"},
+		},
+	})
+	if out.System != "first\n\nsecond" {
+		t.Errorf("system: want hoisted+joined with blank line, got %q", out.System)
+	}
+	if len(out.Messages) != 1 || out.Messages[0].Role != roleUser {
+		t.Fatalf("want a single user message left, got %+v", out.Messages)
+	}
+}
+
+func TestTranslate_MaxTokens(t *testing.T) {
+	for _, tc := range []struct {
+		in, want int
+	}{
+		{0, DefaultMaxTokens}, // zero maps to the default, never dropped
+		{1, 1},
+		{8192, 8192},
+	} {
+		out := mustTranslate(t, oai.ChatRequest{
+			Model:     "m",
+			MaxTokens: tc.in,
+			Messages:  []oai.Message{{Role: oai.RoleUser, Content: "x"}},
+		})
+		if out.MaxTokens != tc.want {
+			t.Errorf("MaxTokens in=%d: want %d got %d", tc.in, tc.want, out.MaxTokens)
+		}
+	}
+}
+
+func TestTranslate_Temperature(t *testing.T) {
+	out := mustTranslate(t, oai.ChatRequest{
+		Model:    "m",
+		Messages: []oai.Message{{Role: oai.RoleUser, Content: "x"}},
+	})
+	if out.Temperature != nil {
+		t.Errorf("nil temperature must stay nil, got %v", *out.Temperature)
+	}
+
+	v := 0.7
+	out = mustTranslate(t, oai.ChatRequest{
+		Model:       "m",
+		Temperature: &v,
+		Messages:    []oai.Message{{Role: oai.RoleUser, Content: "x"}},
+	})
+	if out.Temperature == nil || *out.Temperature != 0.7 {
+		t.Errorf("temperature: want 0.7 got %v", out.Temperature)
+	}
+}
+
+func TestTranslate_Tools(t *testing.T) {
+	params := json.RawMessage(`{"type":"object","properties":{"path":{"type":"string"}}}`)
+	out := mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Tools: []oai.Tool{
+			{Type: "function", Function: oai.ToolSchemaDef{Name: "read_file", Description: "reads", Parameters: params}},
+			{Type: "function", Function: oai.ToolSchemaDef{Name: "submit_result"}},
+		},
+		Messages: []oai.Message{{Role: oai.RoleUser, Content: "x"}},
+	})
+	if len(out.Tools) != 2 {
+		t.Fatalf("want 2 tools, got %d", len(out.Tools))
+	}
+	if out.Tools[0].Name != "read_file" || out.Tools[0].Description != "reads" ||
+		string(out.Tools[0].InputSchema) != string(params) {
+		t.Errorf("tool 0 mismatch: %+v", out.Tools[0])
+	}
+	if out.Tools[1].Name != "submit_result" || out.Tools[1].InputSchema != nil {
+		t.Errorf("tool 1 must drop the empty schema: %+v", out.Tools[1])
+	}
+
+	// No tools advertised -> key absent from the wire entirely.
+	body := mustJSON(t, mustTranslate(t, oai.ChatRequest{
+		Model:    "m",
+		Messages: []oai.Message{{Role: oai.RoleUser, Content: "x"}},
+	}))
+	if strings.Contains(body, `"tools"`) {
+		t.Errorf("tools key must be omitted when empty: %s", body)
+	}
+}
+
+func TestTranslate_StreamAlwaysOn(t *testing.T) {
+	out := mustTranslate(t, oai.ChatRequest{
+		Model:    "m",
+		Stream:   false,
+		Messages: []oai.Message{{Role: oai.RoleUser, Content: "x"}},
+	})
+	if !out.Stream {
+		t.Error("stream must be forced true")
+	}
+}
+
+func TestTranslate_ChatTemplateKwargsIgnored(t *testing.T) {
+	body := mustJSON(t, mustTranslate(t, oai.ChatRequest{
+		Model:              "m",
+		ChatTemplateKwargs: map[string]apiextensionsv1.JSON{"enable_thinking": {Raw: []byte("false")}},
+		Messages:           []oai.Message{{Role: oai.RoleUser, Content: "x"}},
+	}))
+	if strings.Contains(body, "chat_template_kwargs") || strings.Contains(body, "enable_thinking") {
+		t.Errorf("chat template kwargs must not leak onto the Anthropic wire: %s", body)
+	}
+}
+
+func TestTranslate_UserContentShapes(t *testing.T) {
+	out := mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: "plain text"},
+		},
+	})
+	if len(out.Messages[0].Content) != 1 || out.Messages[0].Content[0].Type != blockTypeText ||
+		out.Messages[0].Content[0].Text != "plain text" {
+		t.Errorf("plain user: %+v", out.Messages[0].Content)
+	}
+
+	out = mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{
+				Role: oai.RoleUser,
+				Parts: []oai.ContentPart{
+					{Type: oai.ContentPartText, Text: "look at this"},
+					{Type: oai.ContentPartImageURL, ImageURL: &oai.ImageURL{URL: "data:image/png;base64,AAA"}},
+					{Type: oai.ContentPartImageURL, ImageURL: &oai.ImageURL{URL: "https://example.com/x.png"}},
+				},
+			},
+		},
+	})
+	blocks := out.Messages[0].Content
+	if len(blocks) != 3 {
+		t.Fatalf("want 3 parts blocks, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Type != blockTypeText || blocks[0].Text != "look at this" {
+		t.Errorf("text part: %+v", blocks[0])
+	}
+	if blocks[1].Type != blockTypeImage || blocks[1].Source == nil ||
+		blocks[1].Source.Type != imageSourceBase64 || blocks[1].Source.MediaType != "image/png" ||
+		blocks[1].Source.Data != "AAA" {
+		t.Errorf("data-url image part: %+v", blocks[1])
+	}
+	if blocks[2].Type != blockTypeImage || blocks[2].Source == nil ||
+		blocks[2].Source.Type != imageSourceURL || blocks[2].Source.URL != "https://example.com/x.png" {
+		t.Errorf("remote image part: %+v", blocks[2])
+	}
+
+	// An empty user message (no content, no parts) drops out of the
+	// messages array entirely: an empty Anthropic user message carries
+	// no signal. When that empties out the OPENING message, the
+	// conversation would start assistant-side, which the API rejects —
+	// so the guard turns it into a clean client-side error.
+	_, err := translateRequest(oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: ""},
+			{Role: oai.RoleAssistant, Content: "re"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "first message must be a user message") {
+		t.Fatalf("want the first-user guard to fire, got %v", err)
+	}
+
+	// A later empty user (a dropped nudge) just vanishes; the
+	// conversation still opens with a user, so no error.
+	out = mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: "task"},
+			{Role: oai.RoleAssistant, Content: "re"},
+			{Role: oai.RoleUser, Content: ""},
+		},
+	})
+	if len(out.Messages) != 2 || out.Messages[1].Role != roleAssistant {
+		t.Fatalf("empty later user must drop, got %+v", out.Messages)
+	}
+}
+
+func TestTranslate_ToolResultRidesInUserMessage(t *testing.T) {
+	out := mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: "task"},
+			{
+				Role: oai.RoleAssistant,
+				ToolCalls: []oai.ToolCall{{
+					ID: "tu_1", Type: "function",
+					Function: oai.ToolCallFunction{Name: "read_file", Arguments: `{"path":"a"}`},
+				}},
+			},
+			{Role: oai.RoleTool, ToolCallID: "tu_1", Content: "file body"},
+		},
+	})
+	if len(out.Messages) != 3 {
+		t.Fatalf("want 3 messages, got %d: %+v", len(out.Messages), out.Messages)
+	}
+	got := out.Messages[2].Content
+	if len(got) != 1 || got[0].Type != blockTypeToolResult ||
+		got[0].ToolUseID != "tu_1" || got[0].Content != "file body" {
+		t.Errorf("tool result block: %+v", got)
+	}
+}
+
+func TestTranslate_MergesConsecutiveSameRole(t *testing.T) {
+	// A tool batch followed by a corrective nudge: all of it lands in one
+	// user message, preserving block order.
+	out := mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: "task"},
+			{
+				Role: oai.RoleAssistant,
+				ToolCalls: []oai.ToolCall{
+					{ID: "tu_1", Type: "function", Function: oai.ToolCallFunction{Name: "a", Arguments: `{}`}},
+					{ID: "tu_2", Type: "function", Function: oai.ToolCallFunction{Name: "b", Arguments: `{}`}},
+				},
+			},
+			{Role: oai.RoleTool, ToolCallID: "tu_1", Content: "r1"},
+			{Role: oai.RoleTool, ToolCallID: "tu_2", Content: "r2"},
+			{Role: oai.RoleUser, Content: "nudge"},
+		},
+	})
+	if len(out.Messages) != 3 {
+		t.Fatalf("want 3 messages (merged), got %d: %+v", len(out.Messages), out.Messages)
+	}
+	last := out.Messages[2]
+	if last.Role != roleUser || len(last.Content) != 3 {
+		t.Fatalf("merged user message: %+v", last)
+	}
+	if last.Content[0].Type != blockTypeToolResult || last.Content[0].ToolUseID != "tu_1" ||
+		last.Content[1].Type != blockTypeToolResult || last.Content[1].ToolUseID != "tu_2" ||
+		last.Content[2].Type != blockTypeText || last.Content[2].Text != "nudge" {
+		t.Errorf("merged blocks out of order or wrong: %+v", last.Content)
+	}
+}
+
+func TestTranslate_AssistantTextAndToolUseOrdering(t *testing.T) {
+	out := mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: "task"},
+			{
+				Role:    oai.RoleAssistant,
+				Content: "thinking out loud",
+				ToolCalls: []oai.ToolCall{
+					{ID: "tu_1", Type: "function", Function: oai.ToolCallFunction{Name: "a", Arguments: `{"x":1}`}},
+					{ID: "tu_2", Type: "function", Function: oai.ToolCallFunction{Name: "b", Arguments: ""}},
+				},
+			},
+		},
+	})
+	blocks := out.Messages[1].Content
+	if len(blocks) != 3 {
+		t.Fatalf("want text + 2 tool_use blocks, got %d: %+v", len(blocks), blocks)
+	}
+	if blocks[0].Type != blockTypeText || blocks[0].Text != "thinking out loud" {
+		t.Errorf("text block: %+v", blocks[0])
+	}
+	if blocks[1].Type != blockTypeToolUse || blocks[1].ID != "tu_1" || blocks[1].Name != "a" ||
+		string(blocks[1].Input) != `{"x":1}` {
+		t.Errorf("first tool_use: %+v", blocks[1])
+	}
+	// Empty arguments become the empty object, mirroring the oai dispatch.
+	if blocks[2].Type != blockTypeToolUse || blocks[2].ID != "tu_2" ||
+		string(blocks[2].Input) != "{}" {
+		t.Errorf("second tool_use (empty args): %+v", blocks[2])
+	}
+}
+
+func TestTranslate_ReasoningDropped(t *testing.T) {
+	out := mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: "task"},
+			{Role: oai.RoleAssistant, Content: "answer", ReasoningContent: "deep thoughts"},
+		},
+	})
+	blocks := out.Messages[1].Content
+	if len(blocks) != 1 || blocks[0].Type != blockTypeText || blocks[0].Text != "answer" {
+		t.Errorf("reasoning must not reach the wire: %+v", blocks)
+	}
+
+	// A reasoning-only assistant message (a paused turn) carries no
+	// Anthropic content at all and drops out of the messages array,
+	// which also merges the user messages on either side into one —
+	// the strict-alternation pass sees two consecutive users.
+	out = mustTranslate(t, oai.ChatRequest{
+		Model: "m",
+		Messages: []oai.Message{
+			{Role: oai.RoleUser, Content: "task"},
+			{Role: oai.RoleAssistant, ReasoningContent: "deep thoughts"},
+			{Role: oai.RoleUser, Content: "nudge"},
+		},
+	})
+	if len(out.Messages) != 1 || out.Messages[0].Role != roleUser || len(out.Messages[0].Content) != 2 {
+		t.Fatalf("expected the two users to merge, got %+v", out.Messages)
+	}
+}
+
+func TestTranslate_Errors(t *testing.T) {
+	cases := []struct {
+		name    string
+		req     oai.ChatRequest
+		wantSub string
+	}{
+		{
+			name: "malformed tool args",
+			req: oai.ChatRequest{
+				Messages: []oai.Message{
+					{Role: oai.RoleUser, Content: "x"},
+					{
+						Role: oai.RoleAssistant,
+						ToolCalls: []oai.ToolCall{{
+							ID: "t", Type: "function",
+							Function: oai.ToolCallFunction{Name: "a", Arguments: `{"x":}`},
+						}},
+					},
+				},
+			},
+			wantSub: "not a JSON object",
+		},
+		{
+			name: "non-object tool args",
+			req: oai.ChatRequest{
+				Messages: []oai.Message{
+					{Role: oai.RoleUser, Content: "x"},
+					{
+						Role: oai.RoleAssistant,
+						ToolCalls: []oai.ToolCall{{
+							ID: "t", Type: "function",
+							Function: oai.ToolCallFunction{Name: "a", Arguments: `[1,2]`},
+						}},
+					},
+				},
+			},
+			wantSub: "not a JSON object",
+		},
+		{
+			name:    "unknown role",
+			req:     oai.ChatRequest{Messages: []oai.Message{{Role: oai.Role("gpt"), Content: "x"}}},
+			wantSub: "unsupported message role",
+		},
+		{
+			name: "assistant opens the conversation",
+			req: oai.ChatRequest{
+				Messages: []oai.Message{
+					{Role: oai.RoleSystem, Content: "sys"},
+					{Role: oai.RoleAssistant, Content: "re"},
+				},
+			},
+			wantSub: "first message must be a user message",
+		},
+		{
+			name:    "only system messages",
+			req:     oai.ChatRequest{Messages: []oai.Message{{Role: oai.RoleSystem, Content: "sys"}}},
+			wantSub: "no user or assistant messages",
+		},
+		{
+			name:    "nothing at all",
+			req:     oai.ChatRequest{Messages: []oai.Message{}},
+			wantSub: "no user or assistant messages",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := translateRequest(tc.req)
+			if err == nil {
+				t.Fatalf("want error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q: want it to contain %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestParseDataURL(t *testing.T) {
+	for _, tc := range []struct {
+		in       string
+		wantType string
+		wantData string
+		wantOK   bool
+	}{
+		{"data:image/png;base64,AAA", "image/png", "AAA", true},
+		{"data:;base64,AAA", "", "AAA", true},
+		{"data:text/plain,hello", "", "", false}, // no base64 marker
+		{"data:", "", "", false},
+		{"https://example.com/x.png", "", "", false},
+	} {
+		gotType, gotData, gotOK := parseDataURL(tc.in)
+		if gotType != tc.wantType || gotData != tc.wantData || gotOK != tc.wantOK {
+			t.Errorf("parseDataURL(%q) = (%q, %q, %v); want (%q, %q, %v)",
+				tc.in, gotType, gotData, gotOK, tc.wantType, tc.wantData, tc.wantOK)
+		}
+	}
+}
+
+func TestMaxTokensFor(t *testing.T) {
+	if got := maxTokensFor(0); got != DefaultMaxTokens {
+		t.Errorf("zero: want %d got %d", DefaultMaxTokens, got)
+	}
+	if got := maxTokensFor(1234); got != 1234 {
+		t.Errorf("passthrough: want 1234 got %d", got)
+	}
+}
+
+func mustJSON(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}

--- a/pkg/foreman/agent/anthropic/types.go
+++ b/pkg/foreman/agent/anthropic/types.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package anthropic is a minimal client for the Anthropic-native Messages
+// API (POST /v1/messages, SSE streaming).
+//
+// It lives next to the oai package, not inside it, because the two wires
+// differ in ways that matter to agent quality, not just plumbing (#1627):
+// Messages carries the model's reasoning as a first-class thinking
+// channel, carries tool input as structured JSON (tool_use blocks), and
+// enforces strict user/assistant alternation in the messages array. An
+// OpenAI-compatible translation proxy in front of Anthropic rewrites the
+// wire on both sides and degrades or drops the reasoning trace in the
+// process; dialing the native endpoint keeps the loop's reasoning-only
+// turn and truncation-continuation machinery working against a model that
+// actually emits thinking blocks.
+//
+// As with oai, the official SDK is deliberately not used: Foreman needs
+// exactly one HTTP shape, wants provider-specific retry semantics, and
+// does not want the SDK's transitive cone.
+package anthropic
+
+import "encoding/json"
+
+// APIVersion is the anthropic-version request header value. The Messages
+// API is versioned per request; 2023-06-01 is the stable version that
+// carries the streaming thinking and tool_use events this client parses.
+const APIVersion = "2023-06-01"
+
+// DefaultMaxTokens is the max_tokens value used when the caller leaves
+// the field at zero. Unlike the OpenAI surface (where zero means "let the
+// server decide"), the Messages API requires the field on every request,
+// so zero cannot be dropped and must map to a concrete default. 8192
+// leaves room for a thinking-heavy decision turn without pinning current
+// model generations at the 8K output ceiling.
+const DefaultMaxTokens = 8192
+
+// Role and content-block type values in the request body. Wire literals;
+// the request structs are package-private, so these stay private.
+const (
+	roleUser      = "user"
+	roleAssistant = "assistant"
+
+	blockTypeText       = "text"
+	blockTypeImage      = "image"
+	blockTypeToolUse    = "tool_use"
+	blockTypeToolResult = "tool_result"
+	blockTypeThinking   = "thinking"
+
+	imageSourceBase64 = "base64"
+	imageSourceURL    = "url"
+)
+
+// request is the POST /v1/messages body.
+type request struct {
+	Model       string    `json:"model"`
+	MaxTokens   int       `json:"max_tokens"`
+	Messages    []message `json:"messages"`
+	System      string    `json:"system,omitempty"`
+	Tools       []tool    `json:"tools,omitempty"`
+	Temperature *float64  `json:"temperature,omitempty"`
+	Stream      bool      `json:"stream"`
+}
+
+// message is one entry of the messages array. The schema allows only
+// "user" and "assistant" here: system text is hoisted to the top-level
+// System field, and tool results ride inside user messages as
+// tool_result blocks (there is no tool role).
+type message struct {
+	Role    string         `json:"role"`
+	Content []contentBlock `json:"content"`
+}
+
+// contentBlock is one element of a message's content array. Only the
+// fields relevant to Type are populated; the rest stay off the wire.
+type contentBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	Source    *imageSource    `json:"source,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   string          `json:"content,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+}
+
+// imageSource is the source of an image content block: base64 inline
+// bytes (from a data: URL) or a remote URL.
+type imageSource struct {
+	Type      string `json:"type"`
+	MediaType string `json:"media_type,omitempty"`
+	Data      string `json:"data,omitempty"`
+	URL       string `json:"url,omitempty"`
+}
+
+// tool is one entry of the tools array: the Anthropic shape of an
+// OpenAI function advertisement. The function's parameters JSONSchema
+// maps onto input_schema verbatim.
+type tool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	InputSchema json.RawMessage `json:"input_schema,omitempty"`
+}
+
+// --- SSE event payloads ---
+//
+// The Messages stream is standard SSE: each event is an `event:` name
+// line plus one or more `data:` lines carrying a JSON object whose
+// `type` field duplicates the event name. The parser dispatches on the
+// type field; these structs are what each kind decodes into.
+
+// sseMessageStart is the stream's first event: the message header
+// carrying the message id (echoed into ChatResponse.ID) and
+// usage.input_tokens (the prompt size).
+type sseMessageStart struct {
+	Type    string     `json:"type"`
+	Message sseMessage `json:"message"`
+}
+
+// sseMessage is the message object inside message_start.
+type sseMessage struct {
+	ID    string   `json:"id"`
+	Model string   `json:"model"`
+	Usage sseUsage `json:"usage"`
+}
+
+// sseUsage is the token accounting the API attaches to message_start
+// (input) and message_delta (output). The oai-shaped response the
+// client returns has no Usage field yet, so the aggregator holds the
+// values; they are parsed so a future oai.ChatResponse usage field has
+// a ready source.
+type sseUsage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+// sseContentBlockStart opens one content block of the assistant
+// message. The content_block payload names the block kind: text (bytes
+// arrive as text_delta), thinking (bytes as thinking_delta), or
+// tool_use (id + name up front; the arguments JSON arrives as the
+// initial input field and/or input_json_delta pieces).
+type sseContentBlockStart struct {
+	Type         string   `json:"type"`
+	Index        int      `json:"index"`
+	ContentBlock sseBlock `json:"content_block"`
+}
+
+// sseBlock is the content_block payload of a content_block_start.
+type sseBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+}
+
+// sseContentBlockDelta is one incremental piece of an open block. The
+// delta's type selects the payload: text_delta (text), thinking_delta
+// (thinking), input_json_delta (a fragment of a tool_use arguments
+// JSON), signature_delta (the thinking block's signature, ignored).
+type sseContentBlockDelta struct {
+	Type  string   `json:"type"`
+	Index int      `json:"index"`
+	Delta sseDelta `json:"delta"`
+}
+
+// sseDelta is the delta payload of a content_block_delta.
+type sseDelta struct {
+	Type        string `json:"type"`
+	Text        string `json:"text,omitempty"`
+	Thinking    string `json:"thinking,omitempty"`
+	Signature   string `json:"signature,omitempty"`
+	PartialJSON string `json:"partial_json,omitempty"`
+}
+
+// sseMessageDelta is the stream's terminal metadata event: the final
+// stop_reason and the output token count.
+type sseMessageDelta struct {
+	Type  string   `json:"type"`
+	Delta sseStop  `json:"delta"`
+	Usage sseUsage `json:"usage"`
+}
+
+// sseStop is the delta payload of a message_delta.
+type sseStop struct {
+	StopReason   string  `json:"stop_reason"`
+	StopSequence *string `json:"stop_sequence"`
+}
+
+// sseStreamError is the stream-embedded error event: the API's way of
+// aborting an in-flight 2xx stream (overloaded upstream, blocked
+// generation). It ends the request with an error carrying both fields.
+type sseStreamError struct {
+	Type  string   `json:"type"`
+	Error sseError `json:"error"`
+}
+
+// sseError is the error payload of an sseStreamError.
+type sseError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// SSE event type literals.
+const (
+	sseTypePing       = "ping"
+	sseTypeMsgStart   = "message_start"
+	sseTypeMsgStop    = "message_stop"
+	sseTypeMsgDelta   = "message_delta"
+	sseTypeBlkStart   = "content_block_start"
+	sseTypeBlkDelta   = "content_block_delta"
+	sseTypeBlkStop    = "content_block_stop"
+	sseTypeErrorEvent = "error"
+
+	deltaTypeText      = "text_delta"
+	deltaTypeThinking  = "thinking_delta"
+	deltaTypeInputJSON = "input_json_delta"
+	deltaTypeSignature = "signature_delta"
+)

--- a/pkg/foreman/agent/executor_native.go
+++ b/pkg/foreman/agent/executor_native.go
@@ -39,6 +39,7 @@ import (
 
 	foremanv1alpha1 "github.com/defilantech/llmkube/api/foreman/v1alpha1"
 	inferencev1alpha1 "github.com/defilantech/llmkube/api/v1alpha1"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/anthropic"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/changepolicy"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/codehost"
 	"github.com/defilantech/llmkube/pkg/foreman/agent/githubissue"
@@ -126,10 +127,13 @@ type NativeAgentLoopExecutor struct {
 	// reads $GITHUB_TOKEN or ~/.config/foreman/github-token.
 	AuthFactory func() (*repo.Auth, error)
 
-	// LoopFactory builds the Loop given the resolved OAI client and
+	// LoopFactory builds the Loop given the resolved chat client and
 	// tool registry. Mostly to support tests with a fake loop; nil
-	// uses the real NewLoop.
-	LoopFactory func(client *oai.Client, registry ToolRegistry) *Loop
+	// uses the real NewLoop. The client is provider-shaped at the call
+	// site (oai.Client for local + cloud-proxy, anthropic.Client for
+	// anthropic) but arrives as a ChatCompleter so a fake loop can be
+	// injected without caring which wire it speaks (#1627).
+	LoopFactory func(client ChatCompleter, registry ToolRegistry) *Loop
 
 	// RegistryFactory builds the tool registry for a given workspace +
 	// agent. Required; the executor refuses to start without one
@@ -723,27 +727,14 @@ func (e *NativeAgentLoopExecutor) runLLMPath(
 ) (*Result, error) {
 	log := logf.FromContext(ctx).WithName("native-agent-loop").WithValues("task", task.Name, "ns", task.Namespace)
 
-	// 6. Build OAI client + loop. The auth header is empty for local
-	// providers and "Bearer <token>" for cloud-proxy Agents whose
-	// providerConfig carries an APIKeySecretRef.
-	oaiOpts := []oai.Option{}
-	if endpoint.authHeader != "" {
-		oaiOpts = append(oaiOpts, oai.WithAuthHeader(endpoint.authHeader))
-	}
-	oaiClient := oai.New(
-		endpoint.baseURL,
-		// Per-request header timeout (#532): how long one turn waits for
-		// the first token before retrying. The loop-wide budget is
-		// applied separately via LoopConfig.LoopBudget below.
-		durationFromSeconds(agent.Spec.RequestTurnTimeoutSeconds, 120),
-		int(agent.Spec.MaxRetries),
-		oaiOpts...,
-	)
+	// 6. Build the chat client + loop. The client follows the provider
+	// (#1627); see newChatCompleter for the provider-to-client map.
+	chat := newChatCompleter(agent, endpoint)
 	loopFactory := e.LoopFactory
 	if loopFactory == nil {
-		loopFactory = func(c *oai.Client, r ToolRegistry) *Loop { return NewLoop(c, r, nil) }
+		loopFactory = func(c ChatCompleter, r ToolRegistry) *Loop { return NewLoop(c, r, nil) }
 	}
-	loop := loopFactory(oaiClient, registry)
+	loop := loopFactory(chat, registry)
 
 	// 7. Build the user prompt from the task payload. The composition,
 	// outermost-first:
@@ -1861,16 +1852,18 @@ func buildDeterministicArgs(task *foremanv1alpha1.AgenticTask, branch, cloneURL 
 	return out
 }
 
-// providerEndpoint is the resolved triple the LLM path needs to dial
-// any provider: where to POST, which model to name in the request body,
-// and the optional Authorization header value. The cloud-proxy branch
-// populates all three from Agent.spec.providerConfig + a referenced
-// Secret; the local branch leaves authHeader empty and pulls modelName
-// from Agent.spec.Model.
+// providerEndpoint is the resolved descriptor the LLM path needs to
+// dial any provider: where to POST, which model to name in the request
+// body, and the provider-shaped auth material. The auth is
+// provider-shaped: cloud-proxy carries an Authorization header value
+// ("Bearer <token>"); anthropic carries the raw key for the x-api-key
+// header; local leaves both empty and pulls modelName from
+// Agent.spec.Model.
 type providerEndpoint struct {
 	baseURL    string
 	modelName  string
 	authHeader string
+	apiKey     string
 }
 
 // isDeterministicAgent reports whether the Agent runs the model-free
@@ -1896,7 +1889,8 @@ func mcpEnabledForTask(task *foremanv1alpha1.AgenticTask) bool {
 // resolveProviderEndpoint dispatches to the right resolver based on
 // Agent.spec.Provider. Empty / "local" -> existing InferenceService
 // resolution; "cloud-proxy" -> providerConfig.BaseURL + Secret lookup
-// for the auth header.
+// for the Authorization header; "anthropic" -> providerConfig.BaseURL +
+// Secret lookup for the x-api-key header.
 func (e *NativeAgentLoopExecutor) resolveProviderEndpoint(
 	ctx context.Context, namespace string, agent *foremanv1alpha1.Agent,
 ) (providerEndpoint, error) {
@@ -1911,9 +1905,34 @@ func (e *NativeAgentLoopExecutor) resolveProviderEndpoint(
 	case foremanv1alpha1.AgentProviderCloudProxy:
 		return e.resolveCloudProxyEndpoint(ctx, namespace, agent)
 
+	case foremanv1alpha1.AgentProviderAnthropic:
+		return e.resolveAnthropicEndpoint(ctx, namespace, agent)
+
 	default:
 		return providerEndpoint{}, fmt.Errorf("unknown agent.spec.provider %q", agent.Spec.Provider)
 	}
+}
+
+// newChatCompleter maps a resolved providerEndpoint to the wire client
+// for its provider (#1627). local + cloud-proxy dial an
+// OpenAI-compatible endpoint via oai.Client (Authorization header for
+// cloud-proxy); anthropic dials the native /v1/messages endpoint via
+// anthropic.Client (x-api-key header). Both satisfy ChatCompleter, so
+// the loop never sees the provider difference.
+func newChatCompleter(agent *foremanv1alpha1.Agent, endpoint providerEndpoint) ChatCompleter {
+	// Per-request header timeout (#532): how long one turn waits for
+	// the first byte of the SSE stream before retrying. The loop-wide
+	// budget is applied separately via LoopConfig.LoopBudget.
+	timeout := durationFromSeconds(agent.Spec.RequestTurnTimeoutSeconds, 120)
+	if agent.Spec.Provider == foremanv1alpha1.AgentProviderAnthropic {
+		return anthropic.New(endpoint.baseURL, timeout, int(agent.Spec.MaxRetries),
+			anthropic.WithAPIKey(endpoint.apiKey))
+	}
+	var oaiOpts []oai.Option
+	if endpoint.authHeader != "" {
+		oaiOpts = append(oaiOpts, oai.WithAuthHeader(endpoint.authHeader))
+	}
+	return oai.New(endpoint.baseURL, timeout, int(agent.Spec.MaxRetries), oaiOpts...)
 }
 
 // resolveCloudProxyEndpoint reads providerConfig + the optional
@@ -1943,6 +1962,40 @@ func (e *NativeAgentLoopExecutor) resolveCloudProxyEndpoint(
 			return providerEndpoint{}, err
 		}
 		ep.authHeader = "Bearer " + token
+	}
+	return ep, nil
+}
+
+// resolveAnthropicEndpoint reads providerConfig + the optional
+// APIKeySecretRef to build the endpoint for an Anthropic-native
+// /v1/messages server (#1627). baseURL and model are required; the
+// Secret is optional (a local Anthropic-compatible server can run
+// without auth). Mirrors resolveCloudProxyEndpoint except the secret
+// value is stored RAW in apiKey: the Messages API sends it as the
+// x-api-key header, never as Authorization: Bearer.
+func (e *NativeAgentLoopExecutor) resolveAnthropicEndpoint(
+	ctx context.Context, namespace string, agent *foremanv1alpha1.Agent,
+) (providerEndpoint, error) {
+	cfg := agent.Spec.ProviderConfig
+	if cfg == nil {
+		return providerEndpoint{}, fmt.Errorf("agent.spec.providerConfig is required for provider=anthropic")
+	}
+	if cfg.BaseURL == "" {
+		return providerEndpoint{}, fmt.Errorf("agent.spec.providerConfig.baseURL is required for provider=anthropic")
+	}
+	if cfg.Model == "" {
+		return providerEndpoint{}, fmt.Errorf("agent.spec.providerConfig.model is required for provider=anthropic")
+	}
+	ep := providerEndpoint{
+		baseURL:   strings.TrimRight(cfg.BaseURL, "/"),
+		modelName: cfg.Model,
+	}
+	if cfg.APIKeySecretRef != nil {
+		key, err := e.resolveAuthToken(ctx, namespace, cfg.APIKeySecretRef)
+		if err != nil {
+			return providerEndpoint{}, err
+		}
+		ep.apiKey = key
 	}
 	return ep, nil
 }

--- a/pkg/foreman/agent/executor_native_internal_test.go
+++ b/pkg/foreman/agent/executor_native_internal_test.go
@@ -773,6 +773,139 @@ func TestResolveProviderEndpoint(t *testing.T) {
 	}
 }
 
+// TestResolveAnthropicEndpoint covers the v0.3 anthropic resolution
+// path (#1627): providerConfig must carry baseURL + model, and the
+// optional APIKeySecretRef value lands RAW in the endpoint (the
+// Messages API sends it as x-api-key, never Authorization: Bearer) —
+// the inverse of the cloud-proxy contract, which is the whole point of
+// having a separate resolver.
+func TestResolveAnthropicEndpoint(t *testing.T) {
+	mkAgent := func(name string, cfg *foremanv1alpha1.ProviderConfig) *foremanv1alpha1.Agent {
+		return &foremanv1alpha1.Agent{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Spec: foremanv1alpha1.AgentSpec{
+				Role:           foremanv1alpha1.AgentRoleReviewer,
+				Provider:       foremanv1alpha1.AgentProviderAnthropic,
+				ProviderConfig: cfg,
+				Model:          "human-readable-name",
+			},
+		}
+	}
+	mkSecret := func(name, key, value string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+			Data:       map[string][]byte{key: []byte(value)},
+		}
+	}
+
+	cases := []struct {
+		name        string
+		agent       *foremanv1alpha1.Agent
+		seedObjects []runtime.Object
+		wantBase    string
+		wantModel   string
+		wantAuth    string
+		wantKey     string
+		wantErrFrag string
+	}{
+		{
+			name: "anthropic without auth: baseURL + model resolve, both auth fields empty",
+			agent: mkAgent("anth-no-auth", &foremanv1alpha1.ProviderConfig{
+				BaseURL: "https://api.anthropic.com/v1/",
+				Model:   "claude-sonnet-4-6",
+			}),
+			wantBase:  "https://api.anthropic.com/v1",
+			wantModel: "claude-sonnet-4-6",
+		},
+		{
+			name: "anthropic with Secret: apiKey is the raw value, authHeader stays empty",
+			agent: mkAgent("anth-auth", &foremanv1alpha1.ProviderConfig{
+				BaseURL: "https://api.anthropic.com/v1",
+				Model:   "claude-sonnet-4-6",
+				APIKeySecretRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "anthropic-api-key"},
+					Key:                  "key",
+				},
+			}),
+			seedObjects: []runtime.Object{mkSecret("anthropic-api-key", "key", "sk-ant-test\n")},
+			wantBase:    "https://api.anthropic.com/v1",
+			wantModel:   "claude-sonnet-4-6",
+			wantAuth:    "",            // no Bearer header on the Messages wire
+			wantKey:     "sk-ant-test", // raw, TrimSpace'd
+		},
+		{
+			name:        "anthropic missing providerConfig",
+			agent:       mkAgent("anth-no-cfg", nil),
+			wantErrFrag: "providerConfig is required for provider=anthropic",
+		},
+		{
+			name: "anthropic missing baseURL",
+			agent: mkAgent("anth-no-base", &foremanv1alpha1.ProviderConfig{
+				Model: "claude-sonnet-4-6",
+			}),
+			wantErrFrag: "baseURL is required for provider=anthropic",
+		},
+		{
+			name: "anthropic missing model",
+			agent: mkAgent("anth-no-model", &foremanv1alpha1.ProviderConfig{
+				BaseURL: "https://api.anthropic.com/v1",
+			}),
+			wantErrFrag: "model is required for provider=anthropic",
+		},
+		{
+			name: "anthropic: APIKeySecretRef points at nonexistent Secret",
+			agent: mkAgent("anth-missing-secret", &foremanv1alpha1.ProviderConfig{
+				BaseURL: "https://api.anthropic.com/v1",
+				Model:   "claude-sonnet-4-6",
+				APIKeySecretRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "nope"},
+					Key:                  "key",
+				},
+			}),
+			wantErrFrag: "get Secret",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := fake.NewClientBuilder().WithScheme(resolveSchemeForTests(t))
+			b = b.WithObjects(tc.agent)
+			for _, obj := range tc.seedObjects {
+				if co, ok := obj.(client.Object); ok {
+					b = b.WithObjects(co)
+				}
+			}
+			e := &NativeAgentLoopExecutor{Client: b.Build()}
+
+			ep, err := e.resolveAnthropicEndpoint(context.Background(), "default", tc.agent)
+			if tc.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil (endpoint=%+v)", tc.wantErrFrag, ep)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrFrag) {
+					t.Errorf("error fragment: want %q, got %v", tc.wantErrFrag, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveAnthropicEndpoint: %v", err)
+			}
+			if ep.baseURL != tc.wantBase {
+				t.Errorf("baseURL: want %q got %q", tc.wantBase, ep.baseURL)
+			}
+			if ep.modelName != tc.wantModel {
+				t.Errorf("modelName: want %q got %q", tc.wantModel, ep.modelName)
+			}
+			if ep.authHeader != tc.wantAuth {
+				t.Errorf("authHeader: want %q got %q (anthropic never sends Bearer)", tc.wantAuth, ep.authHeader)
+			}
+			if ep.apiKey != tc.wantKey {
+				t.Errorf("apiKey: want %q got %q", tc.wantKey, ep.apiKey)
+			}
+		})
+	}
+}
+
 // TestIsDeterministicAgent pins the rules for the model-free branch:
 // only local + empty InferenceServiceRef qualifies. A cloud-proxy
 // Agent always runs the LLM loop, even with an empty

--- a/pkg/foreman/agent/loop.go
+++ b/pkg/foreman/agent/loop.go
@@ -674,18 +674,29 @@ func appendCorrectiveIfBudget(res *LoopResult, streak *int, maxRetries int, msg 
 	return true
 }
 
-// Loop runs the native agent loop against a single OAI endpoint. It is
-// safe to reuse a Loop across many Run calls; each call starts a fresh
-// transcript and is self-contained.
+// ChatCompleter is the client seam the loop drives: one turn = one
+// request. Both the oai.Client (OpenAI-compatible: local llama.cpp
+// serve, cloud-proxy gateway) and the anthropic.Client (Anthropic
+// native /v1/messages) satisfy it, so the loop's reasoning / tool /
+// transcript logic is provider-agnostic (#1627).
+type ChatCompleter interface {
+	Chat(ctx context.Context, req oai.ChatRequest) (*oai.ChatResponse, error)
+}
+
+// Loop runs the native agent loop against a single chat endpoint. It
+// is safe to reuse a Loop across many Run calls; each call starts a
+// fresh transcript and is self-contained.
 type Loop struct {
-	client   *oai.Client
+	client   ChatCompleter
 	registry ToolRegistry
 	tracer   trace.Tracer
 }
 
-// NewLoop builds a Loop. Pass tracer=nil to use the global tracer
+// NewLoop builds a Loop. client may be either *oai.Client
+// (OpenAI-compatible) or *anthropic.Client (Anthropic native); both
+// satisfy ChatCompleter. Pass tracer=nil to use the global tracer
 // provider's "foreman.agent.loop" tracer.
-func NewLoop(client *oai.Client, registry ToolRegistry, tracer trace.Tracer) *Loop {
+func NewLoop(client ChatCompleter, registry ToolRegistry, tracer trace.Tracer) *Loop {
 	if tracer == nil {
 		tracer = otel.Tracer("foreman.agent.loop")
 	}

--- a/pkg/foreman/agent/loop_anthropic_test.go
+++ b/pkg/foreman/agent/loop_anthropic_test.go
@@ -1,0 +1,366 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/defilantech/llmkube/pkg/foreman/agent/anthropic"
+	"github.com/defilantech/llmkube/pkg/foreman/agent/oai"
+)
+
+// The loop is provider-agnostic: it drives a ChatCompleter, and
+// anthropic.Client is one implementation of that seam (#1627). These
+// tests run the REAL loop against a real anthropic.Client pointed at an
+// httptest server that speaks the Anthropic SSE wire, and assert both
+// sides of the contract: what the loop does with the parsed response
+// (transcript shape, tool dispatch, terminal) and what the client puts
+// on the wire (x-api-key header, system hoisted, tool_result riding in
+// a user message). The oai-based loop tests (loop_test.go) prove the
+// same loop logic over the other wire; this proves the seam holds.
+
+// anthReq mirrors the anthropic request body the client sends, just
+// enough to assert the wire shape. The real structs live unexported in
+// the anthropic package.
+type anthReq struct {
+	Model     string     `json:"model"`
+	MaxTokens int        `json:"max_tokens"`
+	System    string     `json:"system"`
+	Messages  []anthMsg  `json:"messages"`
+	Tools     []anthTool `json:"tools"`
+	Stream    bool       `json:"stream"`
+	Temp      *float64   `json:"temperature"`
+}
+
+type anthMsg struct {
+	Role    string      `json:"role"`
+	Content []anthBlock `json:"content"`
+}
+
+type anthBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+}
+
+type anthTool struct {
+	Name string `json:"name"`
+}
+
+// anthServer is an httptest server that records every request it
+// receives and answers each POST /v1/messages with a pre-baked
+// Anthropic SSE stream in sequence.
+type anthServer struct {
+	srv   *httptest.Server
+	t     *testing.T
+	mu    sync.Mutex
+	reqs  []anthReq
+	hdrs  []http.Header
+	turns int
+	// scripts are the SSE bodies for turns 1..N; the last one repeats.
+	scripts []string
+}
+
+func newAnthServer(t *testing.T, scripts ...string) *anthServer {
+	t.Helper()
+	s := &anthServer{t: t, scripts: scripts}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Errorf("path: want /v1/messages got %q", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req anthReq
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Errorf("request body is not a parseable anthropic request: %v\n%s", err, body)
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		s.mu.Lock()
+		s.turns++
+		s.reqs = append(s.reqs, req)
+		s.hdrs = append(s.hdrs, r.Header.Clone())
+		i := s.turns - 1
+		if i >= len(s.scripts) {
+			i = len(s.scripts) - 1
+		}
+		script := s.scripts[i]
+		s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, script)
+	}))
+	t.Cleanup(srv.Close)
+	s.srv = srv
+	return s
+}
+
+const (
+	// sseReadFile: a tool_use turn whose input arrives as TWO
+	// input_json_delta fragments — the loop must see the full args
+	// after the client concatenates them.
+	sseReadFile = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_rf","name":"read_file"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"README"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":".md\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+	// sseSubmitGo: a turn with a text block followed by a tool_use
+	// block whose input is seeded from content_block_start (no
+	// input_json deltas) — the other way tool args can arrive.
+	sseSubmitGo = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_2","usage":{"input_tokens":20,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"looks good"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+` +
+		// Split across lines for the linter's line budget; the seeded
+		// input object is what this turn's assertion is about.
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use",` +
+		`"id":"tu_sr","name":"submit_result","input":{"verdict":"GO","summary":"ok"}}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":9}}
+
+event: message_stop
+data: {"type":"message_stop"}
+`
+)
+
+// TestLoop_AnthropicProvider_E2E runs the native agent loop end to end
+// over the Anthropic wire: turn 1 calls read_file (args split across
+// two stream fragments), turn 2 terminates with submit_result (args
+// seeded from content_block_start). Asserts the loop's transcript
+// handling plus the exact wire shape the client produced on the second
+// request — that's where the tool_result rides in a user message and
+// the x-api-key / anthropic-version headers live.
+func TestLoop_AnthropicProvider_E2E(t *testing.T) {
+	srv := newAnthServer(t, sseReadFile, sseSubmitGo)
+	reg := &fakeRegistry{
+		schemas: []oai.Tool{
+			{Type: "function", Function: oai.ToolSchemaDef{Name: "read_file", Description: "read a file"}},
+			{Type: "function", Function: oai.ToolSchemaDef{Name: "submit_result", Description: "terminal"}},
+		},
+		results: map[string]*ToolResult{
+			"read_file":     {Output: map[string]any{"content": "# README\n"}},
+			"submit_result": {Terminal: true, Verdict: "GO", Summary: "ok"},
+		},
+	}
+	client := anthropic.New(srv.srv.URL+"/v1", time.Second, 0, anthropic.WithAPIKey("sk-test-123"))
+	loop := NewLoop(client, reg, nil)
+
+	res, err := loop.Run(context.Background(), LoopConfig{
+		Model: "claude-sonnet-4-6", SystemPrompt: "be brief", UserPrompt: "do the thing", MaxTurns: 5,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Terminal == nil || res.Terminal.Verdict != "GO" {
+		t.Fatalf("expected a GO terminal, got %+v", res.Terminal)
+	}
+	if res.Turns != 2 {
+		t.Errorf("turns: want 2 got %d", res.Turns)
+	}
+	if srv.turns != 2 {
+		t.Errorf("server turns: want 2 got %d", srv.turns)
+	}
+
+	assertAnthE2ETranscript(t, res)
+	assertAnthE2EWireShape(t, srv)
+	assertAnthE2EHeaders(t, srv)
+}
+
+// assertAnthE2ETranscript checks the loop-side view: message roles, the
+// fragmented tool args assembled by the client, and the tool results
+// threaded back with their tool_use ids.
+func assertAnthE2ETranscript(t *testing.T, res *LoopResult) {
+	t.Helper()
+
+	// Transcript: system, user, assistant#1 (tool_use), tool#1,
+	// assistant#2 (text + tool_use), tool#2 = 6 messages.
+	tr := res.Transcript
+	if len(tr) != 6 {
+		t.Fatalf("transcript len: want 6 got %d: %+v", len(tr), tr)
+	}
+	roles := make([]oai.Role, len(tr))
+	for i, m := range tr {
+		roles[i] = m.Role
+	}
+	want := []oai.Role{oai.RoleSystem, oai.RoleUser, oai.RoleAssistant, oai.RoleTool, oai.RoleAssistant, oai.RoleTool}
+	for i := range want {
+		if roles[i] != want[i] {
+			t.Fatalf("transcript roles: want %v got %v", want, roles)
+		}
+	}
+
+	// Turn 1 assistant: the two input_json_delta fragments must have
+	// concatenated into complete, valid JSON args.
+	a1 := tr[2]
+	if len(a1.ToolCalls) != 1 || a1.ToolCalls[0].ID != "tu_rf" || a1.ToolCalls[0].Function.Name != "read_file" {
+		t.Fatalf("assistant#1 tool call wrong: %+v", a1.ToolCalls)
+	}
+	if a1.ToolCalls[0].Function.Arguments != `{"path":"README.md"}` {
+		t.Errorf("fragmented args: want %q got %q", `{"path":"README.md"}`, a1.ToolCalls[0].Function.Arguments)
+	}
+	var args map[string]string
+	if err := json.Unmarshal([]byte(a1.ToolCalls[0].Function.Arguments), &args); err != nil {
+		t.Errorf("args are not valid JSON after concatenation: %v", err)
+	}
+
+	// The tool result must carry the assistant's tool_use id, and its
+	// content is the marshaled ToolResult.Output.
+	if tr[3].ToolCallID != "tu_rf" || tr[3].Name != "read_file" {
+		t.Errorf("tool#1: want tu_rf/read_file got %s/%s", tr[3].ToolCallID, tr[3].Name)
+	}
+	if !strings.Contains(tr[3].Content, "# README") {
+		t.Errorf("tool#1 content: want it to carry the output, got %q", tr[3].Content)
+	}
+
+	// Turn 2 assistant: text block + tool_use seeded from
+	// content_block_start (no input_json deltas on the wire).
+	a2 := tr[4]
+	if !strings.Contains(a2.Content, "looks good") {
+		t.Errorf("assistant#2 text: want it to carry %q, got %q", "looks good", a2.Content)
+	}
+	if len(a2.ToolCalls) != 1 || a2.ToolCalls[0].ID != "tu_sr" || a2.ToolCalls[0].Function.Name != "submit_result" {
+		t.Fatalf("assistant#2 tool call wrong: %+v", a2.ToolCalls)
+	}
+	if a2.ToolCalls[0].Function.Arguments != `{"verdict":"GO","summary":"ok"}` {
+		t.Errorf("seeded args: want %q got %q", `{"verdict":"GO","summary":"ok"}`, a2.ToolCalls[0].Function.Arguments)
+	}
+	if tr[5].ToolCallID != "tu_sr" {
+		t.Errorf("tool#2: want tu_sr got %s", tr[5].ToolCallID)
+	}
+}
+
+// assertAnthE2EWireShape checks what the client put on the wire.
+func assertAnthE2EWireShape(t *testing.T, srv *anthServer) {
+	t.Helper()
+	// Wire contract, turn 2 request: system hoisted to the top level,
+	// the tool result riding in a USER message as a tool_result block,
+	// tools forwarded, streaming on, and the anthropic-specific headers
+	// (x-api-key, not Authorization: Bearer; anthropic-version set).
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if len(srv.reqs) != 2 || len(srv.hdrs) != 2 {
+		t.Fatalf("want 2 recorded requests, got %d/%d", len(srv.reqs), len(srv.hdrs))
+	}
+	req1, req2 := srv.reqs[0], srv.reqs[1]
+
+	if req1.System != "be brief" || req2.System != "be brief" {
+		t.Errorf("system must be hoisted to the top level: %q / %q", req1.System, req2.System)
+	}
+	if req1.Model != "claude-sonnet-4-6" || req2.Model != "claude-sonnet-4-6" {
+		t.Errorf("model: %q / %q", req1.Model, req2.Model)
+	}
+	if req1.MaxTokens <= 0 || req2.MaxTokens <= 0 {
+		t.Errorf("max_tokens must be set (required by the Messages API): %d / %d", req1.MaxTokens, req2.MaxTokens)
+	}
+	if !req1.Stream || !req2.Stream {
+		t.Errorf("stream must be true on every request: %v / %v", req1.Stream, req2.Stream)
+	}
+	for i, name := range []string{"read_file", "submit_result"} {
+		if len(req2.Tools) != 2 || req2.Tools[i].Name != name {
+			t.Errorf("tools on turn 2: want [read_file submit_result] got %+v", req2.Tools)
+		}
+	}
+
+	// Turn 1 request: a single user message with the task text.
+	if len(req1.Messages) != 1 || req1.Messages[0].Role != "user" ||
+		len(req1.Messages[0].Content) != 1 || req1.Messages[0].Content[0].Type != "text" ||
+		req1.Messages[0].Content[0].Text != "do the thing" {
+		t.Errorf("turn 1 request messages wrong: %+v", req1.Messages)
+	}
+
+	// Turn 2 request: user(task), assistant(tool_use), user(tool_result)
+	// in strict alternation — no "tool" role anywhere on the wire.
+	if len(req2.Messages) != 3 {
+		t.Fatalf("turn 2 request messages: want 3 (user, assistant, user) got %d: %+v", len(req2.Messages), req2.Messages)
+	}
+	if req2.Messages[0].Role != "user" || req2.Messages[1].Role != "assistant" || req2.Messages[2].Role != "user" {
+		t.Errorf("turn 2 roles: want [user assistant user] got [%s %s %s]",
+			req2.Messages[0].Role, req2.Messages[1].Role, req2.Messages[2].Role)
+	}
+	asstBlocks := req2.Messages[1].Content
+	if len(asstBlocks) != 1 || asstBlocks[0].Type != "tool_use" || asstBlocks[0].ID != "tu_rf" {
+		t.Errorf("turn 2 assistant must carry the tool_use block: %+v", asstBlocks)
+	}
+	trBlocks := req2.Messages[2].Content
+	if len(trBlocks) != 1 || trBlocks[0].Type != "tool_result" || trBlocks[0].ToolUseID != "tu_rf" {
+		t.Fatalf("turn 2 user must carry a tool_result block: %+v", trBlocks)
+	}
+	if !strings.Contains(string(trBlocks[0].Content), "# README") {
+		t.Errorf("tool_result content: want it to carry the tool output, got %s", trBlocks[0].Content)
+	}
+}
+
+// assertAnthE2EHeaders checks the Messages API auth contract: x-api-key
+// carries the credential, Authorization stays empty, and the version
+// header is present.
+func assertAnthE2EHeaders(t *testing.T, srv *anthServer) {
+	t.Helper()
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	h := srv.hdrs[0]
+	if h.Get("x-api-key") != "sk-test-123" {
+		t.Errorf("x-api-key: want sk-test-123 got %q", h.Get("x-api-key"))
+	}
+	if h.Get("Authorization") != "" {
+		t.Errorf("anthropic client must never send Authorization, got %q", h.Get("Authorization"))
+	}
+	if h.Get("anthropic-version") == "" {
+		t.Errorf("anthropic-version header missing: %v", h)
+	}
+}


### PR DESCRIPTION
## What

Adds an `anthropic` value to `AgentProvider` and a new `pkg/foreman/agent/anthropic` client that speaks the Anthropic Messages API (`POST /v1/messages`, SSE streaming) natively: first-class `thinking` blocks, structured `tool_use` input, `x-api-key` auth. The agent loop gains a `ChatCompleter` seam and is now provider-agnostic. CRD enums regenerated (config + foreman chart), example Agent manifest added.

## Why

Fixes #1627.

The issue is measured, not theoretical: behind MiniMax's OpenAI-compatible shim, reasoning arrives inline in streamed `content` (`<think>…</think>`) while `usage` still counts it as reasoning tokens — and LiteLLM strips that pair only on **non-streaming** responses. The agent is streaming-only, so every coder turn replayed the model's raw reasoning trace as ordinary assistant content. A translation proxy cannot be made to reliably recognize and strip vendor-specific tags; the native wire simply has a separate channel for reasoning, so the class of bug goes away.

(The issue's narrower alternative of surfacing `reasoning_content` and keeping it out of replay history has since landed on the oai path; this PR implements the main ask — targeting Anthropic-native endpoints directly.)

## How

- **New `anthropic` package**, mirroring the `oai` client's conventions (no SDK, stdlib-only, SSE-only, same retry/backoff/jitter policy):
  - `translate.go` maps the internal `oai.ChatRequest` to a Messages body: system messages hoisted to the top-level field, `tool` results riding inside **user** messages as `tool_result` blocks, consecutive same-role messages merged (strict user/assistant alternation is enforced), image `data:` URLs mapped to base64 sources, `max_tokens` defaulting to 8192 (the API requires the field). Historical `ReasoningContent` is dropped on replay — Anthropic only accepts thinking blocks echoed with valid signatures, which no third-party Anthropic-compatible endpoint emits.
  - `client.go` aggregates the SSE stream (`text_delta` → content, `thinking_delta` → reasoning, `input_json_delta` → tool args, `signature_delta` ignored, in-stream `error` events abort) back into the existing `oai.ChatResponse` shape, with `stop_reason` mapped to the OpenAI finish-reason vocabulary. Non-2xx errors wrap `*oai.StatusError` so the loop's temperature-rejection retry keeps working against both wires.
- **Loop seam**: `Loop`/`NewLoop`/`LoopFactory` now take a `ChatCompleter` (the single `Chat` method); `newChatCompleter` in the executor picks the client by provider.
- **Auth is provider-shaped**: cloud-proxy keeps `Authorization: Bearer <token>`; anthropic sends the Secret value verbatim as `x-api-key`.
- **Sovereignty unchanged**: `anthropic` is a non-local provider, so both existing gates — the operator `--allow-cloud-providers` kill switch and per-Workload `spec.allowCloudReviewers` — apply to it without modification.

Tests: 30+ new cases — wire translation, SSE aggregation (fragmented tool args, clean-EOF-without-`message_stop`, empty stream, in-stream errors), retry classification and header contract, executor endpoint resolution, and a real loop running end to end over a fake Anthropic SSE server (tool round-trip + `submit_result`).

## Checklist

- [x] Tests added/updated
- [x] `make test` passes locally
- [x] `make lint` passes locally (also `make vet`, `make fmt`; CRDs regenerated via `make foreman-chart-crds`, `make generate` no-op)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] All commits are signed off (`git commit -s`) per [DCO](https://developercertificate.org/)
- [x] AI assistance (if any) is disclosed above, per [CONTRIBUTING.md](../CONTRIBUTING.md#ai-assisted-and-agent-contributions)
- [x] Documentation updated (if user-facing change) — example Agent manifest + CRD/godoc descriptions; no docs-site page added

Assisted-by: opencode agents (a Qwen3.8-27B coder subagent generated the `anthropic` package and tests; a Qwen3.8-Flash-Next coordinator wired the provider, regenerated manifests, and drafted this description; verified by running `make test`, `make lint`, `make vet` locally, plus an independent second-opinion review pass with Gemma-4-12B that found no blocking issues).
